### PR TITLE
Ship branded @martinloop/mcp package metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 - Martin Loop ships both a repo-wide OSS/RC surface and a standalone publishable MCP package at `packages/mcp`.
 
 ## Build and Verify
-- For MCP-only changes, run `pnpm --filter @keean12/mcp test`, `pnpm --filter @keean12/mcp build`, and `pnpm --filter @keean12/mcp smoke:pack`.
+- For MCP-only changes, run `pnpm --filter @martinloop/mcp test`, `pnpm --filter @martinloop/mcp build`, and `pnpm --filter @martinloop/mcp smoke:pack`.
 - For release-surface or packaging changes that could affect CI, run `pnpm release:matrix:local`.
 
 ## MCP Registry Guardrails

--- a/README.md
+++ b/README.md
@@ -136,22 +136,22 @@ The frozen public package surface for this release candidate is:
 - Install target: `npm install martin-loop`
 - CLI target: `npx martin-loop`
 - SDK target: `import { MartinLoop } from "martin-loop"`
-- MCP target (registry-ready package): `npx @keean12/mcp`
+- MCP target (registry-ready package): `npx @martinloop/mcp`
 
 The `martin` command alias is installed for local operator convenience, but the public CLI surface is `npx martin-loop`.
-The standalone MCP server package is smoke-validated locally with `pnpm --filter @keean12/mcp smoke:pack` and is ready for registry publication as a separate release step.
+The standalone MCP server package is smoke-validated locally with `pnpm --filter @martinloop/mcp smoke:pack` and is ready for registry publication as a separate release step.
 
 ### Claude Code MCP install
 
 Use the published MCP package directly:
 
-- macOS/Linux: `claude mcp add --scope user martin-loop -- npx @keean12/mcp`
-- Windows PowerShell/cmd: `claude mcp add --scope user martin-loop cmd /c "npx @keean12/mcp"`
+- macOS/Linux: `claude mcp add --scope user martin-loop -- npx @martinloop/mcp`
+- Windows PowerShell/cmd: `claude mcp add --scope user martin-loop cmd /c "npx @martinloop/mcp"`
 
 If you just want to launch the server manually, the one-line command is:
 
 ```sh
-npx @keean12/mcp
+npx @martinloop/mcp
 ```
 
 ### Run a governed task
@@ -302,12 +302,12 @@ The lower-level `runMartin` function is also exported for callers that want to a
 | `@martin/core` | Runtime controller, policy engine, safety leash, grounding, persistence, and rollback logic. |
 | `@martin/adapters` | Claude CLI, Codex CLI, direct-provider, and stub adapter surfaces. |
 | `@martin/cli` | Local CLI implementation for `run`, `inspect`, `resume`, and the benchmark redirect. |
-| `@keean12/mcp` | MCP server tools: `martin_run`, `martin_inspect`, and `martin_status`. |
+| `@martinloop/mcp` | MCP server tools: `martin_run`, `martin_inspect`, and `martin_status`. |
 | `benchmarks/` | Workspace-only deterministic benchmark and RC validation harness. |
 | `apps/control-plane/` | Hosted control-plane workstream, outside the initial npm package surface. |
 | `apps/local-dashboard/` | Local dashboard/read-model viewer, not currently packaged as public npm API. |
 
-The `@martin/core`, `@martin/adapters`, and `@martin/contracts` package manifests are still private workspace packages. The public runtime install target is the root `martin-loop` facade, while `@keean12/mcp` is packaged as a standalone MCP server with vendored internal runtime dependencies for registry publication.
+The `@martin/core`, `@martin/adapters`, and `@martin/contracts` package manifests are still private workspace packages. The public runtime install target is the root `martin-loop` facade, while `@martinloop/mcp` is packaged as a standalone MCP server with vendored internal runtime dependencies for registry publication.
 
 ---
 ## Development

--- a/docs/oss/QUICKSTART.md
+++ b/docs/oss/QUICKSTART.md
@@ -9,7 +9,7 @@ The frozen public launch target is:
 - `npm install martin-loop`
 - `npx martin-loop ...`
 - `import { MartinLoop } from "martin-loop"`
-- `npx @keean12/mcp`
+- `npx @martinloop/mcp`
 
 That runtime launch surface is implemented in the root package facade and smoke-validated from a clean temporary install. The MCP package shape is also smoke-validated from a packed tarball. This quickstart still documents the honest RC-from-source path because public registry publication is a separate release step.
 
