### PR TITLE
Harden verify-only runs and Windows MCP builds

### DIFF
--- a/packages/adapters/src/claude-cli.ts
+++ b/packages/adapters/src/claude-cli.ts
@@ -574,17 +574,27 @@ export function createCodexCliAdapter(options: CodexCliAdapterOptions = {}): Mar
 
 function buildPrompt(request: MartinAdapterRequest): string {
   const lines: string[] = [];
+  const mutationMode = request.context.mutationMode ?? "edit";
 
   lines.push("You are running in autonomous agentic mode.");
-  lines.push("MAKE ALL REQUIRED FILE EDITS NOW. Do not ask for confirmation. Do not ask clarifying questions.");
-  lines.push("Do not explain what you found without also making the changes. Edit the files and complete the task.");
+  if (mutationMode === "verify_only") {
+    lines.push("DO NOT EDIT FILES. Run the verifier only and report whether it passes.");
+    lines.push("Do not ask for confirmation. Do not ask clarifying questions.");
+  } else {
+    lines.push("MAKE ALL REQUIRED FILE EDITS NOW. Do not ask for confirmation. Do not ask clarifying questions.");
+    lines.push("Do not explain what you found without also making the changes. Edit the files and complete the task.");
+  }
   lines.push("");
 
   lines.push("If PROGRESS.md exists in your working directory, read it first for context from prior attempts.");
   lines.push("If it does not exist, proceed with the objective below.");
   lines.push("");
 
-  lines.push("Complete the following coding task. Make all necessary file changes.");
+  lines.push(
+    mutationMode === "verify_only"
+      ? "Complete the following verification-only task without making file changes."
+      : "Complete the following coding task. Make all necessary file changes."
+  );
   lines.push("When you are done, the verification commands listed below must pass.");
   lines.push("");
 
@@ -627,7 +637,11 @@ function buildPrompt(request: MartinAdapterRequest): string {
   lines.push(`  Attempt ${String(attemptNumber)}`);
   lines.push(`  Remaining budget: $${String(request.context.remainingBudgetUsd)} USD`);
   lines.push(`  Remaining iterations: ${String(request.context.remainingIterations)}`);
-  lines.push("  Do not expand scope beyond what is needed to pass verification.");
+  lines.push(
+    mutationMode === "verify_only"
+      ? "  Do not modify files; only run verification."
+      : "  Do not expand scope beyond what is needed to pass verification."
+  );
   lines.push("");
 
   if (request.previousAttempts.length > 0) {

--- a/packages/adapters/src/cli-bridge.ts
+++ b/packages/adapters/src/cli-bridge.ts
@@ -117,9 +117,8 @@ export async function runVerification(
   const failedSteps: string[] = [];
 
   for (const step of steps) {
-    const parts = step.command.trim().split(/\s+/u);
-    const bin = parts[0];
-    const args = parts.slice(1);
+    const parts = splitCommand(step.command);
+    const [bin, ...args] = parts;
 
     if (!bin) {
       continue;
@@ -185,6 +184,58 @@ export async function readGitExecutionArtifacts(
 
 function shouldUseWindowsShell(command: string): boolean {
   return process.platform === "win32" && !isAbsolute(command);
+}
+
+export function splitCommand(command: string): string[] {
+  const tokens: string[] = [];
+  let current = "";
+  let quote: '"' | "'" | undefined;
+
+  const trimmed = command.trim();
+  for (let index = 0; index < trimmed.length; index += 1) {
+    const char = trimmed[index];
+    const next = trimmed[index + 1];
+    if (char === undefined) {
+      continue;
+    }
+
+    if (char === "\\") {
+      const canEscape = quote !== "'" && (next === quote || next === "\\");
+      if (canEscape && next !== undefined) {
+        current += next;
+        index += 1;
+        continue;
+      }
+    }
+
+    if (char === '"' || char === "'") {
+      if (!quote) {
+        quote = char;
+        continue;
+      }
+
+      if (quote === char) {
+        quote = undefined;
+        continue;
+      }
+    }
+
+    if (!quote && /\s/u.test(char)) {
+      if (current.length > 0) {
+        tokens.push(current);
+        current = "";
+      }
+      continue;
+    }
+
+    current += char;
+  }
+
+  if (current.length > 0) {
+    tokens.push(current);
+  }
+
+  return tokens;
 }
 
 function truncate(text: string, maxLength: number): string {

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -19,4 +19,8 @@ export {
   type CodexCliAdapterOptions,
   type CliArgsBuilder
 } from "./claude-cli.js";
+export {
+  createVerifierOnlyAdapter,
+  type VerifierOnlyAdapterOptions
+} from "./verifier-only.js";
 export type { SpawnLike, SubprocessResult, VerificationOutcome } from "./cli-bridge.js";

--- a/packages/adapters/src/verifier-only.ts
+++ b/packages/adapters/src/verifier-only.ts
@@ -1,0 +1,76 @@
+import type { MartinAdapter } from "@martin/core";
+
+import { readGitExecutionArtifacts, runVerification } from "./cli-bridge.js";
+import { createAdapterCapabilities, normalizeUsage } from "./runtime-support.js";
+
+export interface VerifierOnlyAdapterOptions {
+  workingDirectory?: string;
+  verifyTimeoutMs?: number;
+  label?: string;
+}
+
+export function createVerifierOnlyAdapter(
+  options: VerifierOnlyAdapterOptions = {}
+): MartinAdapter {
+  const workingDirectory = options.workingDirectory ?? process.cwd();
+  const verifyTimeoutMs = options.verifyTimeoutMs ?? 60_000;
+
+  return {
+    adapterId: "direct:verifier:verify-only",
+    kind: "direct-provider",
+    label: options.label ?? "Verifier-only adapter",
+    metadata: {
+      providerId: "verifier",
+      model: "verify-only",
+      transport: "cli",
+      capabilities: createAdapterCapabilities({
+        usageSettlement: true,
+        diffArtifacts: true
+      })
+    },
+    async execute(request) {
+      const verification = await runVerification(
+        request.context.verificationPlan,
+        workingDirectory,
+        verifyTimeoutMs,
+        request.context.verificationStack
+      );
+      const execution = await readGitExecutionArtifacts(workingDirectory, 5_000);
+      const changedFiles = execution.changedFiles ?? [];
+
+      if (verification.passed) {
+        return {
+          status: "completed",
+          summary:
+            changedFiles.length > 0
+              ? `Verifier-only run completed but modified files: ${changedFiles.join(", ")}`
+              : "Verifier-only run completed without file edits.",
+          usage: normalizeUsage({
+            actualUsd: 0,
+            tokensIn: 0,
+            tokensOut: 0,
+            provenance: "actual"
+          }),
+          verification,
+          execution
+        };
+      }
+
+      return {
+        status: "failed",
+        summary: "Verifier-only run failed.",
+        usage: normalizeUsage({
+          actualUsd: 0,
+          tokensIn: 0,
+          tokensOut: 0,
+          provenance: "actual"
+        }),
+        verification,
+        execution,
+        failure: {
+          message: verification.summary
+        }
+      };
+    }
+  };
+}

--- a/packages/adapters/tests/claude-cli.test.ts
+++ b/packages/adapters/tests/claude-cli.test.ts
@@ -1,12 +1,18 @@
 import { describe, expect, it } from "vitest";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import type { MartinAdapterRequest } from "@martin/core";
 
 import {
   createAgentCliAdapter,
   createClaudeCliAdapter,
-  createCodexCliAdapter
+  createCodexCliAdapter,
+  createVerifierOnlyAdapter
 } from "../src/index.js";
+import { splitCommand } from "../src/cli-bridge.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -220,6 +226,14 @@ describe("createAgentCliAdapter", () => {
     expect(result.verification.summary).toContain("No verification commands");
   });
 
+  it("preserves quoted verifier arguments and executable paths when tokenizing verification commands", () => {
+    expect(splitCommand(`"${process.execPath}" -e "process.exit(0)"`)).toEqual([
+      process.execPath,
+      "-e",
+      "process.exit(0)"
+    ]);
+  });
+
   it("returns estimated cost provenance when the CLI does not emit settled usage", async () => {
     const adapter = createAgentCliAdapter({
       command: process.execPath,
@@ -244,6 +258,67 @@ describe("createAgentCliAdapter", () => {
     expect(result.status).toBe("completed");
     expect(result.usage.provenance).toBe("estimated");
     expect(result.usage.estimatedUsd).toBeGreaterThan(0);
+  });
+});
+
+describe("splitCommand", () => {
+  it("preserves backslashes inside quoted Windows executable paths", () => {
+    const command =
+      '"C:\\Users\\Torram\\OneDrive\\Documents\\Codex Main\\node.exe" -e "process.exit(0)"';
+
+    expect(splitCommand(command)).toEqual([
+      "C:\\Users\\Torram\\OneDrive\\Documents\\Codex Main\\node.exe",
+      "-e",
+      "process.exit(0)",
+    ]);
+  });
+});
+
+describe("createVerifierOnlyAdapter", () => {
+  it("reports verifier-created file changes instead of treating verify-only as clean", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "martin-verify-only-"));
+
+    try {
+      spawnSync("git", ["init"], { cwd: directory, stdio: "ignore" });
+      await writeFile(join(directory, "tracked.txt"), "original", "utf8");
+      spawnSync("git", ["add", "tracked.txt"], { cwd: directory, stdio: "ignore" });
+      spawnSync(
+        "git",
+        [
+          "-c",
+          "user.email=martin@example.com",
+          "-c",
+          "user.name=Martin Test",
+          "commit",
+          "-m",
+          "seed"
+        ],
+        { cwd: directory, stdio: "ignore" }
+      );
+
+      const adapter = createVerifierOnlyAdapter({ workingDirectory: directory });
+      const result = await adapter.execute(
+        makeRequest({
+          context: {
+            taskTitle: "verify only",
+            objective: "Run verification only",
+            verificationPlan: [
+              `"${process.execPath}" -e "require('node:fs').writeFileSync('tracked.txt','changed')"`
+            ],
+            mutationMode: "verify_only",
+            focus: "verify only",
+            remainingBudgetUsd: 8,
+            remainingIterations: 1,
+            remainingTokens: 10_000
+          }
+        })
+      );
+
+      expect(result.verification.passed).toBe(true);
+      expect(result.execution?.changedFiles).toContain("tracked.txt");
+    } finally {
+      await rm(directory, { force: true, recursive: true });
+    }
   });
 });
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,9 +2,20 @@ import { appendFile, mkdir, readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { isAbsolute, join, resolve } from "node:path";
 
-import { createClaudeCliAdapter, createCodexCliAdapter, createStubDirectProviderAdapter } from "@martin/adapters";
+import {
+  createClaudeCliAdapter,
+  createCodexCliAdapter,
+  createStubDirectProviderAdapter,
+  createVerifierOnlyAdapter
+} from "@martin/adapters";
 import { runMartin, type MartinAdapter } from "@martin/core";
-import { buildPortfolioSnapshot, createLoopRecord, type LoopBudget, type LoopRecord } from "@martin/contracts";
+import {
+  buildPortfolioSnapshot,
+  createLoopRecord,
+  type LoopBudget,
+  type LoopRecord,
+  type MutationMode
+} from "@martin/contracts";
 
 export type RunCommandRequest = {
   workspaceId: string;
@@ -18,6 +29,7 @@ export type RunCommandRequest = {
   cwd?: string;
   model?: string;
   engine?: string;
+  mutationMode?: MutationMode;
   allowedPaths?: string[];
   deniedPaths?: string[];
   acceptanceCriteria?: string[];
@@ -96,7 +108,13 @@ export async function executeCli(args: string[]): Promise<{
       };
 
       const workingDirectory = parsed.request.cwd ?? readOption(args, "--cwd") ?? process.cwd();
-      const adapter = selectAdapter(args, workingDirectory, parsed.request.model, parsed.request.engine);
+      const adapter = selectAdapter(
+        args,
+        workingDirectory,
+        parsed.request.model,
+        parsed.request.engine,
+        parsed.request.mutationMode
+      );
 
       let result: Awaited<ReturnType<typeof runMartin>>;
       try {
@@ -107,6 +125,7 @@ export async function executeCli(args: string[]): Promise<{
             title: resolvedRequest.title,
             objective: resolvedRequest.objective,
             verificationPlan: resolvedRequest.verificationPlan,
+            ...(resolvedRequest.mutationMode ? { mutationMode: resolvedRequest.mutationMode } : {}),
             repoRoot: workingDirectory,
             ...(resolvedRequest.allowedPaths?.length ? { allowedPaths: resolvedRequest.allowedPaths } : {}),
             ...(resolvedRequest.deniedPaths?.length ? { deniedPaths: resolvedRequest.deniedPaths } : {}),
@@ -124,6 +143,7 @@ export async function executeCli(args: string[]): Promise<{
             title: resolvedRequest.title,
             objective: resolvedRequest.objective,
             verificationPlan: resolvedRequest.verificationPlan,
+            ...(resolvedRequest.mutationMode ? { mutationMode: resolvedRequest.mutationMode } : {}),
             repoRoot: workingDirectory
           },
           budget: resolvedRequest.budget,
@@ -380,6 +400,9 @@ export function parseCliArguments(args: string[]): ParsedCliArguments {
           request.cwd = next;
           index += 1;
           break;
+        case "--verify-only":
+          request.mutationMode = "verify_only";
+          break;
         case "--allow-path":
           if (next) {
             request.allowedPaths = [...(request.allowedPaths ?? []), next];
@@ -425,6 +448,7 @@ export function parseCliArguments(args: string[]): ParsedCliArguments {
         ...(request.cwd ? { cwd: request.cwd } : {}),
         ...(request.model ? { model: request.model } : {}),
         ...(request.engine ? { engine: request.engine } : {}),
+        ...(request.mutationMode ? { mutationMode: request.mutationMode } : {}),
         ...(request.allowedPaths?.length ? { allowedPaths: request.allowedPaths } : {}),
         ...(request.deniedPaths?.length ? { deniedPaths: request.deniedPaths } : {}),
         ...(request.acceptanceCriteria?.length ? { acceptanceCriteria: request.acceptanceCriteria } : {})
@@ -485,6 +509,7 @@ export function renderCliHelp(): string {
     "  --max-iterations <n>    Set the maximum number of attempts.",
     "  --max-tokens <n>        Set the maximum total token budget.",
     "  --verify <cmd>          Shell command to run as the verifier after each attempt.",
+    "  --verify-only           Skip the coding adapter and run the verifier only.",
     "  --allow-path <glob>     Restrict agent writes to this path pattern (repeatable).",
     "  --deny-path <glob>      Block agent from this path pattern (repeatable).",
     "  --accept <criterion>    Add an acceptance criterion to the prompt (repeatable).",
@@ -759,8 +784,13 @@ function selectAdapter(
   rawArgs: string[],
   workingDirectory: string,
   modelOverride?: string,
-  engineOverride?: string
+  engineOverride?: string,
+  mutationMode?: MutationMode
 ): MartinAdapter {
+  if (mutationMode === "verify_only") {
+    return createVerifierOnlyAdapter({ workingDirectory });
+  }
+
   if (process.env.MARTIN_LIVE === "false") {
     return createStubDirectProviderAdapter({
       label: "Stub adapter (MARTIN_LIVE=false)",

--- a/packages/cli/tests/cli.test.ts
+++ b/packages/cli/tests/cli.test.ts
@@ -190,6 +190,36 @@ describe("executeCli", () => {
     expect(payload.loop.task.verificationPlan).toEqual(["pnpm test"]);
   });
 
+  it("supports verify-only runs without invoking a coding adapter", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "martin-cli-verify-only-"));
+
+    try {
+      const result = await executeCli([
+        "run",
+        "--objective",
+        "Verify the contracts package without edits",
+        "--verify-only",
+        "--verify",
+        `"${process.execPath}" -e "process.exit(0)"`,
+        "--cwd",
+        directory,
+        "--allow-path",
+        "packages/contracts/**"
+      ]);
+
+      expect(result.exitCode).toBe(0);
+
+      const payload = JSON.parse(result.stdout);
+
+      expect(payload.decision.lifecycleState).toBe("completed");
+      expect(payload.loop.lifecycleState).toBe("completed");
+      expect(payload.loop.task.mutationMode).toBe("verify_only");
+      expect(payload.loop.cost.actualUsd).toBe(0);
+    } finally {
+      await rm(directory, { force: true, recursive: true });
+    }
+  });
+
   it("resolves a relative --config path from INIT_CWD for filtered dev runs", async () => {
     const directory = await mkdtemp(join(tmpdir(), "martin-cli-init-cwd-"));
     const packageDirectory = join(directory, "packages", "cli");

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -54,6 +54,7 @@ export interface LoopTask {
   repoRoot?: string;
   verificationPlan: string[];
   verificationStack?: VerificationStep[];
+  mutationMode?: MutationMode;
   executionProfile?: ExecutionProfile;
   allowedNetworkDomains?: string[];
   approvalPolicy?: ApprovalPolicy;
@@ -70,6 +71,8 @@ export type ExecutionProfile =
   | "ci_safe"
   | "staging_controlled"
   | "research_untrusted";
+
+export type MutationMode = "edit" | "verify_only";
 
 export interface ApprovalPolicy {
   dependencyAdds?: boolean;

--- a/packages/core/src/compiler.ts
+++ b/packages/core/src/compiler.ts
@@ -16,6 +16,7 @@ export interface CompilerAdapterRequest {
     objective: string;
     verificationPlan: string[];
     verificationStack?: LoopTask["verificationStack"];
+    mutationMode?: LoopTask["mutationMode"];
     repoRoot?: string;
     allowedPaths?: string[];
     deniedPaths?: string[];
@@ -36,6 +37,7 @@ export interface PromptPacket {
   contract: {
     objective: string;
     verificationPlan: string[];
+    mutationMode?: LoopTask["mutationMode"];
     allowedPaths?: string[];
     deniedPaths?: string[];
     acceptanceCriteria?: string[];
@@ -60,10 +62,16 @@ export function compilePromptPacket(request: CompilerAdapterRequest): PromptPack
     .filter((a) => a.failureClass && a.intervention)
     .map((a) => `${a.failureClass}:${a.intervention}`);
 
-  const guidanceParts: string[] = [
-    "Only modify files directly required to satisfy the contract.",
-    "Do not touch files outside the allowed paths."
-  ];
+  const guidanceParts: string[] =
+    request.context.mutationMode === "verify_only"
+      ? [
+          "Do not modify files.",
+          "Run the verifier only and report whether it passed."
+        ]
+      : [
+          "Only modify files directly required to satisfy the contract.",
+          "Do not touch files outside the allowed paths."
+        ];
 
   if (request.context.allowedPaths && request.context.allowedPaths.length > 0) {
     guidanceParts.push(
@@ -89,6 +97,7 @@ export function compilePromptPacket(request: CompilerAdapterRequest): PromptPack
     contract: {
       objective: redactSecretsFromText(request.context.objective),
       verificationPlan: request.context.verificationPlan,
+      ...(request.context.mutationMode ? { mutationMode: request.context.mutationMode } : {}),
       ...(request.context.allowedPaths ? { allowedPaths: request.context.allowedPaths } : {}),
       ...(request.context.deniedPaths ? { deniedPaths: request.context.deniedPaths } : {}),
       ...(request.context.acceptanceCriteria

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,6 +11,7 @@ import {
   type LoopArtifact,
   type LoopAttempt,
   type LoopBudget,
+  type MutationMode,
   type LoopRecord,
   type LoopTask,
   type PatchDecisionArtifact,
@@ -83,6 +84,7 @@ export type {
   PatchDecisionArtifact,
   PatchDecisionReasonCode,
   PatchScore,
+  MutationMode,
   RollbackBoundaryArtifact,
   RollbackBoundaryStrategy,
   RollbackFileSnapshot,
@@ -169,6 +171,7 @@ export interface MartinAdapterRequest {
     objective: string;
     verificationPlan: string[];
     verificationStack?: LoopTask["verificationStack"];
+    mutationMode?: MutationMode;
     /** Absolute path to the repository root. */
     repoRoot?: string;
     /** Glob patterns for files the agent may modify. Empty = no restriction. */
@@ -446,6 +449,7 @@ export async function runMartin(input: RunMartinInput): Promise<RunMartinResult>
   let currentAdapterIndex = 0;
   let currentAdapter = adapterChain[currentAdapterIndex] ?? input.adapter;
   let useCompressedContext = false;
+  const isVerifyOnly = input.task.mutationMode === "verify_only";
   const executionProfile = resolveExecutionProfile({
     executionProfile: input.task.executionProfile,
     allowedNetworkDomains: input.task.allowedNetworkDomains
@@ -759,6 +763,7 @@ export async function runMartin(input: RunMartinInput): Promise<RunMartinResult>
         objective: loop.task.objective,
         verificationPlan: loop.task.verificationPlan,
         ...(loop.task.verificationStack ? { verificationStack: loop.task.verificationStack } : {}),
+        ...(loop.task.mutationMode ? { mutationMode: loop.task.mutationMode } : {}),
         ...(loop.task.repoRoot ? { repoRoot: loop.task.repoRoot } : {}),
         ...(loop.task.allowedPaths ? { allowedPaths: loop.task.allowedPaths } : {}),
         ...(loop.task.deniedPaths ? { deniedPaths: loop.task.deniedPaths } : {}),
@@ -990,6 +995,107 @@ export async function runMartin(input: RunMartinInput): Promise<RunMartinResult>
     // a git repo) and silently return [], which would falsely trigger no_code_change.
     const changedFileEvidenceAvailable =
       result.execution?.changedFiles !== undefined || changedFiles.length > 0;
+
+    if (isVerifyOnly && changedFiles.length > 0) {
+      const patchDecision = evaluatePatchDecision({
+        verificationPassed: result.verification.passed,
+        previousVerifierScore,
+        verifierScore: result.verification.passed ? 1 : 0,
+        scopeViolationCount: changedFiles.length,
+        changedFileCount: changedFiles.length,
+        diffNovelty: 1,
+        diffStats: result.execution?.diffStats,
+        costUsd: getUsageUsd(result.usage),
+        summary: result.summary
+      });
+      const verifyOnlyExitDecision: ExitDecision = {
+        shouldExit: true,
+        lifecycleState: "human_escalation",
+        status: "exited",
+        reason: "Verify-only mode forbids file changes."
+      };
+      const rollbackOutcome = await restoreRollbackBoundary({
+        repoRoot: request.context.repoRoot,
+        boundary: rollbackBoundary,
+        restoredAt: attemptCompletedAt,
+        decision: patchDecision.decision
+      });
+
+      if (input.store) {
+        const verifyOnlyViolation: SafetyViolation = {
+          kind: "path_not_allowed",
+          message: `Verify-only mode forbids changed files: ${changedFiles.join(", ")}`,
+          file: changedFiles[0]
+        };
+        await input.store.writeAttemptArtifacts(loop.loopId, currentAttemptIndex, {
+          compiledContext,
+          leash: createLeashArtifact(
+            {
+              surface: "filesystem",
+              reason: verifyOnlyExitDecision.reason,
+              violations: [verifyOnlyViolation]
+            },
+            currentAttemptIndex
+          ),
+          patchScore: patchDecision.score,
+          patchDecision: toPatchDecisionArtifact(patchDecision),
+          ...(rollbackBoundary ? { rollbackBoundary } : {}),
+          ...(rollbackOutcome ? { rollbackOutcome } : {})
+        });
+        await input.store.appendLedger(
+          loop.loopId,
+          makeLedgerEvent({
+            kind: "safety.violations_found",
+            runId: loop.loopId,
+            attemptIndex: currentAttemptIndex,
+            payload: {
+              surface: "filesystem",
+              blocked: true,
+              attemptIndex: currentAttemptIndex,
+              violations: [
+                {
+                  kind: "path_not_allowed",
+                  message: verifyOnlyExitDecision.reason,
+                  files: changedFiles
+                }
+              ]
+            }
+          })
+        );
+        await input.store.appendLedger(
+          loop.loopId,
+          makeLedgerEvent({
+            kind: "attempt.discarded",
+            runId: loop.loopId,
+            attemptIndex: currentAttemptIndex,
+            payload: {
+              decision: patchDecision.decision,
+              reason: patchDecision.summary,
+              reasonCodes: patchDecision.reasonCodes,
+              score: patchDecision.score.score
+            }
+          })
+        );
+        await input.store.appendLedger(
+          loop.loopId,
+          makeLedgerEvent({
+            kind: "run.exited",
+            runId: loop.loopId,
+            payload: {
+              lifecycleState: verifyOnlyExitDecision.lifecycleState,
+              status: verifyOnlyExitDecision.status,
+              reason: verifyOnlyExitDecision.reason
+            }
+          })
+        );
+      }
+
+      return {
+        loop: finalizeLoop(loop, verifyOnlyExitDecision, now(), idFactory),
+        decision: verifyOnlyExitDecision
+      };
+    }
+
     const filesystemDecision = evaluateFilesystemLeash({
       repoRoot: request.context.repoRoot,
       changedFiles,
@@ -1210,8 +1316,10 @@ export async function runMartin(input: RunMartinInput): Promise<RunMartinResult>
         previousVerifierScore,
         verifierScore: result.verification.passed ? 1 : 0,
         groundingViolationCount: groundingScanResult?.violations.length ?? 0,
-        changedFileCount: changedFileEvidenceAvailable ? changedFiles.length : undefined,
-        diffNovelty: changedFileEvidenceAvailable ? (changedFiles.length > 0 ? 1 : 0) : undefined,
+        changedFileCount:
+          !isVerifyOnly && changedFileEvidenceAvailable ? changedFiles.length : undefined,
+        diffNovelty:
+          !isVerifyOnly && changedFileEvidenceAvailable ? (changedFiles.length > 0 ? 1 : 0) : undefined,
         diffStats: result.execution?.diffStats,
         costUsd: getUsageUsd(result.usage),
         summary: result.summary
@@ -1471,7 +1579,7 @@ function getUsageProvenance(usage: MartinAdapterResult["usage"]): CostProvenance
 }
 
 function resolveChangedFiles(result: MartinAdapterResult, repoRoot?: string): string[] {
-  if (result.execution?.changedFiles?.length) {
+  if (result.execution?.changedFiles !== undefined) {
     return result.execution.changedFiles;
   }
 

--- a/packages/core/tests/runtime.test.ts
+++ b/packages/core/tests/runtime.test.ts
@@ -409,6 +409,68 @@ describe("runMartin", () => {
     expect(result.decision.lifecycleState).toBe("completed");
   });
 
+  it("allows verifier-only runs to complete without code changes when verification passes", async () => {
+    const adapter: MartinAdapter = {
+      adapterId: "direct:verify-only",
+      kind: "direct-provider",
+      label: "Verify only adapter",
+      metadata: {
+        providerId: "openai",
+        model: "gpt-5-mini"
+      },
+      async execute() {
+        return {
+          status: "completed",
+          summary: "Ran the verifier without making edits.",
+          usage: {
+            actualUsd: 0,
+            tokensIn: 0,
+            tokensOut: 0
+          },
+          verification: {
+            passed: true,
+            summary: "Verification passed without changes."
+          },
+          execution: {
+            changedFiles: []
+          }
+        };
+      }
+    };
+
+    const result = await runMartin({
+      workspaceId: "ws_ops",
+      projectId: "proj_runtime",
+      task: {
+        title: "Verify the contracts package",
+        objective: "Run the verifier only and do not edit files.",
+        verificationPlan: ["pnpm --filter @martin/contracts test"],
+        mutationMode: "verify_only",
+        allowedPaths: ["packages/contracts/**"]
+      },
+      budget: {
+        maxUsd: 10,
+        softLimitUsd: 6,
+        maxIterations: 1,
+        maxTokens: 2_000
+      },
+      adapter,
+      now: createTimestampSource([
+        "2026-05-11T12:00:00.000Z",
+        "2026-05-11T12:00:01.000Z",
+        "2026-05-11T12:00:02.000Z",
+        "2026-05-11T12:00:03.000Z",
+        "2026-05-11T12:00:04.000Z"
+      ]),
+      idFactory: createIdFactory()
+    });
+
+    expect(result.decision.lifecycleState).toBe("completed");
+    expect(result.loop.lifecycleState).toBe("completed");
+    expect(result.loop.attempts).toHaveLength(1);
+    expect(result.loop.attempts[0]?.failureClass).toBeUndefined();
+  });
+
   it("exits on budget pressure after repeated failed attempts", async () => {
     const timestamps = createTimestampSource([
       "2026-03-27T16:10:00.000Z",

--- a/packages/mcp/scripts/build-package-lib.mjs
+++ b/packages/mcp/scripts/build-package-lib.mjs
@@ -68,10 +68,14 @@ async function ensureWorkspaceArtifacts(rootDir) {
 
     await runCommand(
       pnpmCommand(),
-      ["--dir", rootDir, "--filter", facade.packageName, "build"],
+      workspaceBuildCommandArgs(facade.packageName),
       { cwd: rootDir },
     );
   }
+}
+
+export function workspaceBuildCommandArgs(packageName) {
+  return ["--filter", packageName, "build"];
 }
 
 async function copyFacadeDirectory(input) {
@@ -239,8 +243,8 @@ async function runCommand(command, args, options) {
   });
 }
 
-function createCommandLaunch(command, args) {
-  if (process.platform !== "win32") {
+export function createCommandLaunch(command, args, platform = process.platform) {
+  if (platform !== "win32") {
     return { command, args };
   }
 

--- a/packages/mcp/tests/build-package.test.ts
+++ b/packages/mcp/tests/build-package.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { rewritePackageSpecifiers } from "../scripts/build-package-lib.mjs";
+import { rewritePackageSpecifiers, workspaceBuildCommandArgs } from "../scripts/build-package-lib.mjs";
 
 describe("rewritePackageSpecifiers", () => {
   it("rewrites nested internal package subpaths without truncating them", () => {
@@ -26,5 +26,15 @@ describe("rewritePackageSpecifiers", () => {
 
     expect(rewritten).toContain('./vendor/adapters/runtime-support.js');
     expect(rewritten).not.toContain("runtime-support.js.js");
+  });
+});
+
+describe("workspaceBuildCommandArgs", () => {
+  it("avoids --dir so Windows paths with spaces are not reparsed by pnpm", () => {
+    expect(workspaceBuildCommandArgs("@martin/contracts")).toEqual([
+      "--filter",
+      "@martin/contracts",
+      "build",
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- Adds first-class `verify_only` mutation mode so `martin run --verify-only` can run verifier gates without invoking Claude/Codex coding adapters.
- Enforces the no-edit contract by surfacing verifier-created file changes and escalating with rollback artifacts instead of scoring clean verification as `no_code_change`.
- Replaces whitespace-only verifier command splitting with quote-aware parsing so quoted executable paths and arguments work on Windows paths with spaces.
- Fixes standalone MCP package builds from Windows workspaces whose repo path contains spaces by avoiding `pnpm --dir` reparsing in nested workspace builds.

## Red-team repros covered
- Real user attempted to use MartinLoop as a governed verifier around a repo and hit misleading safety/human escalation behavior instead of a true verifier-only path.
- `pnpm build` failed in `@martinloop/mcp` from `C:\Users\Torram\OneDrive\Documents\Codex Main\MartinLoop RedTeam\Martin-Loop` with `ENOENT ... lstat ... \"C:` before the MCP build fix.
- `pnpm --filter @martin/cli test` previously timed out on the verify-only test because quoted Windows executable paths were split incorrectly.

## Verification
- PASS: `pnpm --filter @martin/contracts test`
- PASS: `pnpm --filter @martin/contracts lint`
- PASS: `pnpm --filter @martin/core test`
- PASS: `pnpm --filter @martin/core lint`
- PASS: `pnpm --filter @martin/adapters test`
- PASS: `pnpm --filter @martin/adapters lint`
- PASS: `pnpm --filter @martin/cli test`
- PASS: `pnpm --filter @martin/cli lint`
- PASS: `pnpm --filter @martinloop/mcp test`
- PASS: `pnpm --filter @martinloop/mcp lint`
- PASS: `pnpm --filter @martinloop/mcp build`
- PASS: `pnpm lint`
- PASS: `pnpm build`
- KNOWN FAIL, unrelated: `pnpm test` still fails on `apps/control-plane/tests/control-plane-routes.test.ts > telemetry route > accepts a valid telemetry ingest payload and returns a normalized receipt` timing out at 5000ms. I reproduced that targeted failure separately and will file it as an issue.

## Follow-ups
- Add a distinct structured taxonomy/failure class for pre-attempt safety-leash exits instead of relying on `human_escalation` plus a freeform reason.
- Investigate/fix the control-plane telemetry route timeout.