### PR TITLE
fix(mcp): make package standalone and registry-ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,10 @@ The frozen public package surface for this release candidate is:
 - Install target: `npm install martin-loop`
 - CLI target: `npx martin-loop`
 - SDK target: `import { MartinLoop } from "martin-loop"`
+- MCP target (registry-ready package): `npx -y @martin/mcp`
 
 The `martin` command alias is installed for local operator convenience, but the public CLI surface is `npx martin-loop`.
+The standalone MCP server package is smoke-validated locally with `pnpm --filter @martin/mcp smoke:pack` and is ready for registry publication as a separate release step.
 
 ### Run a governed task
 
@@ -292,7 +294,7 @@ The lower-level `runMartin` function is also exported for callers that want to a
 | `apps/control-plane/` | Hosted control-plane workstream, outside the initial npm package surface. |
 | `apps/local-dashboard/` | Local dashboard/read-model viewer, not currently packaged as public npm API. |
 
-The `@martin/core`, `@martin/adapters`, and `@martin/contracts` package manifests are still private workspace packages; the public install target is the root `martin-loop` facade.
+The `@martin/core`, `@martin/adapters`, and `@martin/contracts` package manifests are still private workspace packages. The public runtime install target is the root `martin-loop` facade, while `@martin/mcp` is packaged as a standalone MCP server with vendored internal runtime dependencies for registry publication.
 
 ---
 ## Development

--- a/docs/oss/OSS-BOUNDARY-REPORT.json
+++ b/docs/oss/OSS-BOUNDARY-REPORT.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-22T11:35:54.851Z",
+  "generatedAt": "2026-05-07T21:23:30.889Z",
   "verdict": "go",
   "publicSurface": {
     "packageName": "martin-loop",
@@ -60,11 +60,7 @@
       "path": "packages/mcp",
       "private": false,
       "publishAccess": "public",
-      "workspaceDependencies": [
-        "@martin/adapters",
-        "@martin/contracts",
-        "@martin/core"
-      ],
+      "workspaceDependencies": [],
       "classification": "oss_core",
       "classificationReason": "Intended Phase 13 OSS core surface."
     }

--- a/docs/oss/OSS-BOUNDARY-REPORT.md
+++ b/docs/oss/OSS-BOUNDARY-REPORT.md
@@ -1,6 +1,6 @@
 # Martin Loop Phase 13 OSS Core Boundary
 
-Generated: 2026-04-22T11:35:54.851Z
+Generated: 2026-05-07T21:23:30.889Z
 
 ## Verdict
 **GO**
@@ -30,7 +30,7 @@ Generated: 2026-04-22T11:35:54.851Z
 | @martin/core | packages/core | yes | n/a | @martin/contracts |
 | @martin/adapters | packages/adapters | yes | n/a | @martin/core |
 | @martin/cli | packages/cli | no | public | @martin/adapters, @martin/contracts, @martin/core |
-| @martin/mcp | packages/mcp | no | public | @martin/adapters, @martin/contracts, @martin/core |
+| @martin/mcp | packages/mcp | no | public | none |
 
 ## Non-OSS Workspace Packages
 | Package | Path | Reason |

--- a/docs/oss/QUICKSTART.md
+++ b/docs/oss/QUICKSTART.md
@@ -9,8 +9,9 @@ The frozen public launch target is:
 - `npm install martin-loop`
 - `npx martin-loop ...`
 - `import { MartinLoop } from "martin-loop"`
+- `npx -y @martin/mcp`
 
-That launch surface is now implemented in the root package facade and smoke-validated from a clean temporary install. This quickstart still documents the honest RC-from-source path because public registry publication is a later release step.
+That runtime launch surface is implemented in the root package facade and smoke-validated from a clean temporary install. The MCP package shape is also smoke-validated from a packed tarball. This quickstart still documents the honest RC-from-source path because public registry publication is a separate release step.
 
 ## Prerequisites
 
