### PR TITLE
Fix Codex subprocess launch before verifier

### DIFF
--- a/apps/control-plane/app/api/telemetry/route.ts
+++ b/apps/control-plane/app/api/telemetry/route.ts
@@ -1,6 +1,6 @@
 import { createTelemetryEnvelope } from "../../../lib/domain/models";
 import { getControlPlaneRepository } from "../../../lib/server/control-plane-repository";
-import { ingestRunsIntoControlPlane } from "../../../lib/server/ingest-run-read-model";
+import { ingestTelemetryEnvelope } from "../../../lib/server/telemetry-ingest";
 import { requireControlPlaneAuth } from "../../../lib/server/auth";
 import { jsonError, jsonResponse } from "../../../lib/server/http";
 import {
@@ -58,7 +58,7 @@ export async function POST(request: Request): Promise<Response> {
     });
   }
 
-  const ingested = await ingestRunsIntoControlPlane(repository);
+  const ingested = await ingestTelemetryEnvelope(repository, envelope);
 
   return jsonResponse(
     {

--- a/apps/control-plane/lib/server/control-plane-read-model.ts
+++ b/apps/control-plane/lib/server/control-plane-read-model.ts
@@ -491,6 +491,8 @@ function buildExceptions(dataset: DashboardDataset, runs: RunPortfolioItem[]): E
         { label: "Actual", value: "human_escalation" },
         { label: "Source", value: "runs table" },
         { label: "Stop reason", value: run.stopReason ?? run.lifecycleState },
+        { label: "Failure class", value: run.failureClass ?? "Unclassified" },
+        { label: "Reason code", value: run.reasonCode ?? "Uncoded" },
         { label: "Patch decision", value: run.latestPatchDecision ?? "Unrecorded" }
       ]
     });
@@ -524,7 +526,8 @@ function buildFocusAreas(runs: RunPortfolioItem[]): OperationsViewModel["focusAr
       { label: "Stop reason", value: run.stopReason ?? run.lifecycleState },
       { label: "Patch decision", value: run.latestPatchDecision ?? "Unrecorded" },
       { label: "Grounding evidence", value: `${String(run.groundingViolationCount)} flagged` },
-      { label: "Leash surface", value: run.lastSafetySurface ?? "none" },
+      { label: "Leash surface", value: run.safetySurface ?? run.lastSafetySurface ?? "none" },
+      { label: "Reason code", value: run.reasonCode ?? "none" },
       { label: "Budget variance", value: formatSignedUsd(run.budgetVarianceUsd) },
       { label: "Accounting mode", value: run.accountingMode }
     ]
@@ -559,6 +562,9 @@ function buildApprovalQueue(runs: RunPortfolioItem[]): GovernanceViewModel["appr
       { label: "Actual", value: run.lifecycleState },
       { label: "Source", value: "run.exited ledger event" },
       { label: "Stop reason", value: run.stopReason ?? run.lifecycleState },
+      { label: "Failure class", value: run.failureClass ?? "Unclassified" },
+      { label: "Leash surface", value: run.safetySurface ?? run.lastSafetySurface ?? "none" },
+      { label: "Reason code", value: run.reasonCode ?? "Uncoded" },
       { label: "Patch decision", value: run.latestPatchDecision ?? "Unrecorded" },
       { label: "Grounding evidence", value: `${String(run.groundingViolationCount)} flagged` }
     ]

