### PR TITLE
fix(mcp): harden one-line install on Windows and macOS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 - Martin Loop ships both a repo-wide OSS/RC surface and a standalone publishable MCP package at `packages/mcp`.
 
 ## Build and Verify
-- For MCP-only changes, run `pnpm --filter @martin/mcp test`, `pnpm --filter @martin/mcp build`, and `pnpm --filter @martin/mcp smoke:pack`.
+- For MCP-only changes, run `pnpm --filter @keean12/mcp test`, `pnpm --filter @keean12/mcp build`, and `pnpm --filter @keean12/mcp smoke:pack`.
 - For release-surface or packaging changes that could affect CI, run `pnpm release:matrix:local`.
 
 ## MCP Registry Guardrails

--- a/README.md
+++ b/README.md
@@ -136,10 +136,23 @@ The frozen public package surface for this release candidate is:
 - Install target: `npm install martin-loop`
 - CLI target: `npx martin-loop`
 - SDK target: `import { MartinLoop } from "martin-loop"`
-- MCP target (registry-ready package): `npx -y @keean12/mcp`
+- MCP target (registry-ready package): `npx @keean12/mcp`
 
 The `martin` command alias is installed for local operator convenience, but the public CLI surface is `npx martin-loop`.
 The standalone MCP server package is smoke-validated locally with `pnpm --filter @keean12/mcp smoke:pack` and is ready for registry publication as a separate release step.
+
+### Claude Code MCP install
+
+Use the published MCP package directly:
+
+- macOS/Linux: `claude mcp add --scope user martin-loop -- npx @keean12/mcp`
+- Windows PowerShell/cmd: `claude mcp add --scope user martin-loop cmd /c "npx @keean12/mcp"`
+
+If you just want to launch the server manually, the one-line command is:
+
+```sh
+npx @keean12/mcp
+```
 
 ### Run a governed task
 

--- a/README.md
+++ b/README.md
@@ -136,10 +136,10 @@ The frozen public package surface for this release candidate is:
 - Install target: `npm install martin-loop`
 - CLI target: `npx martin-loop`
 - SDK target: `import { MartinLoop } from "martin-loop"`
-- MCP target (registry-ready package): `npx -y @martin/mcp`
+- MCP target (registry-ready package): `npx -y @keean12/mcp`
 
 The `martin` command alias is installed for local operator convenience, but the public CLI surface is `npx martin-loop`.
-The standalone MCP server package is smoke-validated locally with `pnpm --filter @martin/mcp smoke:pack` and is ready for registry publication as a separate release step.
+The standalone MCP server package is smoke-validated locally with `pnpm --filter @keean12/mcp smoke:pack` and is ready for registry publication as a separate release step.
 
 ### Run a governed task
 
@@ -289,12 +289,12 @@ The lower-level `runMartin` function is also exported for callers that want to a
 | `@martin/core` | Runtime controller, policy engine, safety leash, grounding, persistence, and rollback logic. |
 | `@martin/adapters` | Claude CLI, Codex CLI, direct-provider, and stub adapter surfaces. |
 | `@martin/cli` | Local CLI implementation for `run`, `inspect`, `resume`, and the benchmark redirect. |
-| `@martin/mcp` | MCP server tools: `martin_run`, `martin_inspect`, and `martin_status`. |
+| `@keean12/mcp` | MCP server tools: `martin_run`, `martin_inspect`, and `martin_status`. |
 | `benchmarks/` | Workspace-only deterministic benchmark and RC validation harness. |
 | `apps/control-plane/` | Hosted control-plane workstream, outside the initial npm package surface. |
 | `apps/local-dashboard/` | Local dashboard/read-model viewer, not currently packaged as public npm API. |
 
