### PR TITLE
test(mcp): isolate run-store temp roots

### DIFF
--- a/packages/mcp/tests/mcp-tools.test.ts
+++ b/packages/mcp/tests/mcp-tools.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -41,9 +41,8 @@ function makeLoopRecord(overrides: { costUsd?: number; avoidedUsd?: number } = {
 
 async function withRunsRoot<T>(fn: (runsRoot: string) => Promise<T>): Promise<T> {
   const previousRunsRoot = process.env.MARTIN_RUNS_DIR;
-  const runsRoot = join(tmpdir(), `martin-mcp-runs-${Date.now()}`);
+  const runsRoot = await mkdtemp(join(tmpdir(), "martin-mcp-runs-"));
   process.env.MARTIN_RUNS_DIR = runsRoot;
-  await mkdir(runsRoot, { recursive: true });
   try {
     return await fn(runsRoot);
   } finally {
@@ -52,6 +51,8 @@ async function withRunsRoot<T>(fn: (runsRoot: string) => Promise<T>): Promise<T>
     } else {
       process.env.MARTIN_RUNS_DIR = previousRunsRoot;
     }
+
+    await rm(runsRoot, { recursive: true, force: true }).catch(() => {});
   }
 }
 

--- a/packages/mcp/tests/server-validation.test.ts
+++ b/packages/mcp/tests/server-validation.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -9,6 +9,24 @@ import {
   sanitizeToolErrorMessage,
   validateToolInput
 } from "../src/server-validation.js";
+
+async function withValidationRunsRoot<T>(fn: (runsRoot: string) => Promise<T>): Promise<T> {
+  const previousRunsRoot = process.env.MARTIN_RUNS_DIR;
+  const runsRoot = await mkdtemp(join(tmpdir(), "martin-mcp-validation-runs-"));
+  process.env.MARTIN_RUNS_DIR = runsRoot;
+
+  try {
+    return await fn(runsRoot);
+  } finally {
+    if (previousRunsRoot === undefined) {
+      delete process.env.MARTIN_RUNS_DIR;
+    } else {
+      process.env.MARTIN_RUNS_DIR = previousRunsRoot;
+    }
+
+    await rm(runsRoot, { recursive: true, force: true }).catch(() => {});
+  }
+}
 
 describe("server validation", () => {
   it("rejects hidden martin_run fields that are not part of the public schema", () => {
@@ -37,31 +55,20 @@ describe("server validation", () => {
   });
 
   it("rejects inspect paths that escape the Martin run store", () => {
-    const previousRunsRoot = process.env.MARTIN_RUNS_DIR;
-    process.env.MARTIN_RUNS_DIR = join(tmpdir(), `martin-mcp-validation-runs-${Date.now()}`);
-    try {
+    return withValidationRunsRoot(async () => {
       expect(() =>
         validateToolInput("martin_inspect", {
           file: "..\\..\\outside.jsonl"
         })
       ).toThrow("Invalid file.");
-    } finally {
-      if (previousRunsRoot === undefined) {
-        delete process.env.MARTIN_RUNS_DIR;
-      } else {
-        process.env.MARTIN_RUNS_DIR = previousRunsRoot;
-      }
-    }
+    });
   });
 
   it("allows inspect paths under the configured Martin run store", async () => {
-    const previousRunsRoot = process.env.MARTIN_RUNS_DIR;
-    const runsRoot = join(tmpdir(), `martin-mcp-validation-runs-${Date.now()}`);
-    process.env.MARTIN_RUNS_DIR = runsRoot;
-    await mkdir(join(runsRoot, "loop_001"), { recursive: true });
-    await writeFile(join(runsRoot, "loop_001", "loop-record.json"), "{}", "utf8");
+    await withValidationRunsRoot(async (runsRoot) => {
+      await mkdir(join(runsRoot, "loop_001"), { recursive: true });
+      await writeFile(join(runsRoot, "loop_001", "loop-record.json"), "{}", "utf8");
 
-    try {
       const result = validateToolInput("martin_inspect", {
         file: "loop_001/loop-record.json"
       });
@@ -69,21 +76,11 @@ describe("server validation", () => {
       expect(result).toEqual({
         file: join(runsRoot, "loop_001", "loop-record.json")
       });
-    } finally {
-      if (previousRunsRoot === undefined) {
-        delete process.env.MARTIN_RUNS_DIR;
-      } else {
-        process.env.MARTIN_RUNS_DIR = previousRunsRoot;
-      }
-    }
+    });
   });
 
   it("allows inspect to target the run-store root explicitly", () => {
-    const previousRunsRoot = process.env.MARTIN_RUNS_DIR;
-    const runsRoot = join(tmpdir(), `martin-mcp-validation-runs-${Date.now()}`);
-    process.env.MARTIN_RUNS_DIR = runsRoot;
-
-    try {
+    return withValidationRunsRoot(async (runsRoot) => {
       const result = validateToolInput("martin_inspect", {
         runsDir: "."
       });
@@ -91,13 +88,7 @@ describe("server validation", () => {
       expect(result).toEqual({
         runsDir: runsRoot
       });
-    } finally {
-      if (previousRunsRoot === undefined) {
-        delete process.env.MARTIN_RUNS_DIR;
-      } else {
-        process.env.MARTIN_RUNS_DIR = previousRunsRoot;
-      }
-    }
+    });
   });
 
   it("rejects ambiguous martin_status selectors", () => {
@@ -154,19 +145,20 @@ describe("server validation", () => {
   it("keeps MCP public tool schemas aligned with validation constraints", async () => {
     const testsDir = dirname(fileURLToPath(import.meta.url));
     const serverSource = await readFile(join(testsDir, "../src/server.ts"), "utf8");
+    const normalizedServerSource = serverSource.replace(/\r\n/g, "\n");
 
-    expect(serverSource).toContain('import { createRequire } from "node:module"');
-    expect(serverSource).toContain("const require = createRequire(import.meta.url);");
-    expect(serverSource).toContain('const packageJson = require("../package.json") as { version: string };');
-    expect(serverSource).toContain('{ name: "martin-loop", version: packageJson.version }');
-    expect(serverSource).toContain("additionalProperties: false");
-    expect(serverSource).toContain('maxIterations: {\n            type: "integer"');
-    expect(serverSource).toContain('maxTokens: {\n            type: "integer"');
-    expect(serverSource).toContain('latest: {\n            const: true');
-    expect(serverSource).toContain("oneOf: [");
-    expect(serverSource).toContain('{ required: ["loopJson"] }');
-    expect(serverSource).toContain('{ required: ["file"] }');
-    expect(serverSource).toContain('{ required: ["loopId"] }');
-    expect(serverSource).toContain('{ required: ["latest"] }');
+    expect(normalizedServerSource).toContain('import { createRequire } from "node:module"');
+    expect(normalizedServerSource).toContain("const require = createRequire(import.meta.url);");
+    expect(normalizedServerSource).toContain('const packageJson = require("../package.json") as { version: string };');
+    expect(normalizedServerSource).toContain('{ name: "martin-loop", version: packageJson.version }');
+    expect(normalizedServerSource).toContain("additionalProperties: false");
+    expect(normalizedServerSource).toMatch(/maxIterations:\s*\{\s*type: "integer"/);
+    expect(normalizedServerSource).toMatch(/maxTokens:\s*\{\s*type: "integer"/);
+    expect(normalizedServerSource).toMatch(/latest:\s*\{\s*const: true/);
+    expect(normalizedServerSource).toContain("oneOf: [");
+    expect(normalizedServerSource).toContain('{ required: ["loopJson"] }');
+    expect(normalizedServerSource).toContain('{ required: ["file"] }');
+    expect(normalizedServerSource).toContain('{ required: ["loopId"] }');
+    expect(normalizedServerSource).toContain('{ required: ["latest"] }');
   });
 });


### PR DESCRIPTION
## Summary
- fix the flaky MCP test helper that can reuse the same temp runs root across parallel test setup
- switch `withRunsRoot()` to `mkdtemp(...)` and remove the temp directory in `finally`
- stabilize the macOS/CI failure exposed after the readiness merge

## Why
After #38 merged, the matrix moved past the published-smoke issue and exposed a different blocker:
- `packages/mcp/tests/mcp-tools.test.ts`
- failing case: `inspectLoopTool > defaults to the Martin run store when no selector is provided`
- CI observed `loopCount === 3` where the test expected `1`

The helper was using `tmpdir() + Date.now()` for its runs root, which is not unique enough under fast parallel test setup.

## Verification
- `pnpm --filter @martinloop/mcp test`
- `pnpm --filter @martinloop/mcp smoke:pack`
- `pnpm mcp:published:smoke:pack`
- `node --test scripts/tests/release-matrix.test.mjs scripts/tests/rc-validation.test.mjs scripts/tests/publish-mcp-workflow.test.mjs scripts/tests/mcp-publish-reliability.test.mjs`