@@ -114,10 +115,18 @@ For persisted run folders, inspect the `contract.json`, `state.json`, `ledger.js
 
 ## MCP server
 
-Build first, then start the server from the workspace:
+The publish-ready MCP install target is:
+
+```bash
+npx -y @martin/mcp
+claude mcp add martin-loop -- npx -y @martin/mcp
+```
+
+For repo-local verification from source:
 
 ```bash
 pnpm --filter @martin/mcp build
+pnpm --filter @martin/mcp smoke:pack
 node packages/mcp/dist/server.js
 ```
 

--- a/docs/oss/README.md
+++ b/docs/oss/README.md
@@ -12,7 +12,7 @@ Martin Loop is a governed AI coding-loop runtime. The core runtime is real and v
 
 ## What is still outside the initial OSS promise
 
-- The root workspace now exposes the `martin-loop` public package facade, but registry publication is still a later release step.
+- The root workspace now exposes the `martin-loop` public package facade, and `@martin/mcp` now has a standalone tarball shape validated via `pnpm --filter @martin/mcp smoke:pack`, but registry publication is still a separate release step.
 - `@martin/contracts`, `@martin/core`, and `@martin/adapters` are still marked `private` in their package manifests.
 - The hosted control-plane and local dashboard remain in the repo, but they are not yet the finalized public OSS boundary.
 - The benchmark harness remains a workspace-only RC surface under `benchmarks/` and is not part of the publishable CLI boundary yet.
@@ -55,8 +55,9 @@ The current engineering memo freezes these public-launch targets for release pla
 - install target: `npm install martin-loop`
 - CLI target: `npx martin-loop ...`
 - SDK target: `import { MartinLoop } from "martin-loop"`
+- MCP target (publish-ready): `npx -y @martin/mcp`
 
-Those targets are now implemented in the root package facade and verified through a clean-install smoke test. During the current RC phase, the honest operator path still includes the repo-local workflow documented below and in the quickstart, because public registry publication and broader release packaging remain later steps.
+Those runtime targets are implemented in the root package facade and verified through a clean-install smoke test. The MCP target is packaged and verified through a tarball launch smoke test. During the current RC phase, the honest operator path still includes the repo-local workflow documented below and in the quickstart, because public registry publication and broader release packaging remain separate release steps.
 
 ## Reproducibility
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,0 +1,40 @@
+# @martin/mcp
+
+Martin Loop's installable Model Context Protocol server.
+
+It exposes three MCP tools over stdio:
+
+- `martin_run`
+- `martin_inspect`
+- `martin_status`
+
+## Quickstart
+
+Run the packaged server directly:
+
+```sh
+npx -y @martin/mcp
+```
+
+Add it to Claude Code:
+
+```sh
+claude mcp add martin-loop -- npx -y @martin/mcp
+```
+
+For clients that want explicit command/args:
+
+- Command: `npx`
+- Args: `-y`, `@martin/mcp`
+
+## Local Verification
+
+From the repository root:
+
+```sh
+pnpm --filter @martin/mcp build
+pnpm --filter @martin/mcp test
+pnpm --filter @martin/mcp smoke:pack
+```
+
+`smoke:pack` packs the tarball, launches it through `npx`, performs the MCP handshake, lists tools, and verifies a `martin_status` call.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,27 +1,59 @@
 {
   "name": "@martin/mcp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": false,
   "type": "module",
-  "description": "Martin Loop MCP server — exposes martin_run, martin_inspect, and martin_status as Model Context Protocol tools.",
-  "main": "dist/server.js",
-  "types": "dist/server.d.ts",
+  "description": "Martin Loop MCP server — installable stdio server for martin_run, martin_inspect, and martin_status.",
+  "license": "MIT",
+  "author": "Vakeesan Mahalingam and Gobi Shanthan",
+  "homepage": "https://martinloop.com/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Keesan12/martin-loop.git",
+    "directory": "packages/mcp"
+  },
+  "bugs": {
+    "url": "https://github.com/Keesan12/martin-loop/issues"
+  },
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "martin-loop",
+    "ai-agent",
+    "claude",
+    "codex"
+  ],
+  "main": "./dist/server.js",
+  "types": "./dist/server.d.ts",
   "bin": {
-    "martin-mcp": "dist/server.js"
+    "martin-mcp": "./dist/server.js"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/server.d.ts",
+      "default": "./dist/server.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=18.0.0"
   },
   "publishConfig": {
     "access": "public"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.build.json",
+    "build": "node ./scripts/build-package.mjs",
+    "prepack": "pnpm build",
+    "smoke:pack": "node ./scripts/smoke-package.mjs",
     "test": "vitest run",
     "lint": "tsc -p tsconfig.json --noEmit",
     "start": "node dist/server.js"
   },
   "dependencies": {
-    "@martin/adapters": "workspace:*",
-    "@martin/contracts": "workspace:*",
-    "@martin/core": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.0.0"
   }
 }

--- a/packages/mcp/scripts/build-package.mjs
+++ b/packages/mcp/scripts/build-package.mjs
@@ -1,0 +1,286 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { chmod, copyFile, mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const PACKAGE_FACADES = [
+  {
+    packageName: "@martin/contracts",
+    sourceDir: ["packages", "contracts", "dist"],
+    targetDir: ["dist", "vendor", "contracts"],
+  },
+  {
+    packageName: "@martin/core",
+    sourceDir: ["packages", "core", "dist"],
+    targetDir: ["dist", "vendor", "core"],
+  },
+  {
+    packageName: "@martin/adapters",
+    sourceDir: ["packages", "adapters", "dist"],
+    targetDir: ["dist", "vendor", "adapters"],
+  },
+];
+
+const REWRITABLE_PACKAGES = {
+  "@martin/contracts": "contracts",
+  "@martin/core": "core",
+  "@martin/adapters": "adapters",
+};
+
+export async function buildStandaloneMcpPackage(options = {}) {
+  const packageDir = path.resolve(options.packageDir ?? fileURLToPath(new URL("..", import.meta.url)));
+  const rootDir = path.resolve(options.rootDir ?? path.join(packageDir, "..", ".."));
+  const distDir = path.join(packageDir, "dist");
+
+  await ensureWorkspaceArtifacts(rootDir);
+  await rm(distDir, { force: true, recursive: true, maxRetries: 10, retryDelay: 100 });
+  await runCommand(pnpmCommand(), ["exec", "tsc", "-p", "tsconfig.build.json"], { cwd: packageDir });
+
+  await rewriteDirectory({
+    currentDir: distDir,
+    distDir,
+    skipDirs: new Set(["vendor"]),
+  });
+
+  for (const facade of PACKAGE_FACADES) {
+    await copyFacadeDirectory({
+      sourceDir: path.join(rootDir, ...facade.sourceDir),
+      targetDir: path.join(packageDir, ...facade.targetDir),
+      distDir,
+    });
+  }
+
+  await chmod(path.join(distDir, "server.js"), 0o755);
+
+  return {
+    packageDir,
+    distDir,
+    vendorDir: path.join(distDir, "vendor"),
+  };
+}
+
+async function ensureWorkspaceArtifacts(rootDir) {
+  for (const facade of PACKAGE_FACADES) {
+    const markerFile = path.join(rootDir, ...facade.sourceDir, "index.js");
+    if (await fileExists(markerFile)) {
+      continue;
+    }
+
+    await runCommand(
+      pnpmCommand(),
+      ["--dir", rootDir, "--filter", facade.packageName, "build"],
+      { cwd: rootDir },
+    );
+  }
+}
+
+async function copyFacadeDirectory(input) {
+  await copyDirectory({
+    sourceDir: input.sourceDir,
+    targetDir: input.targetDir,
+    distDir: input.distDir,
+    relativeDir: "",
+  });
+}
+
+async function copyDirectory(input) {
+  await mkdir(input.targetDir, { recursive: true });
+
+  const entries = await readdir(input.sourceDir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const relativePath = input.relativeDir
+      ? path.join(input.relativeDir, entry.name)
+      : entry.name;
+
+    if (entry.isDirectory()) {
+      if (shouldSkipDirectory(entry.name, relativePath)) {
+        continue;
+      }
+
+      await copyDirectory({
+        sourceDir: path.join(input.sourceDir, entry.name),
+        targetDir: path.join(input.targetDir, entry.name),
+        distDir: input.distDir,
+        relativeDir: relativePath,
+      });
+      continue;
+    }
+
+    if (shouldSkipFile(entry.name)) {
+      continue;
+    }
+
+    const sourcePath = path.join(input.sourceDir, entry.name);
+    const targetPath = path.join(input.targetDir, entry.name);
+
+    if (entry.name.endsWith(".js") || entry.name.endsWith(".d.ts")) {
+      const contents = await readFile(sourcePath, "utf8");
+      const rewritten = rewritePackageSpecifiers(contents, {
+        targetPath,
+        distDir: input.distDir,
+      });
+      await writeFile(targetPath, rewritten, "utf8");
+      continue;
+    }
+
+    await copyFile(sourcePath, targetPath);
+  }
+}
+
+async function rewriteDirectory(input) {
+  const entries = await readdir(input.currentDir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const entryPath = path.join(input.currentDir, entry.name);
+
+    if (entry.isDirectory()) {
+      if (input.skipDirs.has(entry.name)) {
+        continue;
+      }
+      await rewriteDirectory({
+        ...input,
+        currentDir: entryPath,
+      });
+      continue;
+    }
+
+    if (entry.name.endsWith(".map")) {
+      await rm(entryPath, { force: true });
+      continue;
+    }
+
+    if (!entry.name.endsWith(".js") && !entry.name.endsWith(".d.ts")) {
+      continue;
+    }
+
+    const contents = await readFile(entryPath, "utf8");
+    const rewritten = rewritePackageSpecifiers(contents, {
+      targetPath: entryPath,
+      distDir: input.distDir,
+    });
+
+    if (rewritten !== contents) {
+      await writeFile(entryPath, rewritten, "utf8");
+    }
+  }
+}
+
+function shouldSkipDirectory(name, relativePath) {
+  return name === "tests" || relativePath === "src";
+}
+
+function shouldSkipFile(name) {
+  return name.endsWith(".map");
+}
+
+function rewritePackageSpecifiers(contents, input) {
+  return contents.replace(
+    /(['"])(@martin\/(?:contracts|core|adapters)(?:\/[a-z0-9-]+)?)\1/g,
+    (_match, quote, packageName) => {
+      const [basePackageName, subpath] = packageName.split("/", 3).reduce(
+        (parts, segment, index) => {
+          if (index < 2) {
+            parts[0].push(segment);
+          } else {
+            parts[1].push(segment);
+          }
+          return parts;
+        },
+        [[], []],
+      ).map((parts) => parts.join("/"));
+      const mapped = REWRITABLE_PACKAGES[basePackageName];
+      if (!mapped) {
+        return `${quote}${packageName}${quote}`;
+      }
+
+      const targetFile = subpath
+        ? path.join(input.distDir, "vendor", mapped, `${subpath}.js`)
+        : path.join(input.distDir, "vendor", mapped, "index.js");
+      const specifier = toImportSpecifier(path.dirname(input.targetPath), targetFile);
+
+      return `${quote}${specifier}${quote}`;
+    },
+  );
+}
+
+function toImportSpecifier(fromDir, toFile) {
+  const relativePath = path.relative(fromDir, toFile).split(path.sep).join("/");
+  return relativePath.startsWith(".") ? relativePath : `./${relativePath}`;
+}
+
+function pnpmCommand() {
+  return "pnpm";
+}
+
+async function fileExists(targetPath) {
+  try {
+    await readFile(targetPath);
+    return true;
+  } catch (error) {
+    return !(
+      error &&
+      typeof error === "object" &&
+      "code" in error &&
+      error.code === "ENOENT"
+    );
+  }
+}
+
+async function runCommand(command, args, options) {
+  await new Promise((resolve, reject) => {
+    const launch = createCommandLaunch(command, args);
+    const child = spawn(launch.command, launch.args, {
+      cwd: options.cwd,
+      env: process.env,
+      stdio: "inherit",
+      shell: false,
+      windowsHide: true,
+    });
+
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code !== 0) {
+        reject(new Error(`Command failed (${code ?? "unknown"}): ${command} ${args.join(" ")}`));
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+function createCommandLaunch(command, args) {
+  if (process.platform !== "win32") {
+    return { command, args };
+  }
+
+  return {
+    command: process.env.ComSpec ?? "cmd.exe",
+    args: ["/d", "/s", "/c", toCmdCommand(command, args)],
+  };
+}
+
+function toCmdCommand(command, args) {
+  return [quoteForCmdArgument(command), ...args.map((arg) => quoteForCmdArgument(arg))].join(" ");
+}
+
+function quoteForCmdArgument(value) {
+  return /[\s"]/u.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
+}
+
+async function main() {
+  const result = await buildStandaloneMcpPackage();
+  process.stdout.write(`Standalone MCP package built at ${result.distDir}\n`);
+}
+
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : "";
+const modulePath = fileURLToPath(import.meta.url);
+if (invokedPath === path.resolve(modulePath)) {
+  main().catch((error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`Standalone MCP build failed: ${message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/packages/mcp/scripts/build-package.mjs
+++ b/packages/mcp/scripts/build-package.mjs
@@ -176,28 +176,23 @@ function shouldSkipFile(name) {
   return name.endsWith(".map");
 }
 
-function rewritePackageSpecifiers(contents, input) {
+export function rewritePackageSpecifiers(contents, input) {
   return contents.replace(
-    /(['"])(@martin\/(?:contracts|core|adapters)(?:\/[a-z0-9-]+)?)\1/g,
+    /(['"])(@martin\/(?:contracts|core|adapters)(?:\/[^'"]+)?)\1/g,
     (_match, quote, packageName) => {
-      const [basePackageName, subpath] = packageName.split("/", 3).reduce(
-        (parts, segment, index) => {
-          if (index < 2) {
-            parts[0].push(segment);
-          } else {
-            parts[1].push(segment);
-          }
-          return parts;
-        },
-        [[], []],
-      ).map((parts) => parts.join("/"));
+      const parts = packageName.split("/");
+      const basePackageName = parts.slice(0, 2).join("/");
+      const subpath = parts.slice(2).join("/");
       const mapped = REWRITABLE_PACKAGES[basePackageName];
       if (!mapped) {
         return `${quote}${packageName}${quote}`;
       }
 
+      const normalizedSubpath = subpath
+        ? (subpath.endsWith(".js") ? subpath : `${subpath}.js`)
+        : "index.js";
       const targetFile = subpath
-        ? path.join(input.distDir, "vendor", mapped, `${subpath}.js`)
+        ? path.join(input.distDir, "vendor", mapped, normalizedSubpath)
         : path.join(input.distDir, "vendor", mapped, "index.js");
       const specifier = toImportSpecifier(path.dirname(input.targetPath), targetFile);
 

--- a/packages/mcp/scripts/smoke-package.mjs
+++ b/packages/mcp/scripts/smoke-package.mjs
@@ -1,0 +1,286 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { mkdtemp, mkdir, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { createLoopRecord } from "@martin/contracts";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+import { buildStandaloneMcpPackage } from "./build-package.mjs";
+
+const REQUIRED_TOOLS = ["martin_inspect", "martin_run", "martin_status"];
+const REQUIRED_TARBALL_FILES = [
+  "README.md",
+  "dist/server.d.ts",
+  "dist/server.js",
+  "dist/tools/get-status.d.ts",
+  "dist/tools/get-status.js",
+  "dist/tools/inspect-loop.d.ts",
+  "dist/tools/inspect-loop.js",
+  "dist/tools/run-loop.d.ts",
+  "dist/tools/run-loop.js",
+  "dist/vendor/adapters/index.d.ts",
+  "dist/vendor/adapters/index.js",
+  "dist/vendor/contracts/index.d.ts",
+  "dist/vendor/contracts/index.js",
+  "dist/vendor/core/index.d.ts",
+  "dist/vendor/core/index.js",
+  "package.json",
+];
+
+export async function runStandaloneMcpSmoke(options = {}) {
+  const packageDir = path.resolve(options.packageDir ?? fileURLToPath(new URL("..", import.meta.url)));
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "martin-mcp-smoke-"));
+  const packDir = path.join(tempRoot, "pack");
+  await mkdir(packDir, { recursive: true });
+
+  let transport;
+  try {
+    await buildStandaloneMcpPackage({ packageDir });
+
+    const packDryRun = await runCommand(npmCommand(), ["pack", "--ignore-scripts", "--json", "--dry-run"], {
+      cwd: packageDir,
+    });
+    const dryRunEntry = parsePackEntry(packDryRun.stdout);
+    const tarballFiles = dryRunEntry.files.map((file) => file.path).sort();
+    assertTarballFileSet(tarballFiles);
+
+    const packRun = await runCommand(
+      npmCommand(),
+      ["pack", "--ignore-scripts", "--json", "--pack-destination", packDir],
+      { cwd: packageDir },
+    );
+    const packEntry = parsePackEntry(packRun.stdout);
+    const tarballPath = path.join(packDir, packEntry.filename);
+
+    const packedManifestOutput = await runCommand(
+      tarCommand(),
+      ["-xOf", tarballPath, "package/package.json"],
+      { cwd: packageDir },
+    );
+    const packedManifest = JSON.parse(packedManifestOutput.stdout);
+    assertPackedManifest(packedManifest);
+
+    const stderrChunks = [];
+    const launch = createPackagedLaunch(tarballPath);
+    transport = new StdioClientTransport({
+      command: launch.command,
+      args: launch.args,
+      cwd: tempRoot,
+      env: process.env,
+      stderr: "pipe",
+    });
+    transport.stderr?.on("data", (chunk) => {
+      stderrChunks.push(chunk.toString());
+    });
+
+    const client = new Client(
+      { name: "martin-mcp-smoke", version: "0.1.1" },
+      { capabilities: {} },
+    );
+
+    await client.connect(transport);
+    const tools = await client.listTools();
+    const toolNames = tools.tools.map((tool) => tool.name).sort();
+
+    for (const toolName of REQUIRED_TOOLS) {
+      if (!toolNames.includes(toolName)) {
+        throw new Error(`Missing expected tool "${toolName}" in packaged MCP server.`);
+      }
+    }
+
+    const statusResult = await client.callTool({
+      name: "martin_status",
+      arguments: {
+        loopJson: JSON.stringify(
+          createLoopRecord({
+            workspaceId: "ws_pack_smoke",
+            projectId: "proj_pack_smoke",
+            task: {
+              title: "Pack smoke",
+              objective: "Verify packaged MCP status tool",
+              verificationPlan: [],
+            },
+            budget: {
+              maxUsd: 5,
+              softLimitUsd: 3,
+              maxIterations: 2,
+              maxTokens: 1_000,
+            },
+            cost: {
+              actualUsd: 1.25,
+              avoidedUsd: 0,
+              tokensIn: 20,
+              tokensOut: 10,
+            },
+          }),
+        ),
+      },
+    });
+
+    const statusPayload = JSON.parse(readTextContent(statusResult));
+    if (statusPayload.loopId === undefined || statusPayload.pressure === undefined) {
+      throw new Error("Packaged martin_status response is missing expected fields.");
+    }
+
+    return {
+      tarballPath,
+      npxCommand: "npx -y @martin/mcp",
+      toolNames,
+      tarballFiles,
+      packedDependencies: packedManifest.dependencies ?? {},
+      statusPayload,
+      stderr: stderrChunks.join(""),
+    };
+  } finally {
+    if (transport) {
+      await transport.close().catch(() => {});
+    }
+    if (!options.keepTempDir) {
+      await rm(tempRoot, { force: true, recursive: true, maxRetries: 10, retryDelay: 100 });
+    }
+  }
+}
+
+function assertTarballFileSet(filePaths) {
+  const unexpected = filePaths.filter(
+    (filePath) =>
+      filePath !== "package.json" &&
+      filePath !== "README.md" &&
+      !filePath.startsWith("dist/"),
+  );
+  if (unexpected.length > 0) {
+    throw new Error(`Tarball still contains unexpected files: ${unexpected.join(", ")}`);
+  }
+
+  const missing = REQUIRED_TARBALL_FILES.filter((requiredFile) => !filePaths.includes(requiredFile));
+  if (missing.length > 0) {
+    throw new Error(`Tarball is missing required files: ${missing.join(", ")}`);
+  }
+}
+
+function assertPackedManifest(manifest) {
+  const dependencyNames = Object.keys(manifest.dependencies ?? {});
+  const internalDependencies = dependencyNames.filter((name) => name.startsWith("@martin/"));
+  if (internalDependencies.length > 0) {
+    throw new Error(
+      `Packed package still depends on internal workspace packages: ${internalDependencies.join(", ")}`,
+    );
+  }
+}
+
+function readTextContent(result) {
+  if (!Array.isArray(result.content) || result.content.length === 0) {
+    throw new Error("MCP tool call returned no content.");
+  }
+
+  const first = result.content[0];
+  if (first?.type !== "text" || typeof first.text !== "string") {
+    throw new Error("Expected text content from MCP tool call.");
+  }
+
+  return first.text;
+}
+
+function parsePackEntry(stdout) {
+  const parsed = JSON.parse(stdout);
+  const entry = Array.isArray(parsed) ? parsed[0] : null;
+  if (!entry || typeof entry.filename !== "string" || !Array.isArray(entry.files)) {
+    throw new Error("npm pack did not return a usable pack result.");
+  }
+  return entry;
+}
+
+function npmCommand() {
+  return "npm";
+}
+
+function tarCommand() {
+  return process.platform === "win32" ? "tar.exe" : "tar";
+}
+
+function createPackagedLaunch(tarballPath) {
+  if (process.platform === "win32") {
+    const normalizedTarballPath = tarballPath.replace(/\\/g, "/");
+    return {
+      command: process.env.ComSpec ?? "cmd.exe",
+      args: ["/d", "/s", "/c", `npm exec --yes --package ${normalizedTarballPath} -- martin-mcp`],
+    };
+  }
+
+  return {
+    command: "npm",
+    args: ["exec", "--yes", "--package", tarballPath, "--", "martin-mcp"],
+  };
+}
+
+async function runCommand(command, args, options) {
+  return new Promise((resolve, reject) => {
+    const launch = createCommandLaunch(command, args);
+    const child = spawn(launch.command, launch.args, {
+      cwd: options.cwd,
+      env: options.env ?? process.env,
+      shell: false,
+      windowsHide: true,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code !== 0) {
+        reject(new Error(`Command failed (${code ?? "unknown"}): ${command} ${args.join(" ")}\n${stdout}${stderr}`));
+        return;
+      }
+      resolve({ stdout, stderr });
+    });
+  });
+}
+
+function createCommandLaunch(command, args) {
+  if (process.platform !== "win32") {
+    return { command, args };
+  }
+
+  return {
+    command: process.env.ComSpec ?? "cmd.exe",
+    args: ["/d", "/s", "/c", toCmdCommand(command, args)],
+  };
+}
+
+function toCmdCommand(command, args) {
+  return [quoteForCmdArgument(command), ...args.map((arg) => quoteForCmdArgument(arg))].join(" ");
+}
+
+function quoteForCmdArgument(value) {
+  return /[\s"]/u.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
+}
+
+async function main() {
+  const result = await runStandaloneMcpSmoke();
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : "";
+const modulePath = fileURLToPath(import.meta.url);
+if (invokedPath === path.resolve(modulePath)) {
+  main().catch((error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`Standalone MCP smoke failed: ${message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -9,7 +9,10 @@
  *   martin_status   — return cost and pressure state from a loop record
  *
  * Setup (Claude Code):
- *   claude mcp add martin-loop -- npx @martin/mcp
+ *   claude mcp add martin-loop -- npx -y @martin/mcp
+ *
+ * Packaged smoke test:
+ *   pnpm --filter @martin/mcp smoke:pack
  *
  * Manual start:
  *   node dist/server.js
@@ -27,7 +30,7 @@ import { inspectLoopTool } from "./tools/inspect-loop.js";
 import { runLoopTool } from "./tools/run-loop.js";
 
 const server = new Server(
-  { name: "martin-loop", version: "0.1.0" },
+  { name: "martin-loop", version: "0.1.1" },
   { capabilities: { tools: {} } }
 );
 

--- a/packages/mcp/tests/build-package.test.ts
+++ b/packages/mcp/tests/build-package.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { rewritePackageSpecifiers } from "../scripts/build-package.mjs";
+
+describe("rewritePackageSpecifiers", () => {
+  it("rewrites nested internal package subpaths without truncating them", () => {
+    const rewritten = rewritePackageSpecifiers(
+      'import { helper } from "@martin/core/utils/helper";',
+      {
+        targetPath: "C:/repo/packages/mcp/dist/server.js",
+        distDir: "C:/repo/packages/mcp/dist",
+      },
+    );
+
+    expect(rewritten).toContain('./vendor/core/utils/helper.js');
+  });
+
+  it("preserves explicit js extensions instead of appending them twice", () => {
+    const rewritten = rewritePackageSpecifiers(
+      'export * from "@martin/adapters/runtime-support.js";',
+      {
+        targetPath: "C:/repo/packages/mcp/dist/server.js",
+        distDir: "C:/repo/packages/mcp/dist",
+      },
+    );
+
+    expect(rewritten).toContain('./vendor/adapters/runtime-support.js');
+    expect(rewritten).not.toContain("runtime-support.js.js");
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,15 +108,6 @@ importers:
 
   packages/mcp:
     dependencies:
-      '@martin/adapters':
-        specifier: workspace:*
-        version: link:../adapters
-      '@martin/contracts':
-        specifier: workspace:*
-        version: link:../contracts
-      '@martin/core':
-        specifier: workspace:*
-        version: link:../core
       '@modelcontextprotocol/sdk':
         specifier: ^1.0.0
         version: 1.29.0(zod@4.3.6)


### PR DESCRIPTION
update, polish, and simplify the MCP server build for MartinLoop. 

## Summary
- make `@martin/mcp` a standalone publishable package for registry installs
- vendor internal Martin runtime dependencies into the packaged output so registry installs do not rely on private workspace packages
- add a packed smoke test that launches the packaged server and verifies the MCP stdio handshake plus `martin_status`
- document the one-line install path: `npx -y @martin/mcp`

## Verification
- `pnpm --filter @martin/mcp build`
- `pnpm --filter @martin/mcp test`
- `pnpm --filter @martin/mcp lint`
- `pnpm --filter @martin/mcp smoke:pack`
- `pnpm public:smoke`
- `pnpm oss:validate`