-The `@martin/core`, `@martin/adapters`, and `@martin/contracts` package manifests are still private workspace packages. The public runtime install target is the root `martin-loop` facade, while `@martin/mcp` is packaged as a standalone MCP server with vendored internal runtime dependencies for registry publication.
+The `@martin/core`, `@martin/adapters`, and `@martin/contracts` package manifests are still private workspace packages. The public runtime install target is the root `martin-loop` facade, while `@keean12/mcp` is packaged as a standalone MCP server with vendored internal runtime dependencies for registry publication.
 
 ---
 ## Development

--- a/docs/oss/QUICKSTART.md
+++ b/docs/oss/QUICKSTART.md
@@ -9,7 +9,7 @@ The frozen public launch target is:
 - `npm install martin-loop`
 - `npx martin-loop ...`
 - `import { MartinLoop } from "martin-loop"`
-- `npx -y @martin/mcp`
+- `npx -y @keean12/mcp`
 
 That runtime launch surface is implemented in the root package facade and smoke-validated from a clean temporary install. The MCP package shape is also smoke-validated from a packed tarball. This quickstart still documents the honest RC-from-source path because public registry publication is a separate release step.
 
@@ -118,16 +118,16 @@ For persisted run folders, inspect the `contract.json`, `state.json`, `ledger.js
 The publish-ready MCP install target is:
 
 ```bash
-npx -y @martin/mcp
-claude mcp add martin-loop -- npx -y @martin/mcp
+npx -y @keean12/mcp
+claude mcp add martin-loop -- npx -y @keean12/mcp
 ```
 
-Official MCP Registry publication has an extra metadata step beyond npm packaging. Do not mark `@martin/mcp` registry-ready unless both of these exist and match:
+Official MCP Registry publication has an extra metadata step beyond npm packaging. Do not mark `@keean12/mcp` registry-ready unless both of these exist and match:
 
 - `packages/mcp/package.json` with `mcpName`
 - `packages/mcp/server.json` with the official server metadata
 
-After publishing `@martin/mcp` to npm, run the official registry publisher from `packages/mcp`:
+After publishing `@keean12/mcp` to npm, run the official registry publisher from `packages/mcp`:
 
 ```bash
 mcp-publisher login github
@@ -137,8 +137,8 @@ mcp-publisher publish
 For repo-local verification from source:
 
 ```bash
-pnpm --filter @martin/mcp build
-pnpm --filter @martin/mcp smoke:pack
+pnpm --filter @keean12/mcp build
+pnpm --filter @keean12/mcp smoke:pack
 node packages/mcp/dist/server.js
 ```
 

--- a/docs/oss/QUICKSTART.md
+++ b/docs/oss/QUICKSTART.md
@@ -9,7 +9,7 @@ The frozen public launch target is:
 - `npm install martin-loop`
 - `npx martin-loop ...`
 - `import { MartinLoop } from "martin-loop"`
-- `npx -y @keean12/mcp`
+- `npx @keean12/mcp`
 
 That runtime launch surface is implemented in the root package facade and smoke-validated from a clean temporary install. The MCP package shape is also smoke-validated from a packed tarball. This quickstart still documents the honest RC-from-source path because public registry publication is a separate release step.
 
@@ -118,8 +118,17 @@ For persisted run folders, inspect the `contract.json`, `state.json`, `ledger.js
 The publish-ready MCP install target is:
 
 ```bash
