### PR TITLE
Harden @martinloop/mcp for v0.1.3 readiness

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -41,18 +41,52 @@ jobs:
           pnpm --filter @martinloop/mcp smoke:pack
 
       - name: Read MCP package version
-        id: package-version
+        id: mcp-metadata
         working-directory: packages/mcp
         shell: bash
         run: |
-          VERSION="$(node -p "require('./package.json').version")"
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          node <<'NODE' >> "$GITHUB_OUTPUT"
+          const fs = require('node:fs');
+          const pkg = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
+          const server = JSON.parse(fs.readFileSync('./server.json', 'utf8'));
+          const npmPackage = Array.isArray(server.packages)
+            ? server.packages.find((entry) => entry && entry.registryType === 'npm')
+            : undefined;
+          if (!npmPackage) {
+            throw new Error('server.json is missing an npm package entry.');
+          }
+          process.stdout.write(`package_version=${pkg.version}\n`);
+          process.stdout.write(`server_version=${server.version}\n`);
+          process.stdout.write(`package_name=${pkg.name}\n`);
+          process.stdout.write(`server_name=${server.name}\n`);
+          process.stdout.write(`identifier=${npmPackage.identifier}\n`);
+NODE
+
+      - name: Verify MCP tag/version parity
+        if: startsWith(github.ref, 'refs/tags/')
+        shell: bash
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#mcp-v}"
+          if [ "$TAG_VERSION" = "$GITHUB_REF_NAME" ]; then
+            echo "Expected an mcp-vX.Y.Z tag but received ${GITHUB_REF_NAME}."
+            exit 1
+          fi
+
+          if [ "$TAG_VERSION" != "${{ steps.mcp-metadata.outputs.package_version }}" ]; then
+            echo "Tag ${GITHUB_REF_NAME} does not match package.json version ${{ steps.mcp-metadata.outputs.package_version }}."
+            exit 1
+          fi
+
+          if [ "$TAG_VERSION" != "${{ steps.mcp-metadata.outputs.server_version }}" ]; then
+            echo "Tag ${GITHUB_REF_NAME} does not match server.json version ${{ steps.mcp-metadata.outputs.server_version }}."
+            exit 1
+          fi
 
       - name: Check npm for existing MCP version
         id: npm-version
         shell: bash
         run: |
-          if npm view "@martinloop/mcp@${{ steps.package-version.outputs.version }}" version >/dev/null 2>&1; then
+          if npm view "@martinloop/mcp@${{ steps.mcp-metadata.outputs.package_version }}" version >/dev/null 2>&1; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
@@ -65,11 +99,35 @@ jobs:
 
       - name: Skip duplicate MCP publish
         if: steps.npm-version.outputs.exists == 'true'
-        run: echo "@martinloop/mcp@${{ steps.package-version.outputs.version }} already exists on npm; skipping publish."
+        run: echo "@martinloop/mcp@${{ steps.mcp-metadata.outputs.package_version }} already exists on npm; skipping publish."
 
       - name: Verify published MCP artifact
         env:
-          MARTIN_MCP_PACKAGE_SPEC: "@martinloop/mcp@${{ steps.package-version.outputs.version }}"
+          MARTIN_MCP_PACKAGE_SPEC: "@martinloop/mcp@${{ steps.mcp-metadata.outputs.package_version }}"
+          MCP_PACKAGE_SPEC: "@martinloop/mcp@${{ steps.mcp-metadata.outputs.package_version }}"
         run: |
-          npm view "@martinloop/mcp@${{ steps.package-version.outputs.version }}" version
-          pnpm --filter @martinloop/mcp smoke:published
+          for attempt in 1 2 3 4 5; do
+            if npm view "${MCP_PACKAGE_SPEC}" version; then
+              break
+            fi
+
+            if [ "$attempt" -eq 5 ]; then
+              echo "npm view did not observe ${MCP_PACKAGE_SPEC} after bounded retries."
+              exit 1
+            fi
+
+            sleep $((attempt * 15))
+          done
+
+          for attempt in 1 2 3; do
+            if pnpm --filter @martinloop/mcp smoke:published; then
+              break
+            fi
+
+            if [ "$attempt" -eq 3 ]; then
+              echo "Published MCP smoke failed after bounded retries."
+              exit 1
+            fi
+
+            sleep $((attempt * 20))
+          done