@@ -118,25 +118,25 @@ For persisted run folders, inspect the `contract.json`, `state.json`, `ledger.js
 The publish-ready MCP install target is:
 
 ```bash
-npx @keean12/mcp
+npx @martinloop/mcp
 ```
 
 Claude Code one-line install:
 
 ```bash
 # macOS/Linux
-claude mcp add --scope user martin-loop -- npx @keean12/mcp
+claude mcp add --scope user martin-loop -- npx @martinloop/mcp
 
 # Windows PowerShell/cmd
-claude mcp add --scope user martin-loop cmd /c "npx @keean12/mcp"
+claude mcp add --scope user martin-loop cmd /c "npx @martinloop/mcp"
 ```
 
-Official MCP Registry publication has an extra metadata step beyond npm packaging. Do not mark `@keean12/mcp` registry-ready unless both of these exist and match:
+Official MCP Registry publication has an extra metadata step beyond npm packaging. Do not mark `@martinloop/mcp` registry-ready unless both of these exist and match:
 
 - `packages/mcp/package.json` with `mcpName`
 - `packages/mcp/server.json` with the official server metadata
 
-After publishing `@keean12/mcp` to npm, run the official registry publisher from `packages/mcp`:
+After publishing `@martinloop/mcp` to npm, run the official registry publisher from `packages/mcp`:
 
 ```bash
 mcp-publisher login github
@@ -146,8 +146,8 @@ mcp-publisher publish
 For repo-local verification from source:
 
 ```bash
-pnpm --filter @keean12/mcp build
-pnpm --filter @keean12/mcp smoke:pack
+pnpm --filter @martinloop/mcp build
+pnpm --filter @martinloop/mcp smoke:pack
 node packages/mcp/dist/server.js
 ```
 

--- a/docs/oss/README.md
+++ b/docs/oss/README.md
@@ -8,11 +8,11 @@ Martin Loop is a governed AI coding-loop runtime. The core runtime is real and v
 - `@martin/core`: the runtime controller, persistence layer, grounding scanner, leash engine, patch-truth scoring, and rollback restoration logic
 - `@martin/adapters`: normalized Claude CLI, Codex CLI, and direct-provider or stub adapter surfaces
 - `@martin/cli`: the local operator CLI for `run`, `inspect`, and `resume`
-- `@keean12/mcp`: the MCP server surface for `martin_run`, `martin_inspect`, and `martin_status`
+- `@martinloop/mcp`: the MCP server surface for `martin_run`, `martin_inspect`, and `martin_status`
 
 ## What is still outside the initial OSS promise
 
-- The root workspace now exposes the `martin-loop` public package facade, and `@keean12/mcp` now has a standalone tarball shape validated via `pnpm --filter @keean12/mcp smoke:pack`, but registry publication is still a separate release step.
+- The root workspace now exposes the `martin-loop` public package facade, and `@martinloop/mcp` now has a standalone tarball shape validated via `pnpm --filter @martinloop/mcp smoke:pack`, but registry publication is still a separate release step.
 - `@martin/contracts`, `@martin/core`, and `@martin/adapters` are still marked `private` in their package manifests.
 - The hosted control-plane and local dashboard remain in the repo, but they are not yet the finalized public OSS boundary.
 - The benchmark harness remains a workspace-only RC surface under `benchmarks/` and is not part of the publishable CLI boundary yet.
@@ -55,7 +55,7 @@ The current engineering memo freezes these public-launch targets for release pla
 - install target: `npm install martin-loop`
 - CLI target: `npx martin-loop ...`
 - SDK target: `import { MartinLoop } from "martin-loop"`
-- MCP target (publish-ready): `npx @keean12/mcp`
+- MCP target (publish-ready): `npx @martinloop/mcp`
 
 Those runtime targets are implemented in the root package facade and verified through a clean-install smoke test. The MCP target is packaged and verified through a tarball launch smoke test. During the current RC phase, the honest operator path still includes the repo-local workflow documented below and in the quickstart, because public registry publication and broader release packaging remain separate release steps.
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,4 +1,4 @@
-# @keean12/mcp
+# @martinloop/mcp
 
 Martin Loop's installable Model Context Protocol server.
 