-npx -y @keean12/mcp
-claude mcp add martin-loop -- npx -y @keean12/mcp
+npx @keean12/mcp
+```
+
+Claude Code one-line install:
+
+```bash
+# macOS/Linux
+claude mcp add --scope user martin-loop -- npx @keean12/mcp
+
+# Windows PowerShell/cmd
+claude mcp add --scope user martin-loop cmd /c "npx @keean12/mcp"
 ```
 
 Official MCP Registry publication has an extra metadata step beyond npm packaging. Do not mark `@keean12/mcp` registry-ready unless both of these exist and match:

--- a/docs/oss/README.md
+++ b/docs/oss/README.md
@@ -55,7 +55,7 @@ The current engineering memo freezes these public-launch targets for release pla
 - install target: `npm install martin-loop`
 - CLI target: `npx martin-loop ...`
 - SDK target: `import { MartinLoop } from "martin-loop"`
-- MCP target (publish-ready): `npx -y @keean12/mcp`
+- MCP target (publish-ready): `npx @keean12/mcp`
 
 Those runtime targets are implemented in the root package facade and verified through a clean-install smoke test. The MCP target is packaged and verified through a tarball launch smoke test. During the current RC phase, the honest operator path still includes the repo-local workflow documented below and in the quickstart, because public registry publication and broader release packaging remain separate release steps.
 

--- a/docs/oss/README.md
+++ b/docs/oss/README.md
@@ -8,11 +8,11 @@ Martin Loop is a governed AI coding-loop runtime. The core runtime is real and v
 - `@martin/core`: the runtime controller, persistence layer, grounding scanner, leash engine, patch-truth scoring, and rollback restoration logic
 - `@martin/adapters`: normalized Claude CLI, Codex CLI, and direct-provider or stub adapter surfaces
 - `@martin/cli`: the local operator CLI for `run`, `inspect`, and `resume`
-- `@martin/mcp`: the MCP server surface for `martin_run`, `martin_inspect`, and `martin_status`
+- `@keean12/mcp`: the MCP server surface for `martin_run`, `martin_inspect`, and `martin_status`
 
 ## What is still outside the initial OSS promise
 
-- The root workspace now exposes the `martin-loop` public package facade, and `@martin/mcp` now has a standalone tarball shape validated via `pnpm --filter @martin/mcp smoke:pack`, but registry publication is still a separate release step.
+- The root workspace now exposes the `martin-loop` public package facade, and `@keean12/mcp` now has a standalone tarball shape validated via `pnpm --filter @keean12/mcp smoke:pack`, but registry publication is still a separate release step.
 - `@martin/contracts`, `@martin/core`, and `@martin/adapters` are still marked `private` in their package manifests.
 - The hosted control-plane and local dashboard remain in the repo, but they are not yet the finalized public OSS boundary.
 - The benchmark harness remains a workspace-only RC surface under `benchmarks/` and is not part of the publishable CLI boundary yet.
@@ -55,7 +55,7 @@ The current engineering memo freezes these public-launch targets for release pla
 - install target: `npm install martin-loop`
 - CLI target: `npx martin-loop ...`
 - SDK target: `import { MartinLoop } from "martin-loop"`
-- MCP target (publish-ready): `npx -y @martin/mcp`
+- MCP target (publish-ready): `npx -y @keean12/mcp`
 
 Those runtime targets are implemented in the root package facade and verified through a clean-install smoke test. The MCP target is packaged and verified through a tarball launch smoke test. During the current RC phase, the honest operator path still includes the repo-local workflow documented below and in the quickstart, because public registry publication and broader release packaging remain separate release steps.
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -13,19 +13,23 @@ It exposes three MCP tools over stdio:
 Run the packaged server directly:
 
 ```sh
-npx -y @keean12/mcp
+npx @keean12/mcp
 ```
 
 Add it to Claude Code:
 
 ```sh
-claude mcp add martin-loop -- npx -y @keean12/mcp
+# macOS/Linux
+claude mcp add --scope user martin-loop -- npx @keean12/mcp
+
+# Windows PowerShell/cmd
+claude mcp add --scope user martin-loop cmd /c "npx @keean12/mcp"
 ```
 
 For clients that want explicit command/args:
 
 - Command: `npx`
-- Args: `-y`, `@keean12/mcp`
+- Args: `@keean12/mcp`
 
 ## Official MCP Registry
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,4 +1,4 @@
-# @martin/mcp
+# @keean12/mcp
 
 Martin Loop's installable Model Context Protocol server.
 
@@ -13,25 +13,25 @@ It exposes three MCP tools over stdio:
 Run the packaged server directly:
 
 ```sh