--- a/apps/control-plane/lib/server/control-plane-repository.ts
+++ b/apps/control-plane/lib/server/control-plane-repository.ts
@@ -44,6 +44,9 @@ export interface RunRow {
   status: string;
   lifecycleState: string;
   stopReason: string | null;
+  failureClass?: string | null;
+  safetySurface?: string | null;
+  reasonCode?: string | null;
   activeModel: string | null;
   adapterId: string | null;
   providerId: string | null;

--- a/apps/control-plane/lib/server/ingest-run-read-model.ts
+++ b/apps/control-plane/lib/server/ingest-run-read-model.ts
@@ -123,6 +123,9 @@ export function buildRunGraph(
   let lifecycleState = "running";
   let status = "running";
   let stopReason: string | null = null;
+  let failureClass: string | null = null;
+  let safetySurface: string | null = null;
+  let reasonCode: string | null = null;
   let lastTimestamp = contract.createdAt;
 
   for (const event of ledger) {
@@ -342,6 +345,9 @@ export function buildRunGraph(
         lifecycleState = readString(event.payload.lifecycleState) ?? lifecycleState;
         status = readString(event.payload.status) ?? status;
         stopReason = readString(event.payload.reason) ?? stopReason;
+        failureClass = readString(event.payload.failureClass) ?? failureClass;
+        safetySurface = readString(event.payload.safetySurface) ?? safetySurface;
+        reasonCode = readString(event.payload.reasonCode) ?? reasonCode;
         break;
     }
   }
@@ -436,6 +442,9 @@ export function buildRunGraph(
     status,
     lifecycleState,
     stopReason,
+    failureClass,
+    safetySurface,
+    reasonCode,
     activeModel,
     adapterId,
     providerId,

--- a/apps/control-plane/lib/server/telemetry-ingest.ts
+++ b/apps/control-plane/lib/server/telemetry-ingest.ts
@@ -1,0 +1,132 @@
+import type { TelemetryEnvelope, TelemetryLoop } from "../domain/models";
+import type { ControlPlaneRepository, RunGraph, RunRow } from "./control-plane-repository";
+
+export async function ingestTelemetryEnvelope(
+  repository: ControlPlaneRepository,
+  envelope: TelemetryEnvelope
+): Promise<{ runCount: number }> {
+  for (const loop of envelope.loops) {
+    await repository.replaceRunGraph(buildTelemetryRunGraph(envelope, loop));
+  }
+
+  return { runCount: envelope.loops.length };
+}
+
+function buildTelemetryRunGraph(
+  envelope: TelemetryEnvelope,
+  loop: TelemetryLoop
+): RunGraph {
+  const lifecycle = lifecycleFromHealth(loop.status);
+  const run: RunRow = {
+    runId: loop.loopId,
+    workspaceId: envelope.workspaceId,
+    projectId: loop.project,
+    title: loop.name,
+    objective: `External telemetry snapshot from ${envelope.source}.`,
+    repoRoot: null,
+    status: lifecycle.status,
+    lifecycleState: lifecycle.lifecycleState,
+    stopReason: lifecycle.stopReason,
+    activeModel: null,
+    adapterId: `telemetry:${envelope.source}`,
+    providerId: envelope.source,
+    transport: "telemetry",
+    actualUsd: roundUsd(loop.actualCostUsd),
+    estimatedUsd: 0,
+    costProvenance: "actual",
+    modeledAvoidedUsd: roundUsd(loop.avoidedCostUsd),
+    tokensIn: loop.tokensProcessed,
+    tokensOut: 0,
+    attemptsCount: 0,
+    keptAttempts: 0,
+    discardedAttempts: 0,
+    latestPatchDecision: null,
+    latestPatchSummary: null,
+    latestPatchReasonCodes: [],
+    latestPatchScore: null,
+    groundingViolationCount: 0,
+    groundingContentOnlyCount: 0,
+    blockedSafetyViolationCount: 0,
+    lastSafetySurface: null,
+    budgetVarianceUsd: 0,
+    accountingMode: "actual",
+    createdAt: loop.lastSeenAt,
+    updatedAt: envelope.submittedAt
+  };
+
+  return {
+    run,
+    attempts: [],
+    events: [
+      {
+        eventId: `${loop.loopId}:telemetry.ingested:${envelope.submittedAt}`,
+        runId: loop.loopId,
+        attemptIndex: null,
+        kind: "telemetry.ingested",
+        lifecycleState: lifecycle.lifecycleState,
+        timestamp: envelope.submittedAt,
+        payload: {
+          source: envelope.source,
+          health: loop.status,
+          ownerTeam: loop.ownerTeam,
+          agentCount: loop.agentCount,
+          savingsRatio: loop.savingsRatio
+        }
+      }
+    ],
+    violations: [],
+    budgetMetrics: [
+      {
+        metricId: `${loop.loopId}:telemetry:spend`,
+        runId: loop.loopId,
+        attemptIndex: 0,
+        actualUsd: roundUsd(loop.actualCostUsd),
+        estimatedUsd: 0,
+        provenance: "actual",
+        patchCostUsd: roundUsd(loop.actualCostUsd),
+        verificationCostUsd: 0,
+        varianceUsd: 0,
+        tokensIn: loop.tokensProcessed,
+        tokensOut: 0,
+        createdAt: envelope.submittedAt
+      }
+    ]
+  };
+}
+
+function lifecycleFromHealth(status: TelemetryLoop["status"]): {
+  status: RunRow["status"];
+  lifecycleState: RunRow["lifecycleState"];
+  stopReason: string | null;
+} {
+  switch (status) {
+    case "healthy":
+      return {
+        status: "completed",
+        lifecycleState: "completed",
+        stopReason: "Telemetry reports healthy."
+      };
+    case "watch":
+      return {
+        status: "running",
+        lifecycleState: "running",
+        stopReason: "Telemetry reports watch status."
+      };
+    case "alert":
+      return {
+        status: "exited",
+        lifecycleState: "human_escalation",
+        stopReason: "Telemetry reports alert status."
+      };
+    case "critical":
+      return {
+        status: "exited",
+        lifecycleState: "human_escalation",
+        stopReason: "Telemetry reports critical status."
+      };
+  }
+}
+
+function roundUsd(value: number): number {
+  return Math.round(value * 100) / 100;
+}

--- a/apps/control-plane/tests/control-plane-routes.test.ts
+++ b/apps/control-plane/tests/control-plane-routes.test.ts
@@ -76,7 +76,7 @@ describe("executive route rendering", () => {
 
 describe("telemetry route", () => {
   it("accepts a valid telemetry ingest payload and returns a normalized receipt", async () => {
-    await installSeedRepository();
+    const repository = await installSeedRepository();
     installAuthSession({ role: "workspace", workspaceId: "ws_martin" });
 
     const response = await postTelemetry(
@@ -116,7 +116,18 @@ describe("telemetry route", () => {
     expect(payload.accepted).toBe(true);
     expect(payload.summary.loops).toBe(1);
     expect(payload.summary.totalActualUsd).toBe(22);
-    expect(payload.summary.runsIngested).toBeGreaterThanOrEqual(0);
+    expect(payload.summary.runsIngested).toBe(1);
+
+    const runs = await repository.listRuns("ws_martin");
+    const ingestedRun = runs.find((run) => run.runId === "loop_ingest");
+    expect(ingestedRun).toMatchObject({
+      title: "Treasury variance monitor",
+      projectId: "treasury",
+      providerId: "sdk",
+      actualUsd: 22,
+      modeledAvoidedUsd: 49,
+      lifecycleState: "completed"
+    });
   });
 });
 

--- a/apps/control-plane/tests/ingest-run-read-model.test.ts
+++ b/apps/control-plane/tests/ingest-run-read-model.test.ts
@@ -131,7 +131,10 @@ describe("readRunGraph", () => {
         payload: {
           lifecycleState: "human_escalation",
           status: "exited",
-          reason: "Grounding evidence contradicted the claimed repair."
+          reason: "Grounding evidence contradicted the claimed repair.",
+          failureClass: "safety_leash_blocked",
+          safetySurface: "verifier",
+          reasonCode: "destructive_verifier_command"
         }
       }
     ]);
@@ -183,6 +186,9 @@ describe("readRunGraph", () => {
 
     expect(graph.run.lifecycleState).toBe("human_escalation");
     expect(graph.run.stopReason).toBe("Grounding evidence contradicted the claimed repair.");
+    expect(graph.run.failureClass).toBe("safety_leash_blocked");
+    expect(graph.run.safetySurface).toBe("verifier");
+    expect(graph.run.reasonCode).toBe("destructive_verifier_command");
     expect(graph.run.costProvenance).toBe("estimated");
     expect(graph.run.latestPatchDecision).toBe("DISCARD");
     expect(graph.run.groundingViolationCount).toBe(1);

--- a/docs/oss/OSS-BOUNDARY-REPORT.json
+++ b/docs/oss/OSS-BOUNDARY-REPORT.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-11T21:27:27.422Z",
+  "generatedAt": "2026-05-11T21:47:36.834Z",
   "verdict": "go",
   "publicSurface": {
     "packageName": "martin-loop",

--- a/docs/oss/OSS-BOUNDARY-REPORT.json
+++ b/docs/oss/OSS-BOUNDARY-REPORT.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-07T21:23:30.889Z",
+  "generatedAt": "2026-05-11T21:27:27.422Z",
   "verdict": "go",
   "publicSurface": {
     "packageName": "martin-loop",
@@ -56,7 +56,7 @@
       "classificationReason": "Intended Phase 13 OSS core surface."
     },
     {
-      "name": "@martin/mcp",
+      "name": "@martinloop/mcp",
       "path": "packages/mcp",
       "private": false,
       "publishAccess": "public",

--- a/docs/oss/OSS-BOUNDARY-REPORT.md
+++ b/docs/oss/OSS-BOUNDARY-REPORT.md
@@ -1,6 +1,6 @@
 # Martin Loop Phase 13 OSS Core Boundary
 
-Generated: 2026-05-07T21:23:30.889Z
+Generated: 2026-05-11T21:27:27.422Z
 
 ## Verdict
 **GO**
@@ -30,7 +30,7 @@ Generated: 2026-05-07T21:23:30.889Z
 | @martin/core | packages/core | yes | n/a | @martin/contracts |
 | @martin/adapters | packages/adapters | yes | n/a | @martin/core |
 | @martin/cli | packages/cli | no | public | @martin/adapters, @martin/contracts, @martin/core |
-| @martin/mcp | packages/mcp | no | public | none |
+| @martinloop/mcp | packages/mcp | no | public | none |
 
 ## Non-OSS Workspace Packages
 | Package | Path | Reason |

--- a/docs/oss/OSS-BOUNDARY-REPORT.md
+++ b/docs/oss/OSS-BOUNDARY-REPORT.md
@@ -1,6 +1,6 @@
 # Martin Loop Phase 13 OSS Core Boundary
 
-Generated: 2026-05-11T21:27:27.422Z
+Generated: 2026-05-11T21:47:36.834Z
 
 ## Verdict
 **GO**

--- a/docs/oss/RELEASE-SURFACE-REPORT.json
+++ b/docs/oss/RELEASE-SURFACE-REPORT.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-11T21:27:28.254Z",
+  "generatedAt": "2026-05-11T21:47:37.407Z",
   "publicSurface": {
     "packageName": "martin-loop",
     "installCommand": "npm install martin-loop",

--- a/docs/oss/RELEASE-SURFACE-REPORT.json
+++ b/docs/oss/RELEASE-SURFACE-REPORT.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-23T14:55:08.167Z",
+  "generatedAt": "2026-05-11T21:27:28.254Z",
   "publicSurface": {
     "packageName": "martin-loop",
     "installCommand": "npm install martin-loop",

--- a/docs/oss/RELEASE-SURFACE-REPORT.md
+++ b/docs/oss/RELEASE-SURFACE-REPORT.md
@@ -1,6 +1,6 @@
 # Martin Loop Phase 13 Release Surface Audit
 
-Generated: 2026-04-23T14:55:08.167Z
+Generated: 2026-05-11T21:27:28.254Z
 
 ## Verdict
 **GO**

--- a/docs/oss/RELEASE-SURFACE-REPORT.md
+++ b/docs/oss/RELEASE-SURFACE-REPORT.md
@@ -1,6 +1,6 @@
 # Martin Loop Phase 13 Release Surface Audit
 
-Generated: 2026-05-11T21:27:28.254Z
+Generated: 2026-05-11T21:47:37.407Z
 
 ## Verdict
 **GO**

--- a/docs/pilot/PILOT-PREP-REPORT.json
+++ b/docs/pilot/PILOT-PREP-REPORT.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-11T21:27:29.218Z",
+  "generatedAt": "2026-05-11T21:47:37.985Z",
   "defaults": {
     "trustProfile": "strict_local",
     "primaryAdapter": "claude_cli",

--- a/docs/pilot/PILOT-PREP-REPORT.json
+++ b/docs/pilot/PILOT-PREP-REPORT.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-21T09:43:04.353Z",
+  "generatedAt": "2026-05-11T21:27:29.218Z",
   "defaults": {
     "trustProfile": "strict_local",
     "primaryAdapter": "claude_cli",

--- a/docs/pilot/PILOT-PREP-REPORT.md
+++ b/docs/pilot/PILOT-PREP-REPORT.md
@@ -1,6 +1,6 @@
 # Martin Loop Phase 13 Pilot Prep Audit
 
-Generated: 2026-04-21T09:43:04.353Z
+Generated: 2026-05-11T21:27:29.218Z
 
 ## Verdict
 **GO**

--- a/docs/pilot/PILOT-PREP-REPORT.md
+++ b/docs/pilot/PILOT-PREP-REPORT.md
@@ -1,6 +1,6 @@
 # Martin Loop Phase 13 Pilot Prep Audit
 
-Generated: 2026-05-11T21:27:29.218Z
+Generated: 2026-05-11T21:47:37.985Z
 
 ## Verdict
 **GO**

--- a/packages/adapters/src/claude-cli.ts
+++ b/packages/adapters/src/claude-cli.ts
@@ -203,8 +203,16 @@ export interface CodexCliAdapterOptions {
   label?: string;
   /** Override the model passed via --model flag. */
   model?: string;
-  /** Run in full-auto mode (--full-auto). Defaults to true. */
+  /**
+   * Deprecated no-op retained for compatibility.
+   *
+   * Codex CLI's supported non-interactive entrypoint is `codex exec`.
+   * MartinLoop now uses explicit sandboxing instead of the legacy
+   * `--full-auto` compatibility path, which can exit before verifier execution.
+   */
   fullAuto?: boolean;
+  /** Codex sandbox mode for model-generated commands. Defaults to workspace-write. */
+  sandbox?: "read-only" | "workspace-write" | "danger-full-access";
   /** Extra args appended after core args (before prompt). */
   extraArgs?: string[];
   spawnImpl?: SpawnLike;
@@ -295,18 +303,19 @@ export function createAgentCliAdapter(options: AgentCliAdapterOptions): MartinAd
       }
 
       if (agentResult.exitCode !== 0 && agentResult.stdout.trim().length === 0) {
+        const failureMessage = formatPreVerifierSubprocessFailure(options.command, agentResult.stderr, agentResult.exitCode);
         return {
           status: "failed",
-          summary: `${options.command} subprocess exited with an error.`,
+          summary: `${options.command} subprocess exited before verifier execution.`,
           usage: normalizeUsage({
             actualUsd: 0,
             tokensIn: 0,
             tokensOut: 0,
             provenance: "unavailable"
           }),
-          verification: { passed: false, summary: "Subprocess error." },
+          verification: { passed: false, summary: `Verifier not run: ${failureMessage}` },
           failure: {
-            message: `${agentResult.stderr.trim() || `Exit code ${String(agentResult.exitCode)}`}. environment_mismatch`
+            message: failureMessage
           }
         };
       }
@@ -533,15 +542,19 @@ export function createClaudeCliAdapter(options: ClaudeCliAdapterOptions = {}): M
 // ---------------------------------------------------------------------------
 
 /**
- * Spawns `codex [--full-auto] [--model <model>] "<prompt>" [extraArgs]`.
+ * Spawns `codex exec --sandbox <mode> [--model <model>] [extraArgs] -`.
+ *
+ * The prompt is delivered via stdin so Windows shell quoting cannot truncate or
+ * reinterpret long MartinLoop prompts that contain paths, deny rules, or budget
+ * context.
  *
  * Requires the Codex CLI to be installed and authenticated:
  *   npm install -g @openai/codex
  */
 export function createCodexCliAdapter(options: CodexCliAdapterOptions = {}): MartinAdapter {
-  const fullAuto = options.fullAuto !== false;
   const modelArgs: string[] = options.model ? ["--model", options.model] : [];
   const extraArgs = options.extraArgs ?? [];
+  const sandbox = options.sandbox ?? "workspace-write";
 
   return createAgentCliAdapter({
     command: "codex",
@@ -553,11 +566,16 @@ export function createCodexCliAdapter(options: CodexCliAdapterOptions = {}): Mar
     verifyTimeoutMs: options.verifyTimeoutMs,
     supportsJsonOutput: false,
     spawnImpl: options.spawnImpl,
-    argsBuilder: (prompt) => [
-      ...(fullAuto ? ["--full-auto"] : []),
+    argsBuilder: () => [
+      "exec",
+      "--sandbox",
+      sandbox,
+      "--color",
+      "never",
       ...modelArgs,
-      prompt,
-      ...extraArgs
+      ...extraArgs,
+      "-",
+      "--stdin-prompt"
     ]
   });
 }
@@ -679,6 +697,20 @@ function truncate(text: string, maxLength: number): string {
   }
 
   return `...${text.slice(-(maxLength - 3))}`;
+}
+
+function formatPreVerifierSubprocessFailure(command: string, stderr: string, exitCode: number): string {
+  const detail = stderr.trim() || `Exit code ${String(exitCode)}`;
+  const lowerDetail = detail.toLowerCase();
+  const codexLaunchBlocked =
+    command === "codex" &&
+    /\b(full-auto|sandbox|approval|permission|trusted|safety|unexpected argument)\b/u.test(lowerDetail);
+
+  if (codexLaunchBlocked) {
+    return `Codex CLI failed before patch completion, likely due to its launch/sandbox configuration. MartinLoop invokes Codex through "codex exec --sandbox workspace-write"; verify Codex CLI auth and configuration if this persists. ${detail}. environment_mismatch`;
+  }
+
+  return `${detail}. environment_mismatch`;
 }
 
 const INJECTION_PATTERNS = [

--- a/packages/adapters/src/cli-bridge.ts
+++ b/packages/adapters/src/cli-bridge.ts
@@ -1,5 +1,6 @@
 import { spawn, type ChildProcess, type SpawnOptions } from "node:child_process";
-import { isAbsolute } from "node:path";
+import { delimiter, extname, isAbsolute, join, resolve } from "node:path";
+import { existsSync } from "node:fs";
 
 import { diffStatsFromNumstat } from "./runtime-support.js";
 
@@ -35,15 +36,11 @@ export async function runSubprocess(
 
     let proc: ChildProcess;
     try {
-      proc = (options.spawnImpl ?? spawn)(command, args, {
+      const spawnPlan = createSpawnPlan(command, args, options.cwd, options.spawnImpl !== undefined);
+      proc = (options.spawnImpl ?? spawn)(spawnPlan.command, spawnPlan.args, {
         cwd: options.cwd,
         stdio: [stdinMode, "pipe", "pipe"],
-        env: process.env,
-        // shell: true is required on Windows to resolve PATH shims (e.g. claude.cmd).
-        // Avoid it for absolute .exe paths because cmd.exe can split paths with spaces.
-        // Prompt content is never passed as a shell argument, it goes via stdin, so
-        // injection risk from the DEP0190 warning does not apply here.
-        shell: shouldUseWindowsShell(command)
+        env: process.env
       });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -183,8 +180,89 @@ export async function readGitExecutionArtifacts(
   };
 }
 
-function shouldUseWindowsShell(command: string): boolean {
-  return process.platform === "win32" && !isAbsolute(command);
+interface SpawnPlan {
+  command: string;
+  args: string[];
+}
+
+function createSpawnPlan(
+  command: string,
+  args: string[],
+  cwd: string,
+  preserveRawForInjectedSpawn: boolean
+): SpawnPlan {
+  if (preserveRawForInjectedSpawn || process.platform !== "win32" || isAbsolute(command)) {
+    return { command, args };
+  }
+
+  const resolved = resolveWindowsCommand(command, cwd);
+  if (!resolved) {
+    return { command, args };
+  }
+
+  const extension = extname(resolved).toLowerCase();
+  if (extension === ".cmd" || extension === ".bat") {
+    return {
+      command: process.env.ComSpec || "cmd.exe",
+      args: ["/d", "/s", "/c", [quoteWindowsCmdArg(resolved), ...args.map(quoteWindowsCmdArg)].join(" ")]
+    };
+  }
+
+  return { command: resolved, args };
+}
+
+function resolveWindowsCommand(command: string, cwd: string): string | undefined {
+  const hasPathSegment = command.includes("\\") || command.includes("/");
+  const baseCandidates = expandWindowsCommandCandidates(
+    hasPathSegment ? resolve(cwd, command) : command
+  );
+
+  if (hasPathSegment) {
+    return baseCandidates.find((candidate) => existsSync(candidate));
+  }
+
+  for (const directory of windowsPathDirectories()) {
+    for (const candidate of baseCandidates) {
+      const fullPath = join(directory, candidate);
+      if (existsSync(fullPath)) {
+        return fullPath;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function expandWindowsCommandCandidates(command: string): string[] {
+  if (extname(command)) {
+    return [command];
+  }
+
+  const pathExt = process.env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD";
+  return pathExt
+    .split(";")
+    .map((extension) => extension.trim())
+    .filter(Boolean)
+    .map((extension) => `${command}${extension.toLowerCase()}`);
+}
+
+function windowsPathDirectories(): string[] {
+  const rawPath = process.env.Path ?? process.env.PATH ?? "";
+  return rawPath
+    .split(delimiter)
+    .map((entry) => entry.trim().replace(/^"|"$/g, ""))
+    .filter(Boolean);
+}
+
+function quoteWindowsCmdArg(value: string): string {
+  const normalized = value.replace(/\r?\n/gu, " ");
+  const escaped = normalized
+    .replace(/\^/gu, "^^")
+    .replace(/"/gu, '^"')
+    .replace(/%/gu, "%%")
+    .replace(/!/gu, "^^!")
+    .replace(/[&|<>()]/gu, (match) => `^${match}`);
+  return `"${escaped}"`;
 }
 
 function truncate(text: string, maxLength: number): string {

--- a/packages/adapters/tests/claude-cli.test.ts
+++ b/packages/adapters/tests/claude-cli.test.ts
@@ -1,3 +1,7 @@
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import type { ChildProcess, SpawnOptions } from "node:child_process";
+
 import { describe, expect, it } from "vitest";
 
 import type { MartinAdapterRequest } from "@martin/core";
@@ -5,7 +9,8 @@ import type { MartinAdapterRequest } from "@martin/core";
 import {
   createAgentCliAdapter,
   createClaudeCliAdapter,
-  createCodexCliAdapter
+  createCodexCliAdapter,
+  type SpawnLike
 } from "../src/index.js";
 
 // ---------------------------------------------------------------------------
@@ -27,6 +32,67 @@ function makeRequest(overrides: Partial<MartinAdapterRequest> = {}): MartinAdapt
     },
     previousAttempts: [],
     ...overrides
+  };
+}
+
+interface SpawnCall {
+  command: string;
+  args: readonly string[];
+  options?: SpawnOptions;
+  stdin: string;
+}
+
+interface ScriptedSpawnOutput {
+  exitCode?: number;
+  stdout?: string;
+  stderr?: string;
+}
+
+function createScriptedSpawn(
+  calls: SpawnCall[],
+  outputs: ScriptedSpawnOutput[] = [{ stdout: "done\n" }]
+): SpawnLike {
+  let index = 0;
+
+  return (command, args = [], options) => {
+    const output = outputs[index] ?? outputs.at(-1) ?? { stdout: "done\n" };
+    index += 1;
+
+    const child = new EventEmitter() as Partial<ChildProcess> & {
+      stdout: PassThrough;
+      stderr: PassThrough;
+      stdin: PassThrough;
+    };
+    child.stdout = new PassThrough();
+    child.stderr = new PassThrough();
+    child.stdin = new PassThrough();
+    child.kill = () => true;
+
+    const call: SpawnCall = {
+      command,
+      args: [...args],
+      options,
+      stdin: ""
+    };
+    calls.push(call);
+
+    child.stdin.on("data", (chunk: Buffer | string) => {
+      call.stdin += Buffer.isBuffer(chunk) ? chunk.toString("utf8") : chunk;
+    });
+
+    process.nextTick(() => {
+      if (output.stdout) {
+        child.stdout.write(output.stdout);
+      }
+      if (output.stderr) {
+        child.stderr.write(output.stderr);
+      }
+      child.stdout.end();
+      child.stderr.end();
+      child.emit("close", output.exitCode ?? 0);
+    });
+
+    return child as ChildProcess;
   };
 }
 
@@ -303,10 +369,127 @@ describe("createCodexCliAdapter", () => {
     expect(adapter.metadata.model).toBe("o3");
   });
 
-  it("returns failed gracefully when codex is not installed", async () => {
-    const adapter = createCodexCliAdapter({ timeoutMs: 2_000 });
-    const result = await adapter.execute(makeRequest());
+  it("uses codex exec with an explicit writable sandbox instead of legacy full-auto", async () => {
+    const calls: SpawnCall[] = [];
+    const adapter = createCodexCliAdapter({
+      fullAuto: true,
+      spawnImpl: createScriptedSpawn(calls)
+    });
+    const result = await adapter.execute(
+      makeRequest({
+        context: {
+          taskTitle: "test",
+          objective: "update the target file",
+          verificationPlan: [],
+          focus: "test",
+          remainingBudgetUsd: 8,
+          remainingIterations: 3,
+          remainingTokens: 10_000
+        }
+      })
+    );
 
-    expect(["failed", "completed"]).toContain(result.status);
+    expect(result.status).toBe("completed");
+    expect(calls[0]?.command).toBe("codex");
+    expect(calls[0]?.args).toEqual([
+      "exec",
+      "--sandbox",
+      "workspace-write",
+      "--color",
+      "never",
+      "-"
+    ]);
+    expect(calls[0]?.args).not.toContain("--full-auto");
+    expect(calls[0]?.stdin).toContain("OBJECTIVE:");
+    expect(calls[0]?.stdin).toContain("update the target file");
+  });
+
+  it("preserves custom Codex model, sandbox, and extra exec flags before stdin prompt", async () => {
+    const calls: SpawnCall[] = [];
+    const adapter = createCodexCliAdapter({
+      model: "gpt-5.5",
+      sandbox: "read-only",
+      extraArgs: ["--ignore-rules"],
+      spawnImpl: createScriptedSpawn(calls)
+    });
+    const result = await adapter.execute(
+      makeRequest({
+        context: {
+          taskTitle: "test",
+          objective: "inspect only",
+          verificationPlan: [],
+          focus: "test",
+          remainingBudgetUsd: 8,
+          remainingIterations: 3,
+          remainingTokens: 10_000
+        }
+      })
+    );
+
+    expect(result.status).toBe("completed");
+    expect(calls[0]?.args).toEqual([
+      "exec",
+      "--sandbox",
+      "read-only",
+      "--color",
+      "never",
+      "--model",
+      "gpt-5.5",
+      "--ignore-rules",
+      "-"
+    ]);
+  });
+
+  it("runs MartinLoop verification after successful Codex exec completion", async () => {
+    const calls: SpawnCall[] = [];
+    const adapter = createCodexCliAdapter({
+      spawnImpl: createScriptedSpawn(calls, [{ stdout: "patched\n" }, { stdout: "ok\n" }])
+    });
+    const result = await adapter.execute(
+      makeRequest({
+        context: {
+          taskTitle: "test",
+          objective: "patch then verify",
+          verificationPlan: process.platform === "win32" ? ["cmd /c exit 0"] : ["true"],
+          focus: "test",
+          remainingBudgetUsd: 8,
+          remainingIterations: 3,
+          remainingTokens: 10_000
+        }
+      })
+    );
+
+    expect(result.status).toBe("completed");
+    expect(result.verification.passed).toBe(true);
+    expect(calls[0]?.command).toBe("codex");
+    expect(calls[1]?.command).toBe(process.platform === "win32" ? "cmd" : "true");
+  });
+
+  it("reports pre-verifier Codex launch failures without running verifier commands", async () => {
+    const calls: SpawnCall[] = [];
+    const adapter = createCodexCliAdapter({
+      spawnImpl: createScriptedSpawn(calls, [
+        { exitCode: 2, stderr: "unexpected argument '--full-auto'\n" }
+      ])
+    });
+    const result = await adapter.execute(
+      makeRequest({
+        context: {
+          taskTitle: "test",
+          objective: "patch then verify",
+          verificationPlan: process.platform === "win32" ? ["cmd /c exit 0"] : ["true"],
+          focus: "test",
+          remainingBudgetUsd: 8,
+          remainingIterations: 3,
+          remainingTokens: 10_000
+        }
+      })
+    );
+
+    expect(result.status).toBe("failed");
+    expect(result.summary).toContain("before verifier execution");
+    expect(result.verification.summary).toContain("Verifier not run");
+    expect(result.failure?.message).toContain("environment_mismatch");
+    expect(calls).toHaveLength(1);
   });
 });

--- a/packages/cli/tests/cli-integration.test.ts
+++ b/packages/cli/tests/cli-integration.test.ts
@@ -3,7 +3,7 @@
  * and the MARTIN_LIVE guard introduced with the real adapter.
  */
 
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -15,6 +15,8 @@ import { executeCli } from "../src/index.js";
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+const NOOP_VERIFIER = process.platform === "win32" ? "cmd /c exit 0" : "true";
 
 async function withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
   const dir = await mkdtemp(join(tmpdir(), "martin-cli-int-"));
@@ -53,6 +55,33 @@ async function withoutAgentCliOnPath<T>(fn: () => Promise<T>): Promise<T> {
       process.env[pathKey] = original;
     }
   }
+}
+
+async function withPathPrefix<T>(dir: string, fn: () => Promise<T>): Promise<T> {
+  const pathKey = Object.keys(process.env).find((key) => key.toLowerCase() === "path") ?? "PATH";
+  const original = process.env[pathKey] ?? "";
+  process.env[pathKey] = original.length > 0 ? `${dir}${process.platform === "win32" ? ";" : ":"}${original}` : dir;
+
+  try {
+    return await fn();
+  } finally {
+    process.env[pathKey] = original;
+  }
+}
+
+async function withFakeCodexCli<T>(fn: () => Promise<T>): Promise<T> {
+  return withTempDir(async (dir) => {
+    const script = process.platform === "win32"
+      ? "@echo off\r\necho fake codex completed\r\nexit /b 0\r\n"
+      : "#!/usr/bin/env sh\necho fake codex completed\n";
+    const file = join(dir, process.platform === "win32" ? "codex.cmd" : "codex");
+    await writeFile(file, script, "utf8");
+    if (process.platform !== "win32") {
+      await chmod(file, 0o755);
+    }
+
+    return withPathPrefix(dir, fn);
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -129,18 +158,26 @@ describe("--engine flag", () => {
   });
 
   it("selects codex adapter when --engine codex is given", async () => {
-    const result = await withEnv("MARTIN_LIVE", "true", () =>
-      executeCli([
-        "run",
-        "--engine",
-        "codex",
-        "--objective",
-        "Fix the bug",
-        "--max-iterations",
-        "1",
-        "--budget-usd",
-        "2"
-      ])
+    const result = await withTempDir((workspace) =>
+      withFakeCodexCli(() =>
+        withEnv("MARTIN_LIVE", "true", () =>
+          executeCli([
+            "run",
+            "--engine",
+            "codex",
+            "--cwd",
+            workspace,
+            "--objective",
+            "Fix the bug",
+            "--verify",
+            NOOP_VERIFIER,
+            "--max-iterations",
+            "1",
+            "--budget-usd",
+            "2"
+          ])
+        )
+      )
     );
 
     expect(result.exitCode).toBe(0);
@@ -161,6 +198,8 @@ describe("--engine flag", () => {
           "run",
           "--objective",
           "Fix the bug",
+          "--verify",
+          NOOP_VERIFIER,
           "--max-iterations",
           "1",
           "--budget-usd",

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -27,7 +27,8 @@ export type FailureClass =
   | "repo_grounding_failure"
   | "verification_failure"
   | "environment_mismatch"
-  | "budget_pressure";
+  | "budget_pressure"
+  | "safety_leash_blocked";
 
 export type InterventionType =
   | "compress_context"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -469,7 +469,8 @@ export async function runMartin(input: RunMartinInput): Promise<RunMartinResult>
       shouldExit: true,
       lifecycleState: "human_escalation",
       status: "exited",
-      reason
+      reason,
+      ...classifySafetyLeashExit(leashDecision, "verifier")
     };
     if (input.store) {
       await input.store.appendLedger(
@@ -490,11 +491,7 @@ export async function runMartin(input: RunMartinInput): Promise<RunMartinResult>
         makeLedgerEvent({
           kind: "run.exited",
           runId: loop.loopId,
-          payload: {
-            lifecycleState: leashExitDecision.lifecycleState,
-            status: leashExitDecision.status,
-            reason: leashExitDecision.reason
-          }
+          payload: createRunExitPayload(leashExitDecision)
         })
       );
     }
@@ -517,7 +514,8 @@ export async function runMartin(input: RunMartinInput): Promise<RunMartinResult>
       shouldExit: true,
       lifecycleState: "human_escalation",
       status: "exited",
-      reason: secretDecision.reason ?? "Safety leash blocked secret-like values in the runtime context."
+      reason: secretDecision.reason ?? "Safety leash blocked secret-like values in the runtime context.",
+      ...classifySafetyLeashExit(secretDecision, "secret")
     };
 
     if (input.store) {
@@ -538,11 +536,7 @@ export async function runMartin(input: RunMartinInput): Promise<RunMartinResult>
         makeLedgerEvent({
           kind: "run.exited",
           runId: loop.loopId,
-          payload: {
-            lifecycleState: secretExitDecision.lifecycleState,
-            status: secretExitDecision.status,
-            reason: secretExitDecision.reason
-          }
+          payload: createRunExitPayload(secretExitDecision)
         })
       );
     }
@@ -595,11 +589,7 @@ export async function runMartin(input: RunMartinInput): Promise<RunMartinResult>
           makeLedgerEvent({
             kind: "run.exited",
             runId: loop.loopId,
-            payload: {
-              lifecycleState: preflightExitDecision.lifecycleState,
-              status: preflightExitDecision.status,
-              reason: preflightExitDecision.reason
-            }
+            payload: createRunExitPayload(preflightExitDecision)
           })
         );
       }
@@ -629,7 +619,10 @@ export async function runMartin(input: RunMartinInput): Promise<RunMartinResult>
         shouldExit: true,
         lifecycleState: "human_escalation",
         status: "exited",
-        reason: "Context Integrity Pre-gate: context poisoning attempt detected."
+        reason: "Context Integrity Pre-gate: context poisoning attempt detected.",
+        failureClass: "safety_leash_blocked",
+        safetySurface: "context_integrity",
+        reasonCode: "context_poisoning_blocked"
       };
       if (input.store) {
         await input.store.appendLedger(
@@ -705,11 +698,7 @@ export async function runMartin(input: RunMartinInput): Promise<RunMartinResult>
           makeLedgerEvent({
             kind: "run.exited",
             runId: loop.loopId,
-            payload: {
-              lifecycleState: exitDecision.lifecycleState,
-              status: exitDecision.status,
-              reason: exitDecision.reason
-            }
+            payload: createRunExitPayload(exitDecision)
           })
         );
       }
@@ -1012,7 +1001,10 @@ export async function runMartin(input: RunMartinInput): Promise<RunMartinResult>
         shouldExit: true,
         lifecycleState: "human_escalation",
         status: "exited",
-        reason: "Verify-only mode forbids file changes."
+        reason: "Verify-only mode forbids file changes.",
+        failureClass: "safety_leash_blocked",
+        safetySurface: "filesystem",
+        reasonCode: "verify_only_write_attempt"
       };
       const rollbackOutcome = await restoreRollbackBoundary({
         repoRoot: request.context.repoRoot,
@@ -1081,11 +1073,7 @@ export async function runMartin(input: RunMartinInput): Promise<RunMartinResult>
           makeLedgerEvent({
             kind: "run.exited",
             runId: loop.loopId,
-            payload: {
-              lifecycleState: verifyOnlyExitDecision.lifecycleState,
-              status: verifyOnlyExitDecision.status,
-              reason: verifyOnlyExitDecision.reason
-            }
+            payload: createRunExitPayload(verifyOnlyExitDecision)
           })
         );
       }
@@ -1119,7 +1107,8 @@ export async function runMartin(input: RunMartinInput): Promise<RunMartinResult>
         shouldExit: true,
         lifecycleState: "human_escalation",
         status: "exited",
-        reason: filesystemDecision.reason ?? "Safety leash blocked filesystem changes."
+        reason: filesystemDecision.reason ?? "Safety leash blocked filesystem changes.",
+        ...classifySafetyLeashExit(filesystemDecision, "filesystem")
       };
       const rollbackOutcome = await restoreRollbackBoundary({
         repoRoot: request.context.repoRoot,
@@ -1170,11 +1159,7 @@ export async function runMartin(input: RunMartinInput): Promise<RunMartinResult>
           makeLedgerEvent({
             kind: "run.exited",
             runId: loop.loopId,
-            payload: {
-              lifecycleState: filesystemExitDecision.lifecycleState,
-              status: filesystemExitDecision.status,
-              reason: filesystemExitDecision.reason
-            }
+            payload: createRunExitPayload(filesystemExitDecision)
           })
         );
       }
@@ -1210,7 +1195,8 @@ export async function runMartin(input: RunMartinInput): Promise<RunMartinResult>
         status: "exited",
         reason:
           changeApprovalDecision.reason ??
-          "Safety leash blocked dependency or migration changes that require approval."
+          "Safety leash blocked dependency or migration changes that require approval.",
+        ...classifySafetyLeashExit(changeApprovalDecision, "dependency")
       };
       const rollbackOutcome = await restoreRollbackBoundary({
         repoRoot: request.context.repoRoot,
@@ -1262,11 +1248,7 @@ export async function runMartin(input: RunMartinInput): Promise<RunMartinResult>
           makeLedgerEvent({
             kind: "run.exited",
             runId: loop.loopId,
-            payload: {
-              lifecycleState: approvalExitDecision.lifecycleState,
-              status: approvalExitDecision.status,
-              reason: approvalExitDecision.reason
-            }
+            payload: createRunExitPayload(approvalExitDecision)
           })
         );
       }
@@ -1435,11 +1417,7 @@ export async function runMartin(input: RunMartinInput): Promise<RunMartinResult>
           makeLedgerEvent({
             kind: "run.exited",
             runId: loop.loopId,
-            payload: {
-              lifecycleState: patchExitDecision.lifecycleState,
-              status: patchExitDecision.status,
-              reason: patchExitDecision.reason
-            }
+            payload: createRunExitPayload(patchExitDecision)
           })
         );
       }
@@ -1491,11 +1469,7 @@ export async function runMartin(input: RunMartinInput): Promise<RunMartinResult>
           makeLedgerEvent({
             kind: "run.exited",
             runId: loop.loopId,
-            payload: {
-              lifecycleState: decision.lifecycleState,
-              status: decision.status,
-              reason: decision.reason
-            }
+            payload: createRunExitPayload(decision)
           })
         );
       }
@@ -1519,11 +1493,7 @@ export async function runMartin(input: RunMartinInput): Promise<RunMartinResult>
       makeLedgerEvent({
         kind: "run.exited",
         runId: loop.loopId,
-        payload: {
-          lifecycleState: decision.lifecycleState,
-          status: decision.status,
-          reason: decision.reason
-        }
+        payload: createRunExitPayload(decision)
       })
     );
   }
@@ -1532,6 +1502,59 @@ export async function runMartin(input: RunMartinInput): Promise<RunMartinResult>
     loop: finalizeLoop(loop, decision, now(), idFactory),
     decision
   };
+}
+
+function createRunExitPayload(decision: ExitDecision): Record<string, unknown> {
+  return {
+    lifecycleState: decision.lifecycleState,
+    status: decision.status,
+    reason: decision.reason,
+    ...(decision.failureClass ? { failureClass: decision.failureClass } : {}),
+    ...(decision.safetySurface ? { safetySurface: decision.safetySurface } : {}),
+    ...(decision.reasonCode ? { reasonCode: decision.reasonCode } : {})
+  };
+}
+
+function classifySafetyLeashExit(
+  decision: { surface: string; violations: SafetyViolation[] },
+  safetySurface = decision.surface
+): Pick<ExitDecision, "failureClass" | "safetySurface" | "reasonCode"> {
+  return {
+    failureClass: "safety_leash_blocked",
+    safetySurface,
+    reasonCode: safetyLeashReasonCode(decision, safetySurface)
+  };
+}
+
+function safetyLeashReasonCode(
+  decision: { surface: string; violations: SafetyViolation[] },
+  safetySurface: string
+): string {
+  const kind = decision.violations[0]?.kind;
+
+  switch (kind) {
+    case "command_blocked":
+      return safetySurface === "verifier" ? "destructive_verifier_command" : "command_blocked";
+    case "network_blocked":
+      return safetySurface === "verifier" ? "verifier_network_blocked" : "network_access_blocked";
+    case "secret_value":
+      return "secret_context_value";
+    case "path_denied":
+    case "protected_path":
+      return "protected_surface_write";
+    case "path_not_allowed":
+      return "surface_write_not_allowed";
+    case "path_outside_repo":
+      return "outside_repo_write";
+    case "dependency_approval_required":
+      return "dependency_approval_required";
+    case "migration_approval_required":
+      return "migration_approval_required";
+    case "config_change_approval_required":
+      return "config_change_approval_required";
+    default:
+      return `${safetySurface}_safety_block`;
+  }
 }
 
 function finalizeLoop(
@@ -1545,7 +1568,7 @@ function finalizeLoop(
     {
       type: "run.completed",
       lifecycleState: decision.lifecycleState,
-      payload: { status: decision.status, reason: decision.reason }
+      payload: createRunExitPayload(decision)
     },
     { now: timestamp, idFactory }
   );

--- a/packages/core/src/policy.ts
+++ b/packages/core/src/policy.ts
@@ -37,6 +37,12 @@ export interface ExitDecision {
   lifecycleState: LoopLifecycleState;
   status: LoopStatus;
   reason: string;
+  /** Machine-readable stop classifier for non-attempt exits such as preflight safety blocks. */
+  failureClass?: FailureClass;
+  /** Machine-readable safety surface, when the stop came from a safety leash. */
+  safetySurface?: string;
+  /** Stable reason code for dashboards, MCP, and downstream automation. */
+  reasonCode?: string;
 }
 
 export interface MartinAdapterResultLike {

--- a/packages/core/tests/runtime.test.ts
+++ b/packages/core/tests/runtime.test.ts
@@ -669,12 +669,23 @@ describe("runMartin", () => {
     const exitIndex = ledger.findIndex((entry) => entry.kind === "run.exited");
 
     expect(adapterExecutions).toBe(0);
-    expect(result.decision.lifecycleState).toBe("human_escalation");
+    expect(result.decision).toMatchObject({
+      lifecycleState: "human_escalation",
+      failureClass: "safety_leash_blocked",
+      safetySurface: "verifier",
+      reasonCode: "destructive_verifier_command"
+    });
     expect(safetyIndex).toBeGreaterThanOrEqual(0);
     expect(exitIndex).toBeGreaterThan(safetyIndex);
     expect(ledger[safetyIndex]?.payload).toMatchObject({
       surface: "command",
       blocked: true
+    });
+    expect(ledger[exitIndex]?.payload).toMatchObject({
+      lifecycleState: "human_escalation",
+      failureClass: "safety_leash_blocked",
+      safetySurface: "verifier",
+      reasonCode: "destructive_verifier_command"
     });
     expect(ledger[safetyIndex]?.payload.violations).toEqual(
       expect.arrayContaining(["rm -rf ."])

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -8,6 +8,11 @@ It exposes three MCP tools over stdio:
 - `martin_inspect`
 - `martin_status`
 
+`martin_run` accepts budget fields (`maxUsd`, `maxIterations`, `maxTokens`),
+`verificationPlan`, and optional repo-relative `allowedPaths` / `deniedPaths`.
+When scope paths are supplied, MartinLoop passes them into both the agent prompt
+and post-run filesystem leash checks using `workingDirectory` as the repo root.
+
 ## Quickstart
 
 Run the packaged server directly:

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -84,6 +84,18 @@ server.setRequestHandler(ListToolsRequestSchema, () => ({
             description:
               "Shell commands that must all exit 0 for the task to be considered complete (e.g. ['pnpm test', 'pnpm build'])."
           },
+          allowedPaths: {
+            type: "array",
+            items: { type: "string" },
+            description:
+              "Optional repo-relative path patterns MartinLoop is allowed to modify. When set, changes outside these patterns fail scope enforcement."
+          },
+          deniedPaths: {
+            type: "array",
+            items: { type: "string" },
+            description:
+              "Optional repo-relative path patterns MartinLoop must never modify. Denied paths are enforced in prompts and post-run scope checks."
+          },
           workspaceId: {
             type: "string",
             description: "Workspace identifier for telemetry. Defaults to 'ws_mcp'."

--- a/packages/mcp/src/tools/run-loop.ts
+++ b/packages/mcp/src/tools/run-loop.ts
@@ -1,3 +1,5 @@
+import { resolve } from "node:path";
+
 import {
   createClaudeCliAdapter,
   createCodexCliAdapter,
@@ -15,6 +17,8 @@ export interface RunLoopInput {
   maxIterations?: number;
   maxTokens?: number;
   verificationPlan?: string[];
+  allowedPaths?: string[];
+  deniedPaths?: string[];
   workspaceId?: string;
   projectId?: string;
 }
@@ -30,7 +34,7 @@ export interface RunLoopOutput {
 }
 
 export async function runLoopTool(input: RunLoopInput): Promise<RunLoopOutput> {
-  const workingDirectory = input.workingDirectory ?? process.cwd();
+  const workingDirectory = resolve(input.workingDirectory ?? process.cwd());
   const engine = input.engine ?? "claude";
   const model = input.model;
 
@@ -63,7 +67,10 @@ export async function runLoopTool(input: RunLoopInput): Promise<RunLoopOutput> {
     task: {
       title: input.objective.slice(0, 100),
       objective: input.objective,
-      verificationPlan: input.verificationPlan ?? []
+      verificationPlan: input.verificationPlan ?? [],
+      repoRoot: workingDirectory,
+      ...(input.allowedPaths?.length ? { allowedPaths: input.allowedPaths } : {}),
+      ...(input.deniedPaths?.length ? { deniedPaths: input.deniedPaths } : {})
     },
     budget,
     adapter


### PR DESCRIPTION
## Summary
- replace legacy `codex --full-auto <prompt>` launch with `codex exec --sandbox workspace-write --color never -` and stdin prompt delivery
- report pre-verifier Codex launch/sandbox failures as `Verifier not run: ... environment_mismatch` instead of opaque verifier failures
- harden Windows subprocess execution for npm-style `.cmd`/`.bat` shims without `shell: true` argument concatenation
- extend MCP `martin_run` to accept `allowedPaths` / `deniedPaths` and bind `workingDirectory` as `repoRoot`
- remove the telemetry POST lifecycle bug that crawled `~/.martin/runs`; telemetry now persists the submitted envelope through a bounded read-model ingest path
- add machine-readable safety-leash exit taxonomy: `failureClass`, `safetySurface`, and `reasonCode` on decisions, ledgers, and control-plane run views

## Fixes
- Fixes #20
- Fixes #21

## Verification
- `pnpm --filter @martin/adapters test`
- `pnpm --filter @martin/control-plane test -- control-plane-routes.test.ts -t "telemetry route"`
- `pnpm --filter @martin/control-plane test -- control-plane-routes.test.ts ingest-run-read-model.test.ts control-plane-queries.test.ts`
- `pnpm --filter @martin/core test -- runtime.test.ts -t "unsafe shell command"`
- `pnpm test`
- `pnpm lint`
- `pnpm build`
- `pnpm release:matrix:local`

Release matrix logs: `C:\Users\Torram\AppData\Local\Temp\martin-release-matrix-6w8qlJ\logs`