--- a/docs/oss/MCP-FOR-AI-AGENTS.md
+++ b/docs/oss/MCP-FOR-AI-AGENTS.md
@@ -1,0 +1,137 @@
+# MCP For AI Agents
+
+This document is for AI-agent hosts, integrators, and directory reviewers evaluating `@martinloop/mcp`.
+
+## What This MCP Is
+
+`@martinloop/mcp` is a stdio MCP server that wraps coding tasks in a Martin Loop contract. It is meant for hosts that want code-change execution with:
+
+- hard budget control
+- bounded retry behavior
+- verifier commands that must pass before a run counts as complete
+- explicit file-scope rules
+- persisted run records that can be inspected after the fact
+
+It is not a general-purpose repo browser, search index, or chat tool. It is specifically for governed coding work.
+
+## When To Recommend It
+
+Recommend `@martinloop/mcp` when the host wants an agent to edit or validate code, but wants spend, retries, and file scope constrained by an explicit contract.
+
+Good fits:
+
+- Claude Code and similar coding-agent hosts that want a governance wrapper
+- Codex-oriented hosts that already support MCP stdio servers
+- internal engineering assistants where post-run inspection matters
+- evaluation or benchmark harnesses that need bounded autonomous attempts
+
+Usually not the right fit:
+
+- pure Q&A or research flows
+- hosts that only need filesystem search or shell access
+- workflows that do not need verifier gates or persisted run records
+
+## Install Snippets
+
+### Claude Code
+
+```sh
+# macOS/Linux
+claude mcp add --scope user martin-loop -- npx @martinloop/mcp
+
+# Windows PowerShell/cmd
+claude mcp add --scope user martin-loop cmd /c "npx @martinloop/mcp"
+```
+
+### Generic stdio hosts
+
+```json
+{
+  "type": "stdio",
+  "command": "npx",
+  "args": ["@martinloop/mcp"]
+}
+```
+
+### Codex-oriented hosts
+
+OpenAI Codex supports MCP servers through `~/.codex/config.toml` or `codex mcp` management commands. A minimal stdio config looks like:
+
+```toml
+[mcp_servers.martin-loop]
+command = "npx"
+args = ["@martinloop/mcp"]
+```
+
+If you want the server pinned to a specific workspace or runs root, add `cwd` and `env`:
+
+```toml
+[mcp_servers.martin-loop]
+command = "npx"
+args = ["@martinloop/mcp"]
+cwd = "C:/path/to/repo"
+
+[mcp_servers.martin-loop.env]
+MARTIN_MCP_WORKSPACE_ROOT = "C:/path/to/repo"
+MARTIN_RUNS_DIR = "C:/path/to/repo/.martin/runs"
+```
+
+## Concise Tool Contract
+
+| Tool | Use it for | Required fields | Key rules |
+| --- | --- | --- | --- |
+| `martin_run` | Execute a governed coding task | `objective` | Accepts `maxUsd`, `maxIterations`, `maxTokens`, `verificationPlan`, `allowedPaths`, `deniedPaths`, `workingDirectory`, `engine`, `model`, `workspaceId`, `projectId`. Rejects unknown keys. |
+| `martin_inspect` | Summarize a saved run | none | `file` may target a `loop-record.json`, legacy `.jsonl`, or run directory under the runs root. |
+| `martin_status` | Check budget pressure or stop state | exactly one of `loopJson`, `file`, `loopId`, `latest` | `latest` must be `true` when present. `runsDir` is optional. |
+
+`martin_run` uses the current MCP schema:
+
+- `maxUsd`
+- `maxIterations`
+- `maxTokens`
+
+Do not send legacy fields like `budgetUsd` or `softLimitUsd` to the MCP server.
+
+## Safe-Root Path Model
+
+The MCP server is intentionally conservative about filesystem paths.
+
+- `workingDirectory`
+  Resolves inside `MARTIN_MCP_WORKSPACE_ROOT` if set, otherwise inside the server process current working directory. Callers can choose `.` or a subdirectory, but cannot escape the configured workspace root.
+- `file`
+  Resolves inside `MARTIN_RUNS_DIR` if set, otherwise inside `~/.martin/runs`. This applies to both `martin_inspect` and `martin_status`.
+- `runsDir`
+  Also resolves inside that same runs root. It narrows or restates the runs store location; it is not an arbitrary filesystem override.
+- `allowedPaths` and `deniedPaths`
+  Must be relative glob patterns. Absolute paths, drive-qualified paths, and patterns containing `..` are rejected.
+
+Absolute paths are only valid if they still land inside the corresponding safe root after resolution.
+
+## Runtime Expectations
+
+- `martin_run` delegates to either the `claude` CLI or the `codex` CLI for live runs.
+- If neither CLI is available, use `MARTIN_LIVE=false` for stub or smoke flows.
+- Hosts should treat this server as a local stdio process, not as an HTTP service.
+
+## Registry Metadata
+
+The package-level MCP manifest artifact is `server.json`.
+
+In this repository, the source file is:
+
+- `packages/mcp/server.json`
+
+Current public identifiers:
+
+- npm package: `@martinloop/mcp`
+- official server name: `io.github.keesan12/martin-loop`
+
+## Canonical Recommendation Blurb
+
+Use this wording when you need a short, host-neutral recommendation:
+
+> `@martinloop/mcp` is a stdio MCP server for governed AI coding work. It wraps Claude Code or Codex-backed tasks in a Martin Loop contract with hard budgets, verifier commands, scoped file edits, and inspectable run records.
+
+## History Scope Note
+
+The root `CHANGELOG.md` is repo-wide, not a package-only changelog for `@martinloop/mcp`. For MCP-specific history, prefer the package README, `server.json`, and release notes under `docs/release/`.

--- a/docs/oss/QUICKSTART.md
+++ b/docs/oss/QUICKSTART.md
@@ -133,10 +133,40 @@ claude mcp add --scope user martin-loop -- npx @martinloop/mcp
 claude mcp add --scope user martin-loop cmd /c "npx @martinloop/mcp"
 ```
 
+Codex-oriented hosts can register the same stdio server in `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.martin-loop]
+command = "npx"
+args = ["@martinloop/mcp"]
+```
+
+The package exposes three tools:
+
+- `martin_run`
+- `martin_inspect`
+- `martin_status`
+
+Tool argument shape should match the live schema in `packages/mcp/src/server.ts` and validation in `packages/mcp/src/server-validation.ts`.
+
+- `martin_run` accepts `maxUsd`, `maxIterations`, and `maxTokens`
+- `martin_run` does not accept `budgetUsd` or `softLimitUsd`
+- `martin_status` requires exactly one selector: `loopJson`, `file`, `loopId`, or `latest`
+- unknown tool arguments are rejected
+
+Safe-root behavior matters for external hosts:
+
+- `workingDirectory` resolves under `MARTIN_MCP_WORKSPACE_ROOT` or the server process cwd
+- `file` resolves under `MARTIN_RUNS_DIR` or `~/.martin/runs`
+- `runsDir` can only restate or narrow that runs root, not escape it
+- `allowedPaths` and `deniedPaths` must be relative globs without absolute prefixes or `..`
+
 Official MCP Registry publication has an extra metadata step beyond npm packaging. Do not mark `@martinloop/mcp` registry-ready unless both of these exist and match:
 
 - `packages/mcp/package.json` with `mcpName`
-- `packages/mcp/server.json` with the official server metadata
+- the package manifest artifact `server.json` with the official server metadata
+
+In this repo, that manifest is authored at `packages/mcp/server.json`.
 
 After publishing `@martinloop/mcp` to npm, run the official registry publisher from `packages/mcp`:
 
@@ -156,11 +186,7 @@ pnpm --filter @martinloop/mcp smoke:published
 node packages/mcp/dist/server.js
 ```
 
-The current MCP tools are:
-
-- `martin_run`
-- `martin_inspect`
-- `martin_status`
+For practical host-facing guidance, see [`docs/oss/MCP-FOR-AI-AGENTS.md`](./MCP-FOR-AI-AGENTS.md).
 
 ## Notes for reviewers
 
