### PR TITLE
fix: address Gemini code review findings (PRs #11-#12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ The frozen public package surface for this release candidate is:
 - Install target: `npm install martin-loop`
 - CLI target: `npx martin-loop`
 - SDK target: `import { MartinLoop } from "martin-loop"`
-- MCP target (registry-ready package): `npx @martinloop/mcp`
+- MCP target (registry-ready package): `npx -y @martinloop/mcp`
 
 The `martin` command alias is installed for local operator convenience, but the public CLI surface is `npx martin-loop`.
 The standalone MCP server package is smoke-validated locally with `pnpm --filter @martinloop/mcp smoke:pack` and is ready for registry publication as a separate release step.
@@ -145,8 +145,8 @@ The standalone MCP server package is smoke-validated locally with `pnpm --filter
 
 Use the published MCP package directly:
 
-- macOS/Linux: `claude mcp add --scope user martin-loop -- npx @martinloop/mcp`
-- Windows PowerShell/cmd: `claude mcp add --scope user martin-loop cmd /c "npx @martinloop/mcp"`
+- macOS/Linux: `claude mcp add --scope user martin-loop -- npx -y @martinloop/mcp`
+- Windows PowerShell/cmd: `claude mcp add --scope user martin-loop -- cmd /c "npx -y @martinloop/mcp"`
 
 If you just want to launch the server manually, the one-line command is:
 

--- a/packages/mcp/scripts/build-package-lib.mjs
+++ b/packages/mcp/scripts/build-package-lib.mjs
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { chmod, copyFile, mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { access, chmod, copyFile, mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -210,15 +210,10 @@ function pnpmCommand() {
 
 async function fileExists(targetPath) {
   try {
-    await readFile(targetPath);
+    await access(targetPath);
     return true;
-  } catch (error) {
-    return !(
-      error &&
-      typeof error === "object" &&
-      "code" in error &&
-      error.code === "ENOENT"
-    );
+  } catch {
+    return false;
   }
 }
 

--- a/packages/mcp/scripts/smoke-package.mjs
+++ b/packages/mcp/scripts/smoke-package.mjs
@@ -126,7 +126,7 @@ export async function runStandaloneMcpSmoke(options = {}) {
 
     return {
       tarballPath,
-      npxCommand: "npx @martinloop/mcp",
+      npxCommand: "npx -y @martinloop/mcp",
       toolNames,
       tarballFiles,
       packedDependencies: packedManifest.dependencies ?? {},

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -9,8 +9,8 @@
  *   martin_status   — return cost and pressure state from a loop record
  *
  * Setup (Claude Code):
- *   macOS/Linux: claude mcp add --scope user martin-loop -- npx @martinloop/mcp
- *   Windows:     claude mcp add --scope user martin-loop cmd /c "npx @martinloop/mcp"
+ *   macOS/Linux: claude mcp add --scope user martin-loop -- npx -y @martinloop/mcp
+ *   Windows:     claude mcp add --scope user martin-loop -- cmd /c "npx -y @martinloop/mcp"
  *
  * Packaged smoke test:
  *   pnpm --filter @martinloop/mcp smoke:pack


### PR DESCRIPTION
## Summary

Resolves all actionable Gemini code-assist findings from the merged MCP hardening PRs.

**PR #11 — build-package-lib.mjs (2x MEDIUM):**
- Added `access` to `node:fs/promises` imports
- Replaced `fileExists` body: `readFile()` → `access()` — avoids loading file contents into memory just to check existence

**PR #12 — README, smoke-package.mjs, server.ts (4x MEDIUM):**
- Added `-y` flag to all `npx @martinloop/mcp` invocations — prevents interactive confirmation prompts in non-cached or non-interactive environments (CI runners, MCP host processes)
- Added missing `--` separator to Windows install command in README and server.ts comment — now consistent with macOS/Linux form

**PR #10 HIGH (rewritePackageSpecifiers regex + path truncation):**
Already resolved in the PR #11 rewrite — regex now uses `[^'"]+` and path handling uses `slice()` correctly. No additional change needed.

## Test plan
- [ ] `pnpm --filter @martinloop/mcp build` passes
- [ ] `pnpm --filter @martinloop/mcp smoke:pack` passes (exercises fileExists + npxCommand)
- [ ] README install commands are accurate end-to-end