@@ -13,29 +13,29 @@ It exposes three MCP tools over stdio:
 Run the packaged server directly:
 
 ```sh
-npx @keean12/mcp
+npx @martinloop/mcp
 ```
 
 Add it to Claude Code:
 
 ```sh
 # macOS/Linux
-claude mcp add --scope user martin-loop -- npx @keean12/mcp
+claude mcp add --scope user martin-loop -- npx @martinloop/mcp
 
 # Windows PowerShell/cmd
-claude mcp add --scope user martin-loop cmd /c "npx @keean12/mcp"
+claude mcp add --scope user martin-loop cmd /c "npx @martinloop/mcp"
 ```
 
 For clients that want explicit command/args:
 
 - Command: `npx`
-- Args: `@keean12/mcp`
+- Args: `@martinloop/mcp`
 
 ## Official MCP Registry
 
 This package is prepared for the official MCP Registry metadata flow:
 
-- npm package: `@keean12/mcp`
+- npm package: `@martinloop/mcp`
 - registry server name: `io.github.keesan12/martin-loop`
 - manifest file: `packages/mcp/server.json`
 
@@ -51,9 +51,9 @@ mcp-publisher publish
 From the repository root:
 
 ```sh
-pnpm --filter @keean12/mcp build
-pnpm --filter @keean12/mcp test
-pnpm --filter @keean12/mcp smoke:pack
+pnpm --filter @martinloop/mcp build
+pnpm --filter @martinloop/mcp test
+pnpm --filter @martinloop/mcp smoke:pack
 ```
 
 `smoke:pack` packs the tarball, launches it through `npx`, performs the MCP handshake, lists tools, and verifies a `martin_status` call.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@keean12/mcp",
+  "name": "@martinloop/mcp",
   "version": "0.1.1",
   "mcpName": "io.github.keesan12/martin-loop",
   "private": false,

--- a/packages/mcp/scripts/smoke-package.mjs
+++ b/packages/mcp/scripts/smoke-package.mjs
@@ -126,7 +126,7 @@ export async function runStandaloneMcpSmoke(options = {}) {
 
     return {
       tarballPath,
-      npxCommand: "npx @keean12/mcp",
+      npxCommand: "npx @martinloop/mcp",
       toolNames,
       tarballFiles,
       packedDependencies: packedManifest.dependencies ?? {},

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -11,7 +11,7 @@
   "packages": [
     {
       "registryType": "npm",
-      "identifier": "@keean12/mcp",
+      "identifier": "@martinloop/mcp",
       "version": "0.1.1",
       "transport": {
         "type": "stdio"

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -9,11 +9,11 @@
  *   martin_status   — return cost and pressure state from a loop record
  *
  * Setup (Claude Code):
- *   macOS/Linux: claude mcp add --scope user martin-loop -- npx @keean12/mcp
- *   Windows:     claude mcp add --scope user martin-loop cmd /c "npx @keean12/mcp"
+ *   macOS/Linux: claude mcp add --scope user martin-loop -- npx @martinloop/mcp
+ *   Windows:     claude mcp add --scope user martin-loop cmd /c "npx @martinloop/mcp"
  *
  * Packaged smoke test:
- *   pnpm --filter @keean12/mcp smoke:pack
+ *   pnpm --filter @martinloop/mcp smoke:pack
  *
  * Manual start:
  *   node dist/server.js

--- a/scripts/tests/oss-boundary.test.mjs
+++ b/scripts/tests/oss-boundary.test.mjs
@@ -15,7 +15,7 @@ test("createOssBoundaryReport defines the intended OSS core packages without wor
 
   assert.deepEqual(
     report.ossCorePackages.map((pkg) => pkg.name),
-    ["@martin/contracts", "@martin/core", "@martin/adapters", "@martin/cli", "@keean12/mcp"],
+    ["@martin/contracts", "@martin/core", "@martin/adapters", "@martin/cli", "@martinloop/mcp"],
   );
 
   assert.equal(report.summary.dependencyLeakCount, 0);


### PR DESCRIPTION
## Summary
- Rename the standalone MCP package to `@martinloop/mcp`.
- Update install docs, Claude Code setup commands, and MCP Registry metadata for the branded package.
- Keep the Windows package smoke checks aligned with the renamed package.

## Verification
- `pnpm --filter @martinloop/mcp test`
- `pnpm --filter @martinloop/mcp lint`
- `pnpm --filter @martinloop/mcp build`
- `pnpm --filter @martinloop/mcp smoke:pack`