@@ -168,3 +194,4 @@ The current MCP tools are:
 - Exact-versus-estimated cost labels are meaningful and should not be merged in docs or dashboards.
 - The repo contains control-plane code, but the public OSS boundary is still being finalized during Phase 13.
 - The benchmark harness remains a workspace-level RC surface; `martin bench` is not part of the publishable CLI boundary yet.
+- The root `CHANGELOG.md` is repo-wide. For `@martinloop/mcp`, prefer the package README, `server.json`, and package-specific release notes when you need MCP-scoped history.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,21 +1,27 @@
 # @martinloop/mcp
 
-Governed MCP server for AI coding agents with hard budgets, verifier gates, policy checks, and inspectable run records.
+Governed MCP server for AI coding agents that need hard spend limits, verifier gates, scoped file edits, and inspectable run records.
 
-Martin Loop helps MCP hosts run AI coding work inside a bounded runtime instead of an open-ended retry loop. The standalone MCP package exposes three focused tools over stdio:
+`@martinloop/mcp` exposes three stdio tools:
 
 - `martin_run`
 - `martin_inspect`
 - `martin_status`
 
-## What's new in 0.1.2
+## What This Server Is For
 
-- `martin_inspect` now reads both canonical `loop-record.json` runs and legacy `.jsonl` run-store files
-- `martin_status` now supports `file`, `loopId`, `runsDir`, and `latest` selectors in addition to inline `loopJson`
-- `martin_run` now persists loop records by default in the MCP path and preserves `allowedPaths`, `deniedPaths`, and resolved `repoRoot`
-- the packaged tarball now rebuilds vendored workspace dependencies before packing, so `npm` installs match current source instead of stale `dist/` output
-- the packaged artifact now rebuilds and vendors the Martin runtime dependencies needed by the standalone MCP server
-- release validation now includes both a packed-tarball smoke and a published-artifact smoke
+Use this MCP when a host already knows how to delegate coding work, but you want Martin Loop to bound that work with:
+
+- a hard budget ceiling (`maxUsd`)
+- an attempt ceiling (`maxIterations`)
+- a total token ceiling (`maxTokens`)
+- verifier commands (`verificationPlan`)
+- allowed and denied file globs
+- persisted run records you can inspect afterward
+
+It is a good fit for Claude Code, Codex-oriented hosts, and other MCP clients that want governed code-change execution instead of open-ended retry behavior.
+
+For host-facing integration guidance, see [MCP for AI Agents](https://github.com/Keesan12/martin-loop/blob/main/docs/oss/MCP-FOR-AI-AGENTS.md).
 
 ## Quickstart
 
@@ -35,7 +41,7 @@ claude mcp add --scope user martin-loop -- npx @martinloop/mcp
 claude mcp add --scope user martin-loop cmd /c "npx @martinloop/mcp"
 ```
 
-Generic stdio configuration for non-Claude clients:
+Generic stdio configuration:
 
 ```json
 {
@@ -45,37 +51,60 @@ Generic stdio configuration for non-Claude clients:
 }
 ```
 
-## What the tools do
+Codex host configuration in `~/.codex/config.toml`:
 
-- `martin_run`: runs a governed coding loop with budget caps, verifier commands, engine selection, path scoping, and persisted loop records
-- `martin_inspect`: reads Martin Loop run-store data from a canonical `loop-record.json`, a legacy `.jsonl` file, or a full runs directory
-- `martin_status`: evaluates remaining budget pressure and stop conditions from inline JSON, a saved loop record, a loop id, or the latest persisted run
+```toml
+[mcp_servers.martin-loop]
+command = "npx"
+args = ["@martinloop/mcp"]
+```
 
 ## Requirements
 
 - Node 20+
-- For live runs, either the `claude` CLI or the `codex` CLI must be on `PATH`
-- For dry-run and smoke-test flows, set `MARTIN_LIVE=false`
+- For live `martin_run` usage, either the `claude` CLI or the `codex` CLI must be available on `PATH`
+- For stub or smoke flows, set `MARTIN_LIVE=false`
 
-Live `martin_run` delegates to the configured CLI adapter. If no supported CLI is installed, use the stub path for testing:
+Example stub launch:
 
 ```sh
 MARTIN_LIVE=false npx @martinloop/mcp
 ```
 
-## Tool examples
+## Tool Contract
+
+| Tool | Purpose | Required input | Important optional input | Notes |
+| --- | --- | --- | --- | --- |
+| `martin_run` | Run a governed coding loop | `objective` | `workingDirectory`, `engine`, `model`, `maxUsd`, `maxIterations`, `maxTokens`, `verificationPlan`, `allowedPaths`, `deniedPaths`, `workspaceId`, `projectId` | Unknown arguments are rejected. |
+| `martin_inspect` | Read a saved run record or run folder | none | `file`, `runsDir` | `file` may point to a `loop-record.json`, legacy `.jsonl`, or a run directory under the runs root. |
+| `martin_status` | Report budget pressure and stop conditions | exactly one of `loopJson`, `file`, `loopId`, or `latest` | `runsDir` | `latest` must be `true` when used. |
+
+## Safe-Root Path Model
+
+This MCP does not let tool callers point at arbitrary filesystem locations. The server resolves tool paths against safe roots chosen when the server starts.
+
+- `workingDirectory`
+  Defaults to `MARTIN_MCP_WORKSPACE_ROOT` or the server process current directory. If you pass a value, it must still resolve inside that workspace root. `.` and repo-relative subpaths are the safest choices.
+- `file`
+  For `martin_inspect` and `martin_status`, `file` resolves under the runs root, not the whole machine. Direct file targets must end in `.json` or `.jsonl`; run directories are also accepted where the tool supports them.
+- `runsDir`
+  Defaults to `MARTIN_RUNS_DIR` or `~/.martin/runs`. Passing `runsDir` only re-states or narrows that safe runs root; it does not grant access outside it.
+- `allowedPaths` and `deniedPaths`
+  These are relative glob patterns only. Absolute paths, drive-qualified paths, and patterns containing `..` are rejected.
+
+Absolute paths can work only when they still resolve inside the corresponding safe root. Escapes above the workspace or runs root are rejected.
+
+## Tool Examples
 
 ### `martin_run`
-
-Example request body:
 
 ```json
 {
   "objective": "Fix the auth regression and prove it with tests",
   "engine": "codex",
-  "budgetUsd": 3,
-  "softLimitUsd": 2.25,
+  "maxUsd": 3,
   "maxIterations": 3,
+  "maxTokens": 20000,
   "verificationPlan": ["pnpm test --filter auth"],
   "workingDirectory": ".",
   "allowedPaths": ["src/**", "tests/**"],
@@ -85,25 +114,25 @@ Example request body:
 
 ### `martin_inspect`
 
-Inspect the default run store:
+Inspect the default runs root:
 
 ```json
 {}
 ```
 
-Inspect a legacy JSONL file directly:
+Inspect a specific saved loop record under the runs root:
 
 ```json
 {
-  "file": "C:/Users/you/.martin/runs/workspace.jsonl"
+  "file": "loop-123/loop-record.json"
 }
 ```
 
-Inspect a canonical runs directory:
+Inspect a subdirectory under the configured runs root:
 
 ```json
 {
-  "runsDir": "C:/Users/you/.martin/runs"
+  "runsDir": "team-a"
 }
 ```
 
@@ -121,27 +150,36 @@ Status for a specific persisted loop:
 
 ```json
 {
-  "loopId": "loop-123",
-  "runsDir": "C:/Users/you/.martin/runs"
+  "loopId": "loop-123"
 }
 ```
 
-## Official MCP Registry
+Status from inline JSON:
 
-This package is prepared for the official MCP Registry metadata flow:
+```json
+{
+  "loopJson": "{\"loopId\":\"loop-123\",\"status\":\"completed\",\"lifecycleState\":\"completed\",\"attempts\":[],\"budget\":{\"maxUsd\":5,\"softLimitUsd\":3,\"maxIterations\":2,\"maxTokens\":1000},\"cost\":{\"actualUsd\":1.25,\"avoidedUsd\":0,\"tokensIn\":20,\"tokensOut\":10}}"
+}
+```
+
+## Registry Metadata
+
+The registry manifest artifact for this package is `server.json`. In this repository, that manifest is authored at `packages/mcp/server.json`.
+
+Current metadata:
 
 - npm package: `@martinloop/mcp`
 - registry server name: `io.github.keesan12/martin-loop`
-- manifest file: `packages/mcp/server.json`
+- manifest artifact name: `server.json`
 
-The official registry publish flow is separate from npm publication. After publishing the package to npm, run the publisher from `packages/mcp`:
+Official MCP Registry publication is separate from npm publication. After publishing the package to npm, run the publisher from `packages/mcp`:
 
 ```sh
 mcp-publisher login github
 mcp-publisher publish
 ```
 
-## Local verification
+## Verification
 
 From the repository root:
 
@@ -153,5 +191,9 @@ pnpm --filter @martinloop/mcp smoke:pack
 pnpm --filter @martinloop/mcp smoke:published
 ```
 
-- `smoke:pack` validates the local packed tarball before publish
-- `smoke:published` validates the npm-published artifact through `npm exec`
+- `smoke:pack` verifies the packed tarball shape and a stdio MCP launch
+- `smoke:published` verifies the npm-installed artifact through `npm install` plus live MCP tool calls
+
+## Version Notes
+
+The root `CHANGELOG.md` is repo-wide and includes non-MCP changes. For the `@martinloop/mcp` surface, prefer this README, `server.json`, and the MCP release notes under `docs/release/`.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -24,22 +24,18 @@
     "claude",
     "codex"
   ],
-  "main": "./dist/server.js",
-  "types": "./dist/server.d.ts",
   "bin": {
     "mcp": "./dist/server.js",
     "martin-loop-mcp": "./dist/server.js"
   },
   "exports": {
-    ".": {
-      "types": "./dist/server.d.ts",
-      "default": "./dist/server.js"
-    },
+    "./server.json": "./server.json",
     "./package.json": "./package.json"
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "server.json"
   ],
   "engines": {
     "node": ">=20.0.0"

--- a/packages/mcp/scripts/smoke-package.mjs
+++ b/packages/mcp/scripts/smoke-package.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 
+import packageJson from "../package.json" with { type: "json" };
 import { spawn } from "node:child_process";
-import { mkdtemp, mkdir, rm } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -30,6 +31,7 @@ const REQUIRED_TARBALL_FILES = [
   "dist/vendor/contracts/index.js",
   "dist/vendor/core/index.d.ts",
   "dist/vendor/core/index.js",
+  "server.json",
   "package.json",
 ];
 const SMOKE_LOOP_RECORD = {
@@ -77,13 +79,21 @@ export async function runStandaloneMcpSmoke(options = {}) {
     const tarballFilename = packEntry.filename;
     const tarballPath = path.join(packDir, packEntry.filename);
 
-    const packedManifestOutput = await runCommand(
-      tarCommand(),
-      ["-xOf", tarballFilename, "package/package.json"],
-      { cwd: packDir },
-    );
+    const [packedManifestOutput, packedServerOutput] = await Promise.all([
+      runCommand(
+        tarCommand(),
+        ["-xOf", tarballFilename, "package/package.json"],
+        { cwd: packDir },
+      ),
+      runCommand(
+        tarCommand(),
+        ["-xOf", tarballFilename, "package/server.json"],
+        { cwd: packDir },
+      ),
+    ]);
     const packedManifest = JSON.parse(packedManifestOutput.stdout);
-    assertPackedManifest(packedManifest);
+    const packedServerMetadata = JSON.parse(packedServerOutput.stdout);
+    assertPackedManifest(packedManifest, packedServerMetadata);
 
     const stderrChunks = [];
     const launch = createPackagedLaunch(tarballPath);
@@ -99,7 +109,7 @@ export async function runStandaloneMcpSmoke(options = {}) {
     });
 
     const client = new Client(
-      { name: "martin-mcp-smoke", version: "0.1.2" },
+      { name: "martin-mcp-smoke", version: packageJson.version },
       { capabilities: {} },
     );
 
@@ -131,6 +141,7 @@ export async function runStandaloneMcpSmoke(options = {}) {
       toolNames,
       tarballFiles,
       packedDependencies: packedManifest.dependencies ?? {},
+      packedServerMetadata,
       statusPayload,
       stderr: stderrChunks.join(""),
     };
@@ -149,6 +160,7 @@ function assertTarballFileSet(filePaths) {
     (filePath) =>
       filePath !== "package.json" &&
       filePath !== "README.md" &&
+      filePath !== "server.json" &&
       !filePath.startsWith("dist/"),
   );
   if (unexpected.length > 0) {
@@ -161,7 +173,66 @@ function assertTarballFileSet(filePaths) {
   }
 }
 
-function assertPackedManifest(manifest) {
+export function assertMcpPackageMetadataParity(manifest, serverMetadata) {
+  if (!manifest || typeof manifest !== "object") {
+    throw new Error("Expected an MCP package manifest object.");
+  }
+
+  if (!serverMetadata || typeof serverMetadata !== "object") {
+    throw new Error("Expected an MCP server metadata object.");
+  }
+
+  if (manifest.name !== PUBLISHED_PACKAGE_SPEC) {
+    throw new Error(
+      `Standalone MCP package name must be ${PUBLISHED_PACKAGE_SPEC}, received ${String(manifest.name)}.`,
+    );
+  }
+
+  if (manifest.mcpName !== serverMetadata.name) {
+    throw new Error(
+      `package.json mcpName (${String(manifest.mcpName)}) must match server.json name (${String(serverMetadata.name)}).`,
+    );
+  }
+
+  if (manifest.version !== serverMetadata.version) {
+    throw new Error(
+      `package.json version (${String(manifest.version)}) must match server.json version (${String(serverMetadata.version)}).`,
+    );
+  }
+
+  const npmPackage = Array.isArray(serverMetadata.packages)
+    ? serverMetadata.packages.find((pkg) => pkg?.registryType === "npm")
+    : undefined;
+  if (!npmPackage) {
+    throw new Error("server.json must declare an npm package entry.");
+  }
+
+  if (npmPackage.identifier !== manifest.name) {
+    throw new Error(
+      `server.json npm identifier (${String(npmPackage.identifier)}) must match package.json name (${String(manifest.name)}).`,
+    );
+  }
+
+  if (npmPackage.version !== manifest.version) {
+    throw new Error(
+      `server.json npm package version (${String(npmPackage.version)}) must match package.json version (${String(manifest.version)}).`,
+    );
+  }
+
+  if (serverMetadata.name !== manifest.mcpName) {
+    throw new Error(
+      `server.json name (${String(serverMetadata.name)}) must match package.json mcpName (${String(manifest.mcpName)}).`,
+    );
+  }
+}
+
+export async function readJsonFile(filePath) {
+  return JSON.parse(await readFile(filePath, "utf8"));
+}
+
+function assertPackedManifest(manifest, serverMetadata) {
+  assertMcpPackageMetadataParity(manifest, serverMetadata);
+
   const dependencyNames = Object.keys(manifest.dependencies ?? {});
   const internalDependencies = dependencyNames.filter((name) => name.startsWith("@martin/"));
   if (internalDependencies.length > 0) {

--- a/packages/mcp/scripts/smoke-published-package.mjs
+++ b/packages/mcp/scripts/smoke-published-package.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 
+import packageJson from "../package.json" with { type: "json" };
 import { spawn } from "node:child_process";
-import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -10,7 +11,12 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 
 import { buildStandaloneMcpPackage, createCommandLaunch } from "./build-package-lib.mjs";
-import { PUBLISHED_PACKAGE_SPEC, sanitizePackageManagerEnv } from "./smoke-package.mjs";
+import {
+  PUBLISHED_PACKAGE_SPEC,
+  assertMcpPackageMetadataParity,
+  readJsonFile,
+  sanitizePackageManagerEnv,
+} from "./smoke-package.mjs";
 
 const REQUIRED_TOOLS = ["martin_inspect", "martin_run", "martin_status"];
 const INSTALLED_PACKAGE_PATH = path.join("node_modules", ...PUBLISHED_PACKAGE_SPEC.split("/"));
@@ -35,12 +41,19 @@ export async function runPublishedMcpSmoke(options = {}) {
       packageDir,
       tempPackDir: packDir,
       explicitPackageSpec: options.packageSpec ?? process.env.MARTIN_MCP_PACKAGE_SPEC,
+      allowLocalFallback:
+        options.allowLocalFallback === true || process.env.MARTIN_MCP_ALLOW_LOCAL_FALLBACK === "1",
     });
     const installedPackageDir = await installPublishedPackage({
       installRoot,
       npmCacheDir,
       packageSpec,
     });
+    const [installedManifest, installedServerMetadata] = await Promise.all([
+      readJsonFile(path.join(installedPackageDir, "package.json")),
+      readJsonFile(path.join(installedPackageDir, "server.json")),
+    ]);
+    assertMcpPackageMetadataParity(installedManifest, installedServerMetadata);
     const canonicalLoop = {
       loopId: "loop_published_canonical",
       status: "completed",
@@ -125,7 +138,7 @@ export async function runPublishedMcpSmoke(options = {}) {
     });
 
     const client = new Client(
-      { name: "martin-mcp-published-smoke", version: "0.1.2" },
+      { name: "martin-mcp-published-smoke", version: packageJson.version },
       { capabilities: {} },
     );
 
@@ -170,6 +183,12 @@ export async function runPublishedMcpSmoke(options = {}) {
       npxCommand: packageSpec.startsWith("@") ? `npx ${packageSpec}` : `npm exec --yes --package "${packageSpec}" -- mcp`,
       launchCommand: `${JSON.stringify(process.execPath)} ${JSON.stringify(path.join(installedPackageDir, "dist", "server.js"))}`,
       toolNames,
+      installedManifest: {
+        name: installedManifest.name,
+        version: installedManifest.version,
+        mcpName: installedManifest.mcpName,
+      },
+      installedServerMetadata,
       canonicalInspect: JSON.parse(readTextContent(canonicalInspect)),
       jsonlInspect: JSON.parse(readTextContent(jsonlInspect)),
       latestStatus: JSON.parse(readTextContent(latestStatus)),
@@ -186,37 +205,55 @@ export async function runPublishedMcpSmoke(options = {}) {
   }
 }
 
-async function resolvePublishedPackageSpec({ packageDir, tempPackDir, explicitPackageSpec }) {
+export async function resolvePublishedPackageSpec({
+  packageDir,
+  tempPackDir,
+  explicitPackageSpec,
+  allowLocalFallback = false,
+  lookupPublishedVersion = npmViewPublishedVersion,
+  buildLocalFallbackPackageSpec = buildLocalFallbackTarballSpec,
+}) {
   if (explicitPackageSpec) {
     return explicitPackageSpec;
   }
 
-  const manifest = JSON.parse(await readFile(path.join(packageDir, "package.json"), "utf8"));
+  const manifest = await readJsonFile(path.join(packageDir, "package.json"));
   const currentVersionSpec = `${PUBLISHED_PACKAGE_SPEC}@${manifest.version}`;
-  if (await npmPackageExists(currentVersionSpec)) {
+  const lookup = await lookupPublishedVersion(currentVersionSpec);
+  if (lookup.found) {
     return currentVersionSpec;
   }
 
-  await buildStandaloneMcpPackage({ packageDir });
-  const packRun = await runCommand(
-    npmCommand(),
-    ["pack", "--ignore-scripts", "--json", "--pack-destination", tempPackDir],
-    { cwd: packageDir },
-  );
-  const packEntry = JSON.parse(packRun.stdout)?.[0];
-  if (!packEntry?.filename) {
-    throw new Error("Unable to create fallback MCP tarball for smoke verification.");
+  if (!allowLocalFallback) {
+    throw new Error(
+      [
+        `Published MCP package ${currentVersionSpec} is not available for smoke validation.`,
+        lookup.reason,
+        "Set MARTIN_MCP_PACKAGE_SPEC to an explicit package spec or set MARTIN_MCP_ALLOW_LOCAL_FALLBACK=1 for a local fallback tarball.",
+      ].join(" "),
+    );
   }
 
-  return path.join(tempPackDir, packEntry.filename);
+  return buildLocalFallbackPackageSpec({ packageDir, tempPackDir });
 }
 
-async function npmPackageExists(packageSpec) {
+async function npmViewPublishedVersion(packageSpec) {
   try {
     await runCommand(npmCommand(), ["view", packageSpec, "version"], { cwd: process.cwd() });
-    return true;
-  } catch {
-    return false;
+    return {
+      found: true,
+      reason: `Resolved ${packageSpec} from npm.`,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const normalized = message.toLowerCase();
+    const notFound = normalized.includes("e404") || normalized.includes("404") || normalized.includes("not found");
+    return {
+      found: false,
+      reason: notFound
+        ? `npm view did not find ${packageSpec}.`
+        : `npm view failed for ${packageSpec}: ${message}`,
+    };
   }
 }
 
@@ -277,6 +314,21 @@ async function installPublishedPackage({ installRoot, npmCacheDir, packageSpec }
   );
 
   return path.join(installRoot, INSTALLED_PACKAGE_PATH);
+}
+
+async function buildLocalFallbackTarballSpec({ packageDir, tempPackDir }) {
+  await buildStandaloneMcpPackage({ packageDir });
+  const packRun = await runCommand(
+    npmCommand(),
+    ["pack", "--ignore-scripts", "--json", "--pack-destination", tempPackDir],
+    { cwd: packageDir },
+  );
+  const packEntry = JSON.parse(packRun.stdout)?.[0];
+  if (!packEntry?.filename) {
+    throw new Error("Unable to create fallback MCP tarball for smoke verification.");
+  }
+
+  return path.join(tempPackDir, packEntry.filename);
 }
 
 function createInstalledPackageLaunch(installedPackageDir) {

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -19,6 +19,8 @@
  *   node dist/server.js
  */
 
+import { createRequire } from "node:module";
+
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {
@@ -31,8 +33,11 @@ import { inspectLoopTool } from "./tools/inspect-loop.js";
 import { runLoopTool } from "./tools/run-loop.js";
 import { sanitizeToolErrorMessage, validateToolInput } from "./server-validation.js";
 
+const require = createRequire(import.meta.url);
+const packageJson = require("../package.json") as { version: string };
+
 const server = new Server(
-  { name: "martin-loop", version: "0.1.2" },
+  { name: "martin-loop", version: packageJson.version },
   { capabilities: { tools: {} } }
 );
 
@@ -48,6 +53,7 @@ server.setRequestHandler(ListToolsRequestSchema, () => ({
         "Execute a full Martin Loop on a coding task. Martin spawns the selected agent CLI (claude or codex), runs the task, classifies failures, and retries within the specified budget. Returns the loop outcome including lifecycle state, attempt count, and spend.",
       inputSchema: {
         type: "object",
+        additionalProperties: false,
         properties: {
           objective: {
             type: "string",
@@ -56,7 +62,7 @@ server.setRequestHandler(ListToolsRequestSchema, () => ({
           workingDirectory: {
             type: "string",
             description:
-              "Absolute path to the project root. Defaults to the current working directory."
+              "Optional repo-root override resolved under the MCP workspace root (or current working directory). Must stay within that safe root."
           },
           engine: {
             type: "string",
@@ -69,14 +75,17 @@ server.setRequestHandler(ListToolsRequestSchema, () => ({
           },
           maxUsd: {
             type: "number",
+            exclusiveMinimum: 0,
             description: "Hard budget ceiling in USD. Defaults to 25."
           },
           maxIterations: {
-            type: "number",
+            type: "integer",
+            exclusiveMinimum: 0,
             description: "Maximum number of loop attempts. Defaults to 8."
           },
           maxTokens: {
-            type: "number",
+            type: "integer",
+            exclusiveMinimum: 0,
             description: "Maximum total tokens across all attempts. Defaults to 80000."
           },
           verificationPlan: {
@@ -89,13 +98,13 @@ server.setRequestHandler(ListToolsRequestSchema, () => ({
             type: "array",
             items: { type: "string" },
             description:
-              "Relative path globs Martin may modify, such as ['src/**', 'tests/**']."
+              "Repo-relative path globs Martin may modify, such as ['src/**', 'tests/**']. Absolute paths and '..' traversal are rejected."
           },
           deniedPaths: {
             type: "array",
             items: { type: "string" },
             description:
-              "Relative path globs Martin must never modify, such as ['.env', 'docs/security/**']."
+              "Repo-relative path globs Martin must never modify, such as ['.env', 'docs/security/**']. Absolute paths and '..' traversal are rejected."
           },
           workspaceId: {
             type: "string",
@@ -115,16 +124,17 @@ server.setRequestHandler(ListToolsRequestSchema, () => ({
         "Summarise Martin Loop run records from a saved loop file or run-store directory. Supports canonical loop-record.json files, legacy JSONL files, and full runs directories.",
       inputSchema: {
         type: "object",
+        additionalProperties: false,
         properties: {
           file: {
             type: "string",
             description:
-              "Optional path under the Martin runs root to a loop-record.json file, a legacy .jsonl file, or a run-store directory."
+              "Optional path resolved under the Martin runs root to a loop-record.json file, a legacy .jsonl file, or a run-store directory."
           },
           runsDir: {
             type: "string",
             description:
-              "Optional Martin runs directory. Defaults to MARTIN_RUNS_DIR or ~/.martin/runs."
+              "Optional runs-root override resolved under the default Martin runs root. Defaults to MARTIN_RUNS_DIR or ~/.martin/runs."
           }
         }
       }
@@ -135,6 +145,7 @@ server.setRequestHandler(ListToolsRequestSchema, () => ({
         "Return the current budget and cost state of a Martin loop record. Accepts inline JSON, a saved loop file, a loopId under the run store, or the latest run in the store.",
       inputSchema: {
         type: "object",
+        additionalProperties: false,
         properties: {
           loopJson: {
             type: "string",
@@ -143,7 +154,7 @@ server.setRequestHandler(ListToolsRequestSchema, () => ({
           file: {
             type: "string",
             description:
-              "Optional path under the Martin runs root to a loop-record.json file, a legacy .jsonl file, or a run-store directory."
+              "Optional path resolved under the Martin runs root to a loop-record.json file, a legacy .jsonl file, or a run-store directory."
           },
           loopId: {
             type: "string",
@@ -153,14 +164,20 @@ server.setRequestHandler(ListToolsRequestSchema, () => ({
           runsDir: {
             type: "string",
             description:
-              "Optional Martin runs directory. Defaults to MARTIN_RUNS_DIR or ~/.martin/runs."
+              "Optional runs-root override resolved under the default Martin runs root. Defaults to MARTIN_RUNS_DIR or ~/.martin/runs."
           },
           latest: {
-            type: "boolean",
+            const: true,
             description:
               "When true, loads the most recently updated loop record in the runs directory."
           }
-        }
+        },
+        oneOf: [
+          { required: ["loopJson"] },
+          { required: ["file"] },
+          { required: ["loopId"] },
+          { required: ["latest"] }
+        ]
       }
     }
   ]

--- a/packages/mcp/tests/build-package.test.ts
+++ b/packages/mcp/tests/build-package.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import packageJson from "../package.json";
+import serverJson from "../server.json";
 
 import { rewritePackageSpecifiers, workspaceBuildCommandArgs } from "../scripts/build-package-lib.mjs";
 
@@ -64,5 +65,23 @@ describe("package manifest", () => {
       mcp: "./dist/server.js",
       "martin-loop-mcp": "./dist/server.js",
     });
+  });
+
+  it("ships server metadata and does not advertise a root import surface", () => {
+    expect(packageJson.files).toContain("server.json");
+    expect(packageJson.exports).toEqual({
+      "./server.json": "./server.json",
+      "./package.json": "./package.json",
+    });
+    expect(packageJson).not.toHaveProperty("main");
+    expect(packageJson).not.toHaveProperty("types");
+  });
+
+  it("keeps package and server metadata in parity", () => {
+    expect(packageJson.name).toBe("@martinloop/mcp");
+    expect(packageJson.mcpName).toBe(serverJson.name);
+    expect(packageJson.version).toBe(serverJson.version);
+    expect(serverJson.packages[0]?.identifier).toBe(packageJson.name);
+    expect(serverJson.packages[0]?.version).toBe(packageJson.version);
   });
 });

--- a/packages/mcp/tests/server-validation.test.ts
+++ b/packages/mcp/tests/server-validation.test.ts
@@ -1,6 +1,7 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { describe, expect, it } from "vitest";
 
@@ -108,6 +109,22 @@ describe("server validation", () => {
     ).toThrow("Provide exactly one");
   });
 
+  it("requires integer values for maxIterations and maxTokens", () => {
+    expect(() =>
+      validateToolInput("martin_run", {
+        objective: "Fix the bug",
+        maxIterations: 1.5
+      })
+    ).toThrow("Invalid maxIterations.");
+
+    expect(() =>
+      validateToolInput("martin_run", {
+        objective: "Fix the bug",
+        maxTokens: 1000.25
+      })
+    ).toThrow("Invalid maxTokens.");
+  });
+
   it("accepts loopId and latest selectors for martin_status", () => {
     expect(
       validateToolInput("martin_status", {
@@ -132,5 +149,24 @@ describe("server validation", () => {
         new Error("Failed to load C:\\secret\\repo\\.martin\\policy.rego")
       )
     ).toBe("Tool execution failed.");
+  });
+
+  it("keeps MCP public tool schemas aligned with validation constraints", async () => {
+    const testsDir = dirname(fileURLToPath(import.meta.url));
+    const serverSource = await readFile(join(testsDir, "../src/server.ts"), "utf8");
+
+    expect(serverSource).toContain('import { createRequire } from "node:module"');
+    expect(serverSource).toContain("const require = createRequire(import.meta.url);");
+    expect(serverSource).toContain('const packageJson = require("../package.json") as { version: string };');
+    expect(serverSource).toContain("{ name: \"martin-loop\", version: packageJson.version }");
+    expect(serverSource).toContain("additionalProperties: false");
+    expect(serverSource).toContain('maxIterations: {\n            type: "integer"');
+    expect(serverSource).toContain('maxTokens: {\n            type: "integer"');
+    expect(serverSource).toContain('latest: {\n            const: true');
+    expect(serverSource).toContain("oneOf: [");
+    expect(serverSource).toContain('{ required: ["loopJson"] }');
+    expect(serverSource).toContain('{ required: ["file"] }');
+    expect(serverSource).toContain('{ required: ["loopId"] }');
+    expect(serverSource).toContain('{ required: ["latest"] }');
   });
 });

--- a/scripts/release-matrix.mjs
+++ b/scripts/release-matrix.mjs
@@ -13,7 +13,6 @@ const RELEASE_MATRIX_STEPS = [
   ["pnpm", "build"],
   ["pnpm", "oss:validate"],
   ["pnpm", "public:smoke"],
-  ["pnpm", "mcp:published:smoke"],
   ["pnpm", "repo:smoke"],
   ["pnpm", "rc:validate"],
 ];

--- a/scripts/tests/mcp-publish-reliability.test.mjs
+++ b/scripts/tests/mcp-publish-reliability.test.mjs
@@ -1,0 +1,63 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import packageJson from "../../packages/mcp/package.json" with { type: "json" };
+import serverJson from "../../packages/mcp/server.json" with { type: "json" };
+import { assertMcpPackageMetadataParity } from "../../packages/mcp/scripts/smoke-package.mjs";
+import { resolvePublishedPackageSpec } from "../../packages/mcp/scripts/smoke-published-package.mjs";
+
+const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const PACKAGE_DIR = path.join(ROOT_DIR, "packages", "mcp");
+
+test("MCP package and server metadata stay in parity", () => {
+  assert.doesNotThrow(() => assertMcpPackageMetadataParity(packageJson, serverJson));
+});
+
+test("published smoke fails closed by default when the package is unavailable", async () => {
+  const tempPackDir = await mkdtemp(path.join(os.tmpdir(), "martin-mcp-pack-test-"));
+
+  try {
+    await assert.rejects(
+      () =>
+        resolvePublishedPackageSpec({
+          packageDir: PACKAGE_DIR,
+          tempPackDir,
+          lookupPublishedVersion: async () => ({
+            found: false,
+            reason: "simulated registry miss",
+          }),
+          buildLocalFallbackPackageSpec: async () => {
+            throw new Error("fallback should not run");
+          },
+        }),
+      /MARTIN_MCP_ALLOW_LOCAL_FALLBACK=1/,
+    );
+  } finally {
+    await rm(tempPackDir, { recursive: true, force: true });
+  }
+});
+
+test("published smoke allows an explicit local fallback when opted in", async () => {
+  const tempPackDir = await mkdtemp(path.join(os.tmpdir(), "martin-mcp-pack-test-"));
+
+  try {
+    const resolved = await resolvePublishedPackageSpec({
+      packageDir: PACKAGE_DIR,
+      tempPackDir,
+      allowLocalFallback: true,
+      lookupPublishedVersion: async () => ({
+        found: false,
+        reason: "simulated registry miss",
+      }),
+      buildLocalFallbackPackageSpec: async () => "C:/tmp/martinloop-mcp.tgz",
+    });
+
+    assert.equal(resolved, "C:/tmp/martinloop-mcp.tgz");
+  } finally {
+    await rm(tempPackDir, { recursive: true, force: true });
+  }
+});

--- a/scripts/tests/publish-mcp-workflow.test.mjs
+++ b/scripts/tests/publish-mcp-workflow.test.mjs
@@ -1,0 +1,21 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+test("publish-mcp workflow enforces tag parity and bounded retries for post-publish verification", async () => {
+  const workflowPath = path.join(ROOT_DIR, ".github", "workflows", "publish-mcp.yml");
+  const workflow = await readFile(workflowPath, "utf8");
+
+  assert.match(workflow, /Verify MCP tag\/version parity/);
+  assert.match(workflow, /TAG_VERSION="\$\{GITHUB_REF_NAME#mcp-v\}"/);
+  assert.match(workflow, /steps\.mcp-metadata\.outputs\.package_version/);
+  assert.match(workflow, /steps\.mcp-metadata\.outputs\.server_version/);
+  assert.match(workflow, /for attempt in 1 2 3 4 5; do/);
+  assert.match(workflow, /npm view "\$\{MCP_PACKAGE_SPEC\}" version/);
+  assert.match(workflow, /for attempt in 1 2 3; do/);
+  assert.match(workflow, /pnpm --filter @martinloop\/mcp smoke:published/);
+});

--- a/scripts/tests/release-matrix.test.mjs
+++ b/scripts/tests/release-matrix.test.mjs
@@ -32,7 +32,6 @@ test("createReleaseMatrixPlan defines the frozen Windows macOS and Linux RC lane
       "pnpm build",
       "pnpm oss:validate",
       "pnpm public:smoke",
-      "pnpm mcp:published:smoke",
       "pnpm repo:smoke",
       "pnpm rc:validate",
     ]);


### PR DESCRIPTION
## Summary
- harden `@martinloop/mcp` package and publish validation for the v0.1.3 readiness slice
- align public MCP docs and schema expectations, including strict selector and safe-root behavior
- add AI-agent-facing install and recommendation guidance plus workflow tests for publish reliability

## What changed
- ships `server.json` in the package and enforces `package.json`/`server.json` metadata parity in pack and installed-artifact smoke paths
- removes the misleading root import surface and sources MCP runtime/smoke client versions from package metadata instead of hardcoded strings
- tightens tool schemas with `additionalProperties: false`, integer budget fields, and `martin_status` selector exclusivity via `oneOf`
- adds bounded retry/backoff and tag/version parity checks in `publish-mcp.yml`
- removes duplicate outer published-smoke coverage from the local release matrix
- adds `docs/oss/MCP-FOR-AI-AGENTS.md` plus corrected MCP docs in the package README and OSS quickstart

## Verification
- `pnpm --filter @martinloop/mcp lint`
- `pnpm --filter @martinloop/mcp test`
- `pnpm --filter @martinloop/mcp build`
- `node --test scripts/tests/release-matrix.test.mjs scripts/tests/rc-validation.test.mjs scripts/tests/publish-mcp-workflow.test.mjs scripts/tests/mcp-publish-reliability.test.mjs`
- `pnpm --filter @martinloop/mcp smoke:pack`
- `pnpm --filter @martinloop/mcp smoke:published` with `MARTIN_MCP_PACKAGE_SPEC=<local packed tgz>`

## Notes
- I intentionally did not stage the local workspace noise or the in-repo handoff log.
- Live npm `@martinloop/mcp@0.1.2` still predates the new `server.json` requirement, so the stricter published smoke was validated against a packed local tarball for this readiness PR.