### PR TITLE
fix(mcp): separate release and published smoke

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "public:smoke": "node ./scripts/public-facade-smoke.mjs",
     "mcp:pack:smoke": "pnpm --filter @martinloop/mcp smoke:pack",
     "mcp:published:smoke": "pnpm --filter @martinloop/mcp smoke:published",
+    "mcp:published:smoke:pack": "pnpm --filter @martinloop/mcp smoke:published:pack",
     "rc:validate": "node ./scripts/rc-validation.mjs",
     "rc:validate:install": "node ./scripts/rc-validation.mjs --install",
     "release:matrix:local": "node ./scripts/release-matrix.mjs",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -48,6 +48,7 @@
     "prepack": "pnpm build",
     "smoke:pack": "node ./scripts/smoke-package.mjs",
     "smoke:published": "node ./scripts/smoke-published-package.mjs",
+    "smoke:published:pack": "node ./scripts/smoke-published-package.mjs --package-spec=pack",
     "test": "vitest run",
     "lint": "tsc -p tsconfig.json --noEmit",
     "start": "node dist/server.js"

--- a/packages/mcp/scripts/smoke-published-package.mjs
+++ b/packages/mcp/scripts/smoke-published-package.mjs
@@ -228,6 +228,9 @@ export async function resolvePublishedPackageSpec({
   buildLocalFallbackPackageSpec = buildLocalFallbackTarballSpec,
 }) {
   if (explicitPackageSpec) {
+    if (explicitPackageSpec === "__BUILD_LOCAL_PACK__") {
+      return buildLocalFallbackPackageSpec({ packageDir, tempPackDir });
+    }
     return explicitPackageSpec;
   }
 
@@ -385,8 +388,57 @@ function sleep(ms) {
 }
 
 async function main() {
-  const result = await runPublishedMcpSmoke();
+  const cliOptions = parseCliOptions(process.argv.slice(2));
+  const result = await runPublishedMcpSmoke(cliOptions);
   process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+
+function parseCliOptions(argv) {
+  const options = {};
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+
+    if (argument === "--allow-local-fallback") {
+      options.allowLocalFallback = true;
+      continue;
+    }
+
+    if (argument === "--package-spec") {
+      const next = argv[index + 1];
+      if (!next) {
+        throw new Error("--package-spec requires a value.");
+      }
+      options.packageSpec = parsePackageSpecValue(next);
+      index += 1;
+      continue;
+    }
+
+    if (argument.startsWith("--package-spec=")) {
+      options.packageSpec = parsePackageSpecValue(argument.slice("--package-spec=".length));
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${argument}`);
+  }
+
+  return options;
+}
+
+function parsePackageSpecValue(value) {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error("--package-spec requires a non-empty value.");
+  }
+
+  if (value.startsWith("--")) {
+    throw new Error(`--package-spec expected a package spec but received another flag: ${value}`);
+  }
+
+  if (value === "pack") {
+    return "__BUILD_LOCAL_PACK__";
+  }
+
+  return value;
 }
 
 const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : "";

--- a/scripts/rc-validation.mjs
+++ b/scripts/rc-validation.mjs
@@ -12,7 +12,7 @@ const RC_VALIDATION_STEPS = [
   ["pnpm", "oss:validate"],
   ["pnpm", "public:smoke"],
   ["pnpm", "--filter", "@martinloop/mcp", "smoke:pack"],
-  ["pnpm", "mcp:published:smoke"],
+  ["pnpm", "mcp:published:smoke:pack"],
 ];
 
 export function createRcValidationPlan(options = {}) {

--- a/scripts/release-matrix.mjs
+++ b/scripts/release-matrix.mjs
@@ -15,7 +15,7 @@ const RELEASE_MATRIX_STEPS = [
   ["pnpm", "oss:validate"],
   ["pnpm", "public:smoke"],
   ["pnpm", "--filter", "@martinloop/mcp", "smoke:pack"],
-  ["pnpm", "mcp:published:smoke"],
+  ["pnpm", "mcp:published:smoke:pack"],
 ];
 
 const RELEASE_MATRIX_LANES = [

--- a/scripts/tests/mcp-publish-reliability.test.mjs
+++ b/scripts/tests/mcp-publish-reliability.test.mjs
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -31,4 +32,26 @@ test("publish-mcp workflow keeps bounded npm view and smoke retries with backoff
   assert.match(workflow, /pnpm --filter @martinloop\/mcp smoke:published/);
   assert.match(workflow, /sleep \$\(\(attempt \* 20\)\)/);
   assert.match(workflow, /after bounded retries/);
+});
+
+test("published smoke CLI rejects missing or flag-like package specs", () => {
+  const scriptPath = path.join(ROOT_DIR, "packages", "mcp", "scripts", "smoke-published-package.mjs");
+
+  const missingValue = spawnSync(process.execPath, [scriptPath, "--package-spec="], {
+    cwd: ROOT_DIR,
+    encoding: "utf8",
+  });
+  assert.notEqual(missingValue.status, 0);
+  assert.match(missingValue.stderr, /--package-spec requires a non-empty value/);
+
+  const flagValue = spawnSync(
+    process.execPath,
+    [scriptPath, "--package-spec", "--allow-local-fallback"],
+    {
+      cwd: ROOT_DIR,
+      encoding: "utf8",
+    },
+  );
+  assert.notEqual(flagValue.status, 0);
+  assert.match(flagValue.stderr, /expected a package spec but received another flag/);
 });

--- a/scripts/tests/rc-validation.test.mjs
+++ b/scripts/tests/rc-validation.test.mjs
@@ -18,7 +18,7 @@ test("createRcValidationPlan omits install by default and includes the OSS-safe 
   assert.ok(commands.includes("pnpm oss:validate"));
   assert.ok(commands.includes("pnpm public:smoke"));
   assert.ok(commands.includes("pnpm --filter @martinloop/mcp smoke:pack"));
-  assert.equal(commands.at(-1), "pnpm mcp:published:smoke");
+  assert.equal(commands.at(-1), "pnpm mcp:published:smoke:pack");
   assert.ok(!commands.includes("pnpm install --frozen-lockfile"));
 });
 

--- a/scripts/tests/release-matrix.test.mjs
+++ b/scripts/tests/release-matrix.test.mjs
@@ -34,7 +34,7 @@ test("createReleaseMatrixPlan defines the Windows macOS and Linux OSS-safe relea
       "pnpm oss:validate",
       "pnpm public:smoke",
       "pnpm --filter @martinloop/mcp smoke:pack",
-      "pnpm mcp:published:smoke",
+      "pnpm mcp:published:smoke:pack",
     ]);
   }
 });


### PR DESCRIPTION
## Summary
- fix the red post-merge regression from #37 by separating pre-release packaged-artifact smoke from post-publish live npm smoke
- keep publish-mcp verifying the real npm artifact after publish, while elease-matrix and c-validation validate a freshly packed local MCP tarball explicitly
- harden CLI parsing for --package-spec and add regression coverage for invalid values

## Why
The merged readiness work made smoke:published fail closed when the installed artifact is missing server.json, which is correct for post-publish verification. But main still ran that live-npm smoke in the pre-release matrix, so all three lanes failed against the currently published @martinloop/mcp@0.1.2 artifact before 