-npx -y @martin/mcp
+npx -y @keean12/mcp
 ```
 
 Add it to Claude Code:
 
 ```sh
-claude mcp add martin-loop -- npx -y @martin/mcp
+claude mcp add martin-loop -- npx -y @keean12/mcp
 ```
 
 For clients that want explicit command/args:
 
 - Command: `npx`
-- Args: `-y`, `@martin/mcp`
+- Args: `-y`, `@keean12/mcp`
 
 ## Official MCP Registry
 
 This package is prepared for the official MCP Registry metadata flow:
 
-- npm package: `@martin/mcp`
+- npm package: `@keean12/mcp`
 - registry server name: `io.github.keesan12/martin-loop`
 - manifest file: `packages/mcp/server.json`
 
@@ -47,9 +47,9 @@ mcp-publisher publish
 From the repository root:
 
 ```sh
-pnpm --filter @martin/mcp build
-pnpm --filter @martin/mcp test
-pnpm --filter @martin/mcp smoke:pack
+pnpm --filter @keean12/mcp build
+pnpm --filter @keean12/mcp test
+pnpm --filter @keean12/mcp smoke:pack
 ```
 
 `smoke:pack` packs the tarball, launches it through `npx`, performs the MCP handshake, lists tools, and verifies a `martin_status` call.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@martin/mcp",
+  "name": "@keean12/mcp",
   "version": "0.1.1",
   "mcpName": "io.github.keesan12/martin-loop",
   "private": false,
@@ -27,7 +27,7 @@
   "main": "./dist/server.js",
   "types": "./dist/server.d.ts",
   "bin": {
-    "martin-mcp": "./dist/server.js"
+    "mcp": "./dist/server.js"
   },
   "exports": {
     ".": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://martinloop.com/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Keesan12/martin-loop.git",
+    "url": "git+https://github.com/Keesan12/martin-loop.git",
     "directory": "packages/mcp"
   },
   "bugs": {
@@ -27,7 +27,7 @@
   "main": "./dist/server.js",
   "types": "./dist/server.d.ts",
   "bin": {
-    "mcp": "./dist/server.js"
+    "mcp": "dist/server.js"
   },
   "exports": {
     ".": {

--- a/packages/mcp/scripts/smoke-package.mjs
+++ b/packages/mcp/scripts/smoke-package.mjs
@@ -12,6 +12,7 @@ import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 import { buildStandaloneMcpPackage } from "./build-package-lib.mjs";
 
 const REQUIRED_TOOLS = ["martin_inspect", "martin_run", "martin_status"];
+const PACKAGED_BIN_NAME = "mcp";
 const REQUIRED_TARBALL_FILES = [
   "README.md",
   "dist/server.d.ts",
@@ -72,12 +73,13 @@ export async function runStandaloneMcpSmoke(options = {}) {
       { cwd: packageDir },
     );
     const packEntry = parsePackEntry(packRun.stdout);
+    const tarballFilename = packEntry.filename;
     const tarballPath = path.join(packDir, packEntry.filename);
 
     const packedManifestOutput = await runCommand(
       tarCommand(),
-      ["-xOf", tarballPath, "package/package.json"],
-      { cwd: packageDir },
+      ["-xOf", tarballFilename, "package/package.json"],
+      { cwd: packDir },
     );
     const packedManifest = JSON.parse(packedManifestOutput.stdout);
     assertPackedManifest(packedManifest);
@@ -124,7 +126,7 @@ export async function runStandaloneMcpSmoke(options = {}) {
 
     return {
       tarballPath,
-      npxCommand: "npx -y @keean12/mcp",
+      npxCommand: "npx @keean12/mcp",
       toolNames,
       tarballFiles,
       packedDependencies: packedManifest.dependencies ?? {},
@@ -203,13 +205,13 @@ function createPackagedLaunch(tarballPath) {
     const normalizedTarballPath = tarballPath.replace(/\\/g, "/");
     return {
       command: process.env.ComSpec ?? "cmd.exe",
-      args: ["/d", "/s", "/c", `npm exec --yes --package ${normalizedTarballPath} -- martin-mcp`],
+      args: ["/d", "/s", "/c", `npm exec --yes --package ${normalizedTarballPath} -- ${PACKAGED_BIN_NAME}`],
     };
   }
 
   return {
     command: "npm",
-    args: ["exec", "--yes", "--package", tarballPath, "--", "martin-mcp"],
+    args: ["exec", "--yes", "--package", tarballPath, "--", PACKAGED_BIN_NAME],
   };
 }
 

--- a/packages/mcp/scripts/smoke-package.mjs
+++ b/packages/mcp/scripts/smoke-package.mjs
@@ -124,7 +124,7 @@ export async function runStandaloneMcpSmoke(options = {}) {
 
     return {
       tarballPath,
-      npxCommand: "npx -y @martin/mcp",
+      npxCommand: "npx -y @keean12/mcp",
       toolNames,
       tarballFiles,
       packedDependencies: packedManifest.dependencies ?? {},

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -11,7 +11,7 @@
   "packages": [
     {
       "registryType": "npm",
-      "identifier": "@martin/mcp",
+      "identifier": "@keean12/mcp",
       "version": "0.1.1",
       "transport": {
         "type": "stdio"

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -9,7 +9,8 @@
  *   martin_status   — return cost and pressure state from a loop record
  *
  * Setup (Claude Code):
- *   claude mcp add martin-loop -- npx -y @keean12/mcp
+ *   macOS/Linux: claude mcp add --scope user martin-loop -- npx @keean12/mcp
+ *   Windows:     claude mcp add --scope user martin-loop cmd /c "npx @keean12/mcp"
  *
  * Packaged smoke test:
  *   pnpm --filter @keean12/mcp smoke:pack

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -9,10 +9,10 @@
  *   martin_status   — return cost and pressure state from a loop record
  *
  * Setup (Claude Code):
- *   claude mcp add martin-loop -- npx -y @martin/mcp
+ *   claude mcp add martin-loop -- npx -y @keean12/mcp
  *
  * Packaged smoke test:
- *   pnpm --filter @martin/mcp smoke:pack
+ *   pnpm --filter @keean12/mcp smoke:pack
  *
  * Manual start:
  *   node dist/server.js

--- a/scripts/tests/oss-boundary.test.mjs
+++ b/scripts/tests/oss-boundary.test.mjs
@@ -15,7 +15,7 @@ test("createOssBoundaryReport defines the intended OSS core packages without wor
 
   assert.deepEqual(
     report.ossCorePackages.map((pkg) => pkg.name),
-    ["@martin/contracts", "@martin/core", "@martin/adapters", "@martin/cli", "@martin/mcp"],
+    ["@martin/contracts", "@martin/core", "@martin/adapters", "@martin/cli", "@keean12/mcp"],
   );
 
   assert.equal(report.summary.dependencyLeakCount, 0);


### PR DESCRIPTION
## Summary
- document the real one-line MCP launch command as 
px @keean12/mcp
- document the working Claude Code install commands for macOS/Linux and native Windows
- fix the standalone MCP smoke test on Windows by reading the packed manifest from the pack directory and launching the published mcp bin
- remove npm publish auto-corrections by normalizing the MCP package in and repository URL fields

## Verification
- pnpm --filter @keean12/mcp test
- pnpm --filter @keean12/mcp lint
- pnpm --filter @keean12/mcp build
- pnpm --filter @keean12/mcp smoke:pack
- manual Windows verification: 
pm view @keean12/mcp version, 
px @keean12/mcp, and claude mcp list with martin-loop connected

## Why
The prior docs claimed a simple one-line install path that did not hold up on native Windows Claude Code. This change makes the repo honest about the command that actually works today and restores a passing local Windows smoke path for the published package.