### PR TITLE
Harden Codex exec workspace invocation

### DIFF
--- a/packages/adapters/src/claude-cli.ts
+++ b/packages/adapters/src/claude-cli.ts
@@ -152,16 +152,19 @@ function inferStructuralClassHint(
 
 /**
  * Given a prompt string, returns the full argv array to pass to spawn().
- * Example for Claude:  (p) => ["--print", p, "--dangerously-skip-permissions"]
- * Example for Codex:   (p) => ["--full-auto", p]
+ * Example for Claude:  () => ["--output-format", "json", "--print"]
+ * Example for Codex:   () => ["exec", "--sandbox", "workspace-write", "-"]
  */
 export type CliArgsBuilder = (prompt: string) => string[];
+export type CliStdinBuilder = (prompt: string) => string | undefined;
 
 export interface AgentCliAdapterOptions {
   /** The executable to spawn (e.g. "claude", "codex"). */
   command: string;
   /** Converts a prompt string into the argv array passed to spawn(). */
   argsBuilder: CliArgsBuilder;
+  /** Optional stdin payload for CLIs that accept prompt input via stdin or `-`. */
+  stdinBuilder?: CliStdinBuilder;
   /** Adapter ID suffix. Defaults to command. */
   adapterIdSuffix?: string;
   /** Working directory for all subprocesses. Defaults to process.cwd(). */
@@ -271,17 +274,13 @@ export function createAgentCliAdapter(options: AgentCliAdapterOptions): MartinAd
       }
 
       const args = options.argsBuilder(prompt);
+      const stdinData = options.stdinBuilder?.(prompt);
 
-      // stdinPrompt: if argsBuilder signals stdin delivery by returning args ending with "--stdin-prompt",
-      // remove that sentinel and pass the prompt via stdin instead (avoids Windows shell-escaping issues).
-      const useStdin = args.at(-1) === "--stdin-prompt";
-      const spawnArgs = useStdin ? args.slice(0, -1) : args;
-
-      const agentResult = await runSubprocess(options.command, spawnArgs, {
+      const agentResult = await runSubprocess(options.command, args, {
         cwd: workingDirectory,
         timeoutMs,
         spawnImpl: options.spawnImpl,
-        ...(useStdin ? { stdinData: prompt } : {})
+        ...(stdinData === undefined ? {} : { stdinData })
       });
 
       if (agentResult.timedOut) {
@@ -531,9 +530,9 @@ export function createClaudeCliAdapter(options: ClaudeCliAdapterOptions = {}): M
       "--print",
       "--dangerously-skip-permissions",
       ...modelArgs,
-      ...extraArgs,
-      "--stdin-prompt"  // sentinel: tells execute() to deliver prompt via stdin
-    ]
+      ...extraArgs
+    ],
+    stdinBuilder: (prompt) => prompt
   });
 }
 
@@ -542,7 +541,7 @@ export function createClaudeCliAdapter(options: ClaudeCliAdapterOptions = {}): M
 // ---------------------------------------------------------------------------
 
 /**
- * Spawns `codex exec --sandbox <mode> [--model <model>] [extraArgs] -`.
+ * Spawns `codex exec --cd <workspace> --sandbox <mode> [--model <model>] [extraArgs] -`.
  *
  * The prompt is delivered via stdin so Windows shell quoting cannot truncate or
  * reinterpret long MartinLoop prompts that contain paths, deny rules, or budget
@@ -555,28 +554,31 @@ export function createCodexCliAdapter(options: CodexCliAdapterOptions = {}): Mar
   const modelArgs: string[] = options.model ? ["--model", options.model] : [];
   const extraArgs = options.extraArgs ?? [];
   const sandbox = options.sandbox ?? "workspace-write";
+  const workingDirectory = options.workingDirectory ?? process.cwd();
 
   return createAgentCliAdapter({
     command: "codex",
     adapterIdSuffix: "codex",
     model: options.model ?? "codex",
     label: options.label ?? "Codex CLI adapter",
-    workingDirectory: options.workingDirectory,
+    workingDirectory,
     timeoutMs: options.timeoutMs,
     verifyTimeoutMs: options.verifyTimeoutMs,
     supportsJsonOutput: false,
     spawnImpl: options.spawnImpl,
     argsBuilder: () => [
       "exec",
+      "--cd",
+      workingDirectory,
       "--sandbox",
       sandbox,
       "--color",
       "never",
       ...modelArgs,
       ...extraArgs,
-      "-",
-      "--stdin-prompt"
-    ]
+      "-"
+    ],
+    stdinBuilder: (prompt) => prompt
   });
 }
 

--- a/packages/adapters/tests/claude-cli.test.ts
+++ b/packages/adapters/tests/claude-cli.test.ts
@@ -446,8 +446,10 @@ describe("createCodexCliAdapter", () => {
 
   it("uses codex exec with an explicit writable sandbox instead of legacy full-auto", async () => {
     const calls: SpawnCall[] = [];
+    const workingDirectory = join(tmpdir(), "martin codex path with spaces");
     const adapter = createCodexCliAdapter({
       fullAuto: true,
+      workingDirectory,
       spawnImpl: createScriptedSpawn(calls)
     });
     const result = await adapter.execute(
@@ -468,6 +470,8 @@ describe("createCodexCliAdapter", () => {
     expect(calls[0]?.command).toBe("codex");
     expect(calls[0]?.args).toEqual([
       "exec",
+      "--cd",
+      workingDirectory,
       "--sandbox",
       "workspace-write",
       "--color",
@@ -475,6 +479,8 @@ describe("createCodexCliAdapter", () => {
       "-"
     ]);
     expect(calls[0]?.args).not.toContain("--full-auto");
+    expect(calls[0]?.args).not.toContain("--stdin-prompt");
+    expect(calls[0]?.options?.cwd).toBe(workingDirectory);
     expect(calls[0]?.stdin).toContain("OBJECTIVE:");
     expect(calls[0]?.stdin).toContain("update the target file");
   });
@@ -504,6 +510,8 @@ describe("createCodexCliAdapter", () => {
     expect(result.status).toBe("completed");
     expect(calls[0]?.args).toEqual([
       "exec",
+      "--cd",
+      expect.any(String),
       "--sandbox",
       "read-only",
       "--color",


### PR DESCRIPTION
## Summary
- Replace the Codex/Claude stdin sentinel with an explicit adapter stdin contract.
- Pin Codex noninteractive runs to the intended workspace via documented `codex exec --cd <workspace> ... -`.
- Extend adapter tests for paths with spaces, stdin prompt delivery, and absence of legacy `--full-auto` / sentinel args.

## Customer feedback addressed
CounterSwarm evaluation said MartinLoop was promising but not drop-in yet, with concerns around Codex CLI execution patterns, Windows/path-with-spaces confidence, and root suite reliability. Current public `main` did not reproduce the control-plane route timeout after a fresh install, but this PR hardens the Codex sidecar path further so verifier execution is less dependent on cwd inference or argv/sentinel behavior.

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm --filter @martin/control-plane exec vitest run tests/control-plane-routes.test.ts`
- `pnpm --filter @martin/adapters test -- tests/claude-cli.test.ts`
- `pnpm --filter @martin/adapters lint`
- `pnpm --filter @martin/adapters build` after building workspace deps
- `pnpm test`
- `pnpm lint`
- `pnpm build`
- `pnpm release:matrix:local`