### PR TITLE
feat: ship distribution demo and release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
         with:
@@ -82,14 +84,20 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: Fetch tags
+        run: git fetch --force --tags
+
       - name: Pack tarballs
         run: |
           mkdir -p dist-release
           cd packages/core && pnpm pack --pack-destination ../../dist-release && cd ../..
           cd packages/cli && pnpm pack --pack-destination ../../dist-release && cd ../..
 
+      - name: Generate release notes
+        run: node ./scripts/generate-release-notes.mjs --current-tag "${GITHUB_REF_NAME}" --output dist-release/release-notes.md
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           files: dist-release/*
-          generate_release_notes: true
+          body_path: dist-release/release-notes.md

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ MartinLoop V3 3-31-2026/
 
 # Legacy demo directory
 demo/
+!demo/
+!demo/seeded-workspace/
+!demo/seeded-workspace/**

--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ pnpm --filter @martin/benchmarks eval
 pnpm --filter @martin/benchmarks eval:phase12
 ```
 
+Challenge page: [Can your AI coding agent finish this task under $3?](./docs/distribution/UNDER-3-CHALLENGE.md)
+
 ---
 
 ## Quick Start
@@ -131,6 +133,8 @@ npm install -g martin-loop
 ```
 
 This installs both the `martin-loop` package and the `martin` command alias. The package is currently published on npm as version `0.1.4`.
+
+Want a safe sandbox first? Run `npx martin-loop demo` and MartinLoop will copy a disposable local workspace into `./martin-loop-demo`.
 
 ### Public Package Surface
 
@@ -214,7 +218,7 @@ martin run <objective> [options]
   --metadata <key=value>  Attach metadata to the run record; repeatable
 ```
 
-The public CLI also includes `inspect`, `resume`, and a `bench` redirect that points reviewers to the workspace benchmark harness.
+The public CLI also includes `demo`, `inspect`, `resume`, and a `bench` redirect that points reviewers to the workspace benchmark harness.
 
 <div align="center">
   <img src="./docs/assets/cli-static.svg" alt="MartinLoop CLI terminal output" width="720">
@@ -350,6 +354,9 @@ Helpful docs:
 
 - [OSS quickstart](./docs/oss/QUICKSTART.md)
 - [OSS examples](./docs/oss/EXAMPLES.md)
+- [Under-$3 benchmark challenge](./docs/distribution/UNDER-3-CHALLENGE.md)
+- [Directory submission pack](./docs/distribution/DIRECTORY-SUBMISSIONS.md)
+- [Integration outreach pack](./docs/distribution/INTEGRATION-OUTREACH.md)
 - [Claude Code walkthrough](./docs/oss/CLAUDE-CODE-WALKTHROUGH.md)
 - [Ralph-style loop safety guide](./docs/oss/RALPH-LOOP-SAFETY.md)
 - [OSS boundary report](./docs/oss/OSS-BOUNDARY-REPORT.md)

--- a/demo/seeded-workspace/README.md
+++ b/demo/seeded-workspace/README.md
@@ -1,0 +1,35 @@
+# MartinLoop Demo Sandbox
+
+This workspace is the safe public demo copied by `martin-loop demo`.
+
+It is intentionally small:
+
+- `npm test` is green out of the box
+- `martin.config.yaml` keeps the budget tiny
+- the first suggested MartinLoop run can stay in stub mode with `MARTIN_LIVE=false`
+
+## Files
+
+- `src/invoice-summary.js`: tiny module used by the demo task
+- `test/invoice-summary.test.js`: Node test suite
+- `TASKS.md`: suggested objectives for a stub-safe run or a live adapter run
+- `martin.config.yaml`: low-risk governance defaults
+
+## Suggested flow
+
+```sh
+npm install
+npm test
+```
+
+Safe first run:
+
+```sh
+MARTIN_LIVE=false npx martin-loop run "Summarize the demo workspace and confirm the verifier is green" --verify "npm test"
+```
+
+Optional live run:
+
+```sh
+npx martin-loop run "Add support for a discount percentage to summarizeInvoice and update the tests" --verify "npm test" --engine codex
+```

--- a/demo/seeded-workspace/TASKS.md
+++ b/demo/seeded-workspace/TASKS.md
@@ -1,0 +1,29 @@
+# Suggested Demo Tasks
+
+## Stub-safe first run
+
+Use this when you want to see MartinLoop create a governed run record without spending provider budget:
+
+```text
+Summarize the demo workspace, confirm the verifier command is green, and explain the safest next change to make.
+```
+
+Verifier:
+
+```sh
+npm test
+```
+
+## Optional live run
+
+Use this when you want a real coding task in the sandbox:
+
+```text
+Add support for a discount percentage to summarizeInvoice and update the tests while keeping the existing tax behavior intact.
+```
+
+Verifier:
+
+```sh
+npm test
+```

--- a/demo/seeded-workspace/martin.config.yaml
+++ b/demo/seeded-workspace/martin.config.yaml
@@ -1,0 +1,11 @@
+policyProfile: strict_local
+budget:
+  maxUsd: 2
+  softLimitUsd: 1
+  maxIterations: 2
+  maxTokens: 12000
+governance:
+  destructiveActionPolicy: approval
+  telemetryDestination: local-only
+  verifierRules:
+    - npm test

--- a/demo/seeded-workspace/package.json
+++ b/demo/seeded-workspace/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "martin-loop-demo-sandbox",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/demo/seeded-workspace/src/invoice-summary.js
+++ b/demo/seeded-workspace/src/invoice-summary.js
@@ -1,0 +1,11 @@
+export function summarizeInvoice(items, taxRate = 0) {
+  const subtotal = items.reduce((sum, item) => sum + item.quantity * item.unitPrice, 0);
+  const tax = Number((subtotal * taxRate).toFixed(2));
+  const total = Number((subtotal + tax).toFixed(2));
+
+  return {
+    subtotal: Number(subtotal.toFixed(2)),
+    tax,
+    total
+  };
+}

--- a/demo/seeded-workspace/test/invoice-summary.test.js
+++ b/demo/seeded-workspace/test/invoice-summary.test.js
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { summarizeInvoice } from "../src/invoice-summary.js";
+
+test("summarizeInvoice returns subtotal, tax, and total", () => {
+  const result = summarizeInvoice(
+    [
+      { quantity: 2, unitPrice: 19.99 },
+      { quantity: 1, unitPrice: 5.5 }
+    ],
+    0.13
+  );
+
+  assert.deepEqual(result, {
+    subtotal: 45.48,
+    tax: 5.91,
+    total: 51.39
+  });
+});

--- a/docs/distribution/DIRECTORY-SUBMISSIONS.md
+++ b/docs/distribution/DIRECTORY-SUBMISSIONS.md
@@ -1,0 +1,89 @@
+# Directory Submission Pack
+
+Use this file as the single source of truth for public directory submissions.
+
+## Short tagline
+
+Open-source control plane for AI coding agents.
+
+## Long description
+
+MartinLoop is an open-source governed runtime for AI coding agents. It wraps autonomous coding loops with budget caps, verifier gates, rollback evidence, JSONL run records, failure classification, and MCP/Claude/Codex integration so agent work can be inspected, halted, and trusted.
+
+## Primary links
+
+- GitHub repo: [github.com/Keesan12/martin-loop](https://github.com/Keesan12/martin-loop)
+- Website: [martinloop.com](https://martinloop.com)
+- npm package: [npmjs.com/package/martin-loop](https://www.npmjs.com/package/martin-loop)
+- Benchmark challenge: [UNDER-3-CHALLENGE.md](./UNDER-3-CHALLENGE.md)
+
+## Submission checklist
+
+### OpenAlternative
+
+- status: pending
+- surface: OSS alternative listing
+- copy to use: short tagline + long description
+- include: GitHub, website, npm
+
+### DevHunt
+
+- status: pending
+- surface: product hunt style dev tools directory
+- copy to use: short tagline + long description
+- include: benchmark challenge and demo command
+
+### Uneed
+
+- status: pending
+- surface: startup/tool discovery
+- copy to use: short tagline + long description
+- include: GitHub, website, npm
+
+### BetaList
+
+- status: pending
+- surface: early product discovery
+- copy to use: short tagline + long description
+- include: why governed agent runs matter
+
+### Microlaunch
+
+- status: pending
+- surface: lightweight launch directory
+- copy to use: short tagline + long description
+- include: demo command and benchmark challenge
+
+### AlternativeTo
+
+- status: pending
+- surface: alternative comparison listing
+- copy to use: short tagline + long description
+- include: comparable tools and differentiators
+
+### Futurepedia
+
+- status: pending
+- surface: AI tools directory
+- copy to use: short tagline + long description
+- include: Claude, Codex, and MCP integration
+
+### Toolify
+
+- status: pending
+- surface: AI tool directory
+- copy to use: short tagline + long description
+- include: benchmark challenge link
+
+### There’s An AI For That
+
+- status: pending
+- surface: AI tool catalog
+- copy to use: short tagline + long description
+- include: GitHub, website, npm
+
+## Notes
+
+- Prefer submissions that link directly to the repo, website, and npm package together.
+- Reuse the benchmark challenge and `martin-loop demo` as the fastest trust-building assets.
+- If a directory wants screenshots, use the current public repo README visuals instead of inventing a separate pitch deck.

--- a/docs/distribution/INTEGRATION-OUTREACH.md
+++ b/docs/distribution/INTEGRATION-OUTREACH.md
@@ -1,0 +1,61 @@
+# Integration Outreach Pack
+
+Use this file for direct outreach to projects and communities building around AI coding agents.
+
+## Core message
+
+Hey [Name] — I’m building MartinLoop, an OSS governed runtime for AI coding agents.
+
+The repo already supports budget caps, verifier gates, JSONL run records, rollback evidence, Claude/Codex adapters, and an MCP package.
+
+I’m trying to understand where a control layer like this should integrate best with projects like [their project]: CLI wrapper, MCP boundary, CI, or runtime adapter.
+
+Would value your blunt take — useful direction or wrong abstraction?
+
+## Target projects
+
+- Claude Code
+- Codex CLI
+- MCP servers
+- Aider
+- Cline
+- Continue
+- OpenHands
+- SWE-agent
+- Goose
+- DevContainers
+- GitHub Actions
+
+## Outreach notes by target
+
+### Claude Code
+
+- emphasize governed repo runs and MCP install path
+- ask whether the best control point is local CLI wrapper or MCP boundary
+
+### Codex CLI
+
+- emphasize budget caps, verifier gates, and auditable run records
+- ask whether wrapper, runtime adapter, or CI integration is most useful
+
+### MCP projects
+
+- emphasize the packaged `@martinloop/mcp` server surface
+- ask whether the trust layer belongs at tool boundary or runtime boundary
+
+### Aider, Cline, Continue, OpenHands, SWE-agent, Goose
+
+- emphasize adapter-normalized receipts and halt reasons
+- ask how much control should live in the agent runtime versus CI or wrapper
+
+### DevContainers and GitHub Actions
+
+- emphasize safe default automation, budget visibility, and verifier gates in shared team workflows
+- ask where platform teams want policy to live
+
+## Supporting assets
+
+- challenge page: [UNDER-3-CHALLENGE.md](./UNDER-3-CHALLENGE.md)
+- directory copy: [DIRECTORY-SUBMISSIONS.md](./DIRECTORY-SUBMISSIONS.md)
+- repo: [github.com/Keesan12/martin-loop](https://github.com/Keesan12/martin-loop)
+- npm: [npmjs.com/package/martin-loop](https://www.npmjs.com/package/martin-loop)

--- a/docs/distribution/UNDER-3-CHALLENGE.md
+++ b/docs/distribution/UNDER-3-CHALLENGE.md
@@ -1,0 +1,65 @@
+# Can your AI coding agent finish this task under $3?
+
+MartinLoop is testing a simple question:
+
+Can an AI coding agent complete a task under a fixed budget, with verifier-passed completion and an inspectable run record?
+
+## Current repo-backed comparison
+
+Same task, same starting state:
+
+- governed MartinLoop run: `$2.30`
+- uncontrolled retry loop: `$5.20`
+- governed outcome: `completed` and verifier-passed with an inspectable record
+- uncontrolled outcome: failed after repeated retries with no comparable audit trail
+
+These numbers match the current public benchmark story shown in the repo README and visualized in [`docs/assets/side-by-side.svg`](../assets/side-by-side.svg).
+
+## Why this matters
+
+The claim is not that every governed run is always cheaper. The claim is that the run becomes inspectable and enforceable:
+
+- budget policy is explicit
+- verifier success is explicit
+- stop reasons are explicit
+- artifacts are inspectable after the run
+
+That makes a coding-agent result easier to trust, replay, compare, and audit.
+
+## Reproduce it
+
+From the repo root:
+
+```bash
+pnpm --filter @martin/benchmarks test
+pnpm --filter @martin/benchmarks eval
+pnpm --filter @martin/benchmarks eval:phase12
+```
+
+## What to share back
+
+If you run a similar challenge with Claude Code, Codex CLI, Cursor, Aider, Cline, Continue, OpenHands, SWE-agent, Goose, or an internal coding agent, share:
+
+- total budget used
+- number of attempts
+- verifier result
+- whether the final run was auditable
+- whether rollback evidence was available
+
+## Try MartinLoop without risking your repo
+
+You can copy the public demo sandbox first:
+
+```bash
+npx martin-loop demo
+```
+
+Then run the sandbox locally with the printed next steps.
+
+## Claim boundary
+
+This page intentionally stays inside the current public evidence boundary:
+
+- the `$2.30` and `$5.20` figures are the current repo-backed benchmark story used in the public README
+- the reproduction commands above are real commands from this repository
+- the benchmark harness remains a workspace-level surface, so challenge claims should stay tied to repo-backed outputs rather than generic marketing numbers

--- a/package.json
+++ b/package.json
@@ -21,8 +21,10 @@
   },
   "files": [
     "dist",
+    "demo",
     "README.md",
-    "docs/oss"
+    "docs/oss",
+    "docs/distribution"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,7 @@
-import { appendFile, mkdir, readFile } from "node:fs/promises";
+import { appendFile, cp, mkdir, readFile, readdir, rm } from "node:fs/promises";
 import { homedir } from "node:os";
-import { isAbsolute, join, resolve } from "node:path";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import {
   createClaudeCliAdapter,
@@ -65,6 +66,11 @@ export type ParsedCliArguments =
   | {
       command: "bench";
       suiteId: string;
+    }
+  | {
+      command: "demo";
+      directory: string;
+      force: boolean;
     }
   | {
       command: "inspect";
@@ -206,6 +212,27 @@ export async function executeCli(args: string[]): Promise<{
         stderr:
           "The benchmark harness remains a workspace-only RC surface and is not part of the publishable @martin/cli boundary yet. Use pnpm --filter @martin/benchmarks test or pnpm --filter @martin/benchmarks eval:phase12 from the repo root instead."
       };
+    }
+    case "demo": {
+      try {
+        const targetDirectory = await createDemoWorkspace({
+          targetDirectory: parsed.directory,
+          force: parsed.force
+        });
+
+        return {
+          exitCode: 0,
+          stdout: renderDemoInstructions(targetDirectory),
+          stderr: ""
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          exitCode: 1,
+          stdout: "",
+          stderr: `Error: ${message}`
+        };
+      }
     }
     case "inspect": {
       try {
@@ -463,6 +490,14 @@ export function parseCliArguments(args: string[]): ParsedCliArguments {
     };
   }
 
+  if (command === "demo") {
+    return {
+      command: "demo",
+      directory: resolve(readOption(rest, "--dir") ?? join(process.cwd(), "martin-loop-demo")),
+      force: hasFlag(rest, "--force")
+    };
+  }
+
   if (command === "inspect") {
     return {
       command: "inspect",
@@ -488,12 +523,14 @@ export function renderCliHelp(): string {
     "  martin-loop run <objective> [options]",
     "  martin run <objective> [options]       (alias)",
     "  martin-loop run --objective <text> [options]",
+    "  martin-loop demo [--dir <path>] [--force]",
     "  martin-loop inspect --file <path>",
     "  martin-loop resume <loopId>",
     "  martin-loop bench --suite <suiteId>",
     "",
     "Commands:",
     "  run      Execute a bounded Martin loop against the current repository.",
+    "  demo     Copy a safe local sandbox so you can try MartinLoop outside your own repo.",
     "  inspect  Read a persisted loop record and summarize its portfolio metrics.",
     "  resume   Load a persisted loop record by loop ID from ~/.martin/runs/.",
     "  bench    Redirect to the workspace-only RC benchmark harness.",
@@ -513,7 +550,11 @@ export function renderCliHelp(): string {
     "  --allow-path <glob>     Restrict agent writes to this path pattern (repeatable).",
     "  --deny-path <glob>      Block agent from this path pattern (repeatable).",
     "  --accept <criterion>    Add an acceptance criterion to the prompt (repeatable).",
-    "  --config <path>         Path to martin.config.yaml."
+    "  --config <path>         Path to martin.config.yaml.",
+    "",
+    "Demo options:",
+    "  --dir <path>            Target directory for the copied demo sandbox.",
+    "  --force                 Replace an existing non-empty demo target."
   ].join("\n");
 }
 
@@ -539,6 +580,94 @@ function parseLoopRecords(contents: string): LoopRecord[] {
 
     return lines.map((line) => JSON.parse(line) as LoopRecord);
   }
+}
+
+async function createDemoWorkspace(input: {
+  targetDirectory: string;
+  force: boolean;
+}): Promise<string> {
+  const rootDir = await findMartinPackageRoot();
+  const sourceDirectory = join(rootDir, "demo", "seeded-workspace");
+
+  try {
+    await readdir(sourceDirectory);
+  } catch (error) {
+    if (isNodeErrorWithCode(error, "ENOENT")) {
+      throw new Error(`Demo assets are missing from this install: ${sourceDirectory}`);
+    }
+
+    throw error;
+  }
+
+  const targetDirectory = resolve(input.targetDirectory);
+  const existingEntries = await readdir(targetDirectory).catch((error: unknown) => {
+    if (isNodeErrorWithCode(error, "ENOENT")) {
+      return undefined;
+    }
+
+    throw error;
+  });
+
+  if (existingEntries) {
+    if (existingEntries.length > 0 && !input.force) {
+      throw new Error(
+        `Demo target already exists and is not empty: ${targetDirectory}. Re-run with --force to replace it.`
+      );
+    }
+
+    await rm(targetDirectory, { force: true, recursive: true });
+  }
+
+  await mkdir(dirname(targetDirectory), { recursive: true });
+  await cp(sourceDirectory, targetDirectory, { recursive: true });
+
+  return targetDirectory;
+}
+
+async function findMartinPackageRoot(): Promise<string> {
+  let currentDirectory = dirname(fileURLToPath(import.meta.url));
+
+  for (let depth = 0; depth < 8; depth += 1) {
+    const manifestPath = join(currentDirectory, "package.json");
+
+    try {
+      const manifest = JSON.parse(await readFile(manifestPath, "utf8")) as { name?: string };
+      if (manifest.name === "martin-loop") {
+        return currentDirectory;
+      }
+    } catch (error) {
+      if (!isNodeErrorWithCode(error, "ENOENT")) {
+        throw error;
+      }
+    }
+
+    const parentDirectory = dirname(currentDirectory);
+    if (parentDirectory === currentDirectory) {
+      break;
+    }
+    currentDirectory = parentDirectory;
+  }
+
+  throw new Error("Unable to resolve the martin-loop package root for demo assets.");
+}
+
+function renderDemoInstructions(targetDirectory: string): string {
+  return [
+    `MartinLoop demo sandbox created at ${targetDirectory}`,
+    "",
+    "Next steps:",
+    `  cd ${targetDirectory}`,
+    "  npm install",
+    "  npm test",
+    "",
+    "Safe first run (no provider spend):",
+    '  MARTIN_LIVE=false npx martin-loop run "Summarize the demo workspace and confirm the verifier is green" --verify "npm test"',
+    "",
+    "Optional live run:",
+    '  npx martin-loop run "Add support for a discount percentage to summarizeInvoice and update the tests" --verify "npm test" --engine codex',
+    "",
+    `Task ideas live in ${join(targetDirectory, "TASKS.md")}`
+  ].join("\n");
 }
 
 async function resolveGuardrails(

--- a/packages/cli/tests/cli-integration.test.ts
+++ b/packages/cli/tests/cli-integration.test.ts
@@ -310,6 +310,20 @@ describe("bench command", () => {
   });
 });
 
+describe("demo command", () => {
+  it("copies a public-safe sandbox and prints next steps", async () => {
+    await withTempDir(async (dir) => {
+      const targetDirectory = join(dir, "demo sandbox");
+      const result = await executeCli(["demo", "--dir", targetDirectory]);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain(targetDirectory);
+      expect(result.stdout).toContain("npm test");
+      expect(result.stdout).toContain("Task ideas live in");
+    });
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Help surface
 // ---------------------------------------------------------------------------
@@ -321,6 +335,7 @@ describe("help command", () => {
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
     expect(result.stdout).toContain("martin-loop run");
+    expect(result.stdout).toContain("martin-loop demo");
     expect(result.stdout).toContain("martin-loop inspect");
     expect(result.stdout).toContain("martin-loop resume");
   });

--- a/packages/cli/tests/cli.test.ts
+++ b/packages/cli/tests/cli.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -294,6 +294,98 @@ describe("executeCli", () => {
     expect(result.stdout).toBe("");
     expect(result.stderr).toContain("workspace-only RC surface");
     expect(result.stderr).toContain("@martin/benchmarks");
+  });
+
+  it("copies the seeded demo workspace into the default target directory", async () => {
+    const previousCwd = process.cwd();
+    const directory = await mkdtemp(join(tmpdir(), "martin-cli-demo-default-"));
+
+    try {
+      process.chdir(directory);
+
+      const result = await executeCli(["demo"]);
+      const targetDirectory = join(directory, "martin-loop-demo");
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain(targetDirectory);
+      expect(result.stdout).toContain("npm install");
+      expect(result.stdout).toContain("MARTIN_LIVE=false");
+      expect(await readFile(join(targetDirectory, "README.md"), "utf8")).toContain("Demo Sandbox");
+    } finally {
+      process.chdir(previousCwd);
+      await rm(directory, { force: true, recursive: true });
+    }
+  });
+
+  it("supports --dir for the demo sandbox target", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "martin-cli-demo-dir-"));
+    const targetDirectory = join(directory, "custom-demo");
+
+    try {
+      const result = await executeCli(["demo", "--dir", targetDirectory]);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain(targetDirectory);
+      expect(await readFile(join(targetDirectory, "package.json"), "utf8")).toContain(
+        "martin-loop-demo-sandbox"
+      );
+    } finally {
+      await rm(directory, { force: true, recursive: true });
+    }
+  });
+
+  it("refuses to overwrite a non-empty demo target without --force", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "martin-cli-demo-blocked-"));
+    const targetDirectory = join(directory, "existing demo");
+
+    try {
+      await mkdir(targetDirectory, { recursive: true });
+      await writeFile(join(targetDirectory, "keep.txt"), "do not replace", "utf8");
+
+      const result = await executeCli(["demo", "--dir", targetDirectory]);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain("already exists and is not empty");
+      expect(await readFile(join(targetDirectory, "keep.txt"), "utf8")).toBe("do not replace");
+    } finally {
+      await rm(directory, { force: true, recursive: true });
+    }
+  });
+
+  it("replaces a non-empty demo target when --force is provided", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "martin-cli-demo-force-"));
+    const targetDirectory = join(directory, "existing demo");
+
+    try {
+      await mkdir(targetDirectory, { recursive: true });
+      await writeFile(join(targetDirectory, "keep.txt"), "replace me", "utf8");
+
+      const result = await executeCli(["demo", "--dir", targetDirectory, "--force"]);
+
+      expect(result.exitCode).toBe(0);
+      await expect(readFile(join(targetDirectory, "keep.txt"), "utf8")).rejects.toThrow();
+      expect(await readFile(join(targetDirectory, "TASKS.md"), "utf8")).toContain("Optional live run");
+    } finally {
+      await rm(directory, { force: true, recursive: true });
+    }
+  });
+
+  it("handles demo target paths with spaces and prints the guided next steps", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "martin-cli-demo-spaces-"));
+    const targetDirectory = join(directory, "demo sandbox with spaces");
+
+    try {
+      const result = await executeCli(["demo", "--dir", targetDirectory]);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain(`cd ${targetDirectory}`);
+      expect(result.stdout).toContain("Optional live run");
+      expect(await readFile(join(targetDirectory, "martin.config.yaml"), "utf8")).toContain(
+        "strict_local"
+      );
+    } finally {
+      await rm(directory, { force: true, recursive: true });
+    }
   });
 
   it("inspects loop record files and returns a portfolio summary", async () => {

--- a/scripts/generate-release-notes.mjs
+++ b/scripts/generate-release-notes.mjs
@@ -1,0 +1,208 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const DEFAULT_CONFIG_PATH = path.join(SCRIPT_DIR, "release-notes.config.json");
+
+export async function loadReleaseNotesConfig(configPath = DEFAULT_CONFIG_PATH) {
+  return JSON.parse(await readFile(configPath, "utf8"));
+}
+
+export function parseSemverTag(tag) {
+  const match = /^v(\d+)\.(\d+)\.(\d+)$/u.exec(tag);
+  if (!match) {
+    return undefined;
+  }
+
+  return {
+    raw: tag,
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3])
+  };
+}
+
+export function compareSemverTags(left, right) {
+  if (left.major !== right.major) {
+    return left.major - right.major;
+  }
+  if (left.minor !== right.minor) {
+    return left.minor - right.minor;
+  }
+  return left.patch - right.patch;
+}
+
+export function resolvePreviousTag(tags, currentTag) {
+  const current = parseSemverTag(currentTag);
+  if (!current) {
+    return undefined;
+  }
+
+  return tags
+    .map((tag) => parseSemverTag(tag))
+    .filter((tag) => tag && compareSemverTags(tag, current) < 0)
+    .sort(compareSemverTags)
+    .at(-1)?.raw;
+}
+
+export async function generateReleaseNotes(options = {}) {
+  const rootDir = options.rootDir ?? path.resolve(SCRIPT_DIR, "..");
+  const config = options.config ?? await loadReleaseNotesConfig(options.configPath);
+  const currentTag = options.currentTag ?? process.env.GITHUB_REF_NAME ?? getExactHeadTag(rootDir);
+  const tags = listTags(rootDir);
+  const previousTag = options.previousTag ?? resolvePreviousTag(tags, currentTag);
+  const compareRange = previousTag ? `${previousTag}...${currentTag}` : undefined;
+  const compareUrl = previousTag
+    ? `https://github.com/${config.repo}/compare/${compareRange}`
+    : `https://github.com/${config.repo}/releases/tag/${currentTag}`;
+  const subjects = compareRange ? listCommitSubjects(rootDir, compareRange) : [];
+
+  const lines = [
+    `## What changed since ${previousTag ?? "the previous tag"}`,
+    ...renderSummary(subjects, currentTag, previousTag),
+    "",
+    "## Install or quick try",
+    "```sh",
+    config.installCommand,
+    config.quickTryCommand,
+    "```",
+    "",
+    "## Benchmark challenge",
+    `Try the public challenge: ${config.challengeUrl}`,
+    "",
+    "## GitHub discussions",
+    ...config.discussions.map((discussion) => `- [${discussion.title}](${discussion.url})`),
+    "",
+    "## Verification and provenance",
+    ...config.provenance.map((item) => `- ${item}`),
+    "",
+    `**Full Changelog**: ${compareUrl}`
+  ];
+
+  return {
+    currentTag,
+    previousTag,
+    compareRange,
+    compareUrl,
+    notes: `${lines.join("\n")}\n`
+  };
+}
+
+export async function writeReleaseNotesFile(options = {}) {
+  const result = await generateReleaseNotes(options);
+  if (!options.outputPath) {
+    return result;
+  }
+
+  await mkdir(path.dirname(options.outputPath), { recursive: true });
+  await writeFile(options.outputPath, result.notes, "utf8");
+  return result;
+}
+
+function renderSummary(subjects, currentTag, previousTag) {
+  if (subjects.length === 0) {
+    return [
+      `- This release refreshes the public MartinLoop package surface for ${currentTag}.`,
+      previousTag
+        ? `- Compare against ${previousTag} for the exact file-level delta.`
+        : "- This tag does not have an earlier semver tag to compare against in the current checkout."
+    ];
+  }
+
+  return subjects.slice(0, 8).map((subject) => `- ${subject}`);
+}
+
+function listTags(rootDir) {
+  const output = runGit(rootDir, ["tag", "--list"]);
+  return output
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function listCommitSubjects(rootDir, compareRange) {
+  const output = runGit(rootDir, ["log", "--pretty=format:%s", compareRange]);
+  return output
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function getExactHeadTag(rootDir) {
+  const tag = runGit(rootDir, ["describe", "--tags", "--exact-match"]).trim();
+  if (!tag) {
+    throw new Error("Unable to determine the current release tag. Pass --current-tag explicitly.");
+  }
+  return tag;
+}
+
+function runGit(rootDir, args) {
+  return execFileSync("git", args, {
+    cwd: rootDir,
+    encoding: "utf8"
+  });
+}
+
+function parseArgs(argv) {
+  const parsed = {};
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    const next = argv[index + 1];
+
+    switch (token) {
+      case "--current-tag":
+        parsed.currentTag = next;
+        index += 1;
+        break;
+      case "--previous-tag":
+        parsed.previousTag = next;
+        index += 1;
+        break;
+      case "--output":
+        parsed.outputPath = next;
+        index += 1;
+        break;
+      case "--config":
+        parsed.configPath = next;
+        index += 1;
+        break;
+      default:
+        break;
+    }
+  }
+
+  return parsed;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const result = await writeReleaseNotesFile({
+    rootDir: path.resolve(SCRIPT_DIR, ".."),
+    currentTag: args.currentTag,
+    previousTag: args.previousTag,
+    outputPath: args.outputPath,
+    configPath: args.configPath
+  });
+
+  if (!args.outputPath) {
+    process.stdout.write(result.notes);
+    return;
+  }
+
+  process.stdout.write(`Release notes written to ${args.outputPath}\n`);
+}
+
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : "";
+const modulePath = fileURLToPath(import.meta.url);
+if (invokedPath === path.resolve(modulePath)) {
+  main().catch((error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`Release notes generation failed: ${message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/public-facade-smoke.mjs
+++ b/scripts/public-facade-smoke.mjs
@@ -23,6 +23,9 @@ export function createPublicFacadeSmokePlan(options = {}) {
     cliSmoke: {
       description: "npx martin-loop --help resolves through the root public package facade.",
     },
+    demoSmoke: {
+      description: "npx martin-loop demo copies the packaged sandbox from a clean temp install.",
+    },
   };
 }
 
@@ -86,6 +89,15 @@ export async function runPublicFacadeSmoke(options = {}) {
       throw new Error(`Expected CLI help output to include "martin-loop run" or "Martin Loop CLI".\n${cliRun.stdout}${cliRun.stderr}`);
     }
 
+    const demoTarget = path.join(appDir, "martin-loop-demo");
+    const demoRun = await runCommand(["npx", "martin-loop", "demo", "--dir", demoTarget], {
+      cwd: appDir,
+    });
+    const demoReadme = await readFile(path.join(demoTarget, "README.md"), "utf8");
+    if (!demoRun.stdout.includes("MartinLoop demo sandbox created at") || !demoReadme.includes("Demo Sandbox")) {
+      throw new Error(`Expected demo command to copy the packaged sandbox.\n${demoRun.stdout}${demoRun.stderr}`);
+    }
+
     return {
       packageName: rootManifest.name,
       tarballPath,
@@ -97,6 +109,10 @@ export async function runPublicFacadeSmoke(options = {}) {
       cliSmoke: {
         ok: true,
         command: "npx martin-loop --help",
+      },
+      demoSmoke: {
+        ok: true,
+        command: "npx martin-loop demo --dir ./martin-loop-demo",
       },
     };
   } finally {

--- a/scripts/release-notes.config.json
+++ b/scripts/release-notes.config.json
@@ -1,0 +1,26 @@
+{
+  "repo": "Keesan12/martin-loop",
+  "installCommand": "npm install -g martin-loop",
+  "quickTryCommand": "npx martin-loop demo",
+  "challengeUrl": "https://github.com/Keesan12/martin-loop/blob/main/docs/distribution/UNDER-3-CHALLENGE.md",
+  "discussions": [
+    {
+      "title": "What should every AI coding agent run record include?",
+      "url": "https://github.com/Keesan12/martin-loop/discussions/26"
+    },
+    {
+      "title": "Should budget checks happen only at safe halt boundaries?",
+      "url": "https://github.com/Keesan12/martin-loop/discussions/27"
+    },
+    {
+      "title": "Where should the AI agent control layer live?",
+      "url": "https://github.com/Keesan12/martin-loop/discussions/28"
+    }
+  ],
+  "provenance": [
+    "npm publication runs before the GitHub release job and skips duplicate publishes when the tagged version already exists on npm.",
+    "Release assets are built from the tagged source and packed in CI before the release is published.",
+    "The public smoke path covers the root SDK import, CLI help, and the packaged `martin-loop demo` sandbox flow.",
+    "The benchmark challenge numbers stay tied to the public repo-backed benchmark story and reproduction commands."
+  ]
+}

--- a/scripts/tests/public-facade.test.mjs
+++ b/scripts/tests/public-facade.test.mjs
@@ -18,9 +18,10 @@ test("createPublicFacadeSmokePlan targets the frozen public package surface", ()
   assert.equal(plan.npxCommand, "npx martin-loop --help");
   assert.match(plan.sdkSmoke.description, /MartinLoop root import/i);
   assert.match(plan.cliSmoke.description, /npx martin-loop/i);
+  assert.match(plan.demoSmoke.description, /demo copies the packaged sandbox/i);
 });
 
-test("runPublicFacadeSmoke proves the root SDK import and CLI help work from a clean temp project", async () => {
+test("runPublicFacadeSmoke proves the root SDK import, CLI help, and demo sandbox work from a clean temp project", async () => {
   const result = await runPublicFacadeSmoke({ rootDir: ROOT_DIR });
 
   assert.equal(result.packageName, "martin-loop");
@@ -28,4 +29,6 @@ test("runPublicFacadeSmoke proves the root SDK import and CLI help work from a c
   assert.equal(result.sdkSmoke.exportName, "MartinLoop");
   assert.equal(result.cliSmoke.ok, true);
   assert.equal(result.cliSmoke.command, "npx martin-loop --help");
+  assert.equal(result.demoSmoke.ok, true);
+  assert.equal(result.demoSmoke.command, "npx martin-loop demo --dir ./martin-loop-demo");
 });

--- a/scripts/tests/release-notes.test.mjs
+++ b/scripts/tests/release-notes.test.mjs
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  generateReleaseNotes,
+  loadReleaseNotesConfig,
+  resolvePreviousTag
+} from "../generate-release-notes.mjs";
+
+const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+test("resolvePreviousTag finds the prior semver tag for a release", () => {
+  const previous = resolvePreviousTag(["v0.1.0", "v0.1.3", "v0.1.4", "v0.1.5", "v1.2.0"], "v0.1.4");
+  assert.equal(previous, "v0.1.3");
+});
+
+test("generateReleaseNotes renders the compare range, challenge link, and discussion links", async () => {
+  const config = await loadReleaseNotesConfig();
+  const result = await generateReleaseNotes({
+    rootDir: ROOT_DIR,
+    currentTag: "v0.1.4",
+    previousTag: "v0.1.3",
+    config
+  });
+
+  assert.equal(result.compareRange, "v0.1.3...v0.1.4");
+  assert.match(result.notes, /## What changed since v0\.1\.3/);
+  assert.match(result.notes, /https:\/\/github\.com\/Keesan12\/martin-loop\/blob\/main\/docs\/distribution\/UNDER-3-CHALLENGE\.md/);
+  assert.match(result.notes, /https:\/\/github\.com\/Keesan12\/martin-loop\/discussions\/26/);
+  assert.match(result.notes, /\*\*Full Changelog\*\*: https:\/\/github\.com\/Keesan12\/martin-loop\/compare\/v0\.1\.3\.\.\.v0\.1\.4/);
+});


### PR DESCRIPTION
## Summary
- add a public-safe \\martin-loop demo\\ sandbox and package it in the root npm facade
- add distribution docs plus automated release-note generation for future tagged releases
- extend public smoke coverage and refresh the live GitHub growth surfaces for discussions, topics, and v0.1.4 release notes

## Validation
- pnpm --filter @martin/cli test
- node --test scripts/tests/release-notes.test.mjs scripts/tests/public-facade.test.mjs
- pnpm build
- pnpm public:smoke
- pnpm test
- pnpm lint
- pnpm release:matrix:local