### PR TITLE
fix(mcp): restore publish workflow parsing

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -45,24 +45,7 @@ jobs:
         working-directory: packages/mcp
         shell: bash
         run: |
-          node <<'NODE' >> "$GITHUB_OUTPUT"
-          const fs = require('node:fs');
-          const pkg = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
-          const server = JSON.parse(fs.readFileSync('./server.json', 'utf8'));
-          const npmPackage = Array.isArray(server.packages)
-            ? server.packages.find((entry) => entry && entry.registryType === 'npm')
-            : undefined;
-
-          if (!npmPackage) {
-            throw new Error('server.json is missing an npm package entry.');
-          }
-
-          process.stdout.write(`package_version=${pkg.version}\n`);
-          process.stdout.write(`server_version=${server.version}\n`);
-          process.stdout.write(`package_name=${pkg.name}\n`);
-          process.stdout.write(`server_name=${server.name}\n`);
-          process.stdout.write(`identifier=${npmPackage.identifier}\n`);
-NODE
+          node ../../scripts/read-mcp-package-metadata.mjs >> "$GITHUB_OUTPUT"
 
       - name: Verify MCP tag/version parity
         if: startsWith(github.ref, 'refs/tags/')

--- a/scripts/read-mcp-package-metadata.mjs
+++ b/scripts/read-mcp-package-metadata.mjs
@@ -1,0 +1,25 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+const metadataDir = process.argv[2]
+  ? path.resolve(process.cwd(), process.argv[2])
+  : process.cwd();
+
+const packageJsonPath = path.join(metadataDir, "package.json");
+const serverJsonPath = path.join(metadataDir, "server.json");
+
+const packageJson = JSON.parse(await readFile(packageJsonPath, "utf8"));
+const serverJson = JSON.parse(await readFile(serverJsonPath, "utf8"));
+const npmPackage = Array.isArray(serverJson.packages)
+  ? serverJson.packages.find((entry) => entry && entry.registryType === "npm")
+  : undefined;
+
+if (!npmPackage) {
+  throw new Error("server.json is missing an npm package entry.");
+}
+
+process.stdout.write(`package_version=${packageJson.version}\n`);
+process.stdout.write(`server_version=${serverJson.version}\n`);
+process.stdout.write(`package_name=${packageJson.name}\n`);
+process.stdout.write(`server_name=${serverJson.name}\n`);
+process.stdout.write(`identifier=${npmPackage.identifier}\n`);

--- a/scripts/tests/publish-mcp-workflow.test.mjs
+++ b/scripts/tests/publish-mcp-workflow.test.mjs
@@ -1,18 +1,25 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import packageJson from "../../packages/mcp/package.json" with { type: "json" };
+import serverJson from "../../packages/mcp/server.json" with { type: "json" };
+
 const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const METADATA_SCRIPT = path.join(ROOT_DIR, "scripts", "read-mcp-package-metadata.mjs");
 
 test("publish-mcp workflow enforces mcp tag parity against package and server metadata", async () => {
   const workflowPath = path.join(ROOT_DIR, ".github", "workflows", "publish-mcp.yml");
   const workflow = await readFile(workflowPath, "utf8");
+  const metadataScript = await readFile(METADATA_SCRIPT, "utf8");
 
   assert.match(workflow, /Read MCP package metadata/);
   assert.match(workflow, /id: mcp-metadata/);
-  assert.match(workflow, /server\.json is missing an npm package entry/);
+  assert.match(workflow, /read-mcp-package-metadata\.mjs/);
+  assert.match(metadataScript, /server\.json is missing an npm package entry/);
   assert.match(workflow, /Verify MCP tag\/version parity/);
   assert.match(workflow, /TAG_VERSION="\$\{GITHUB_REF_NAME#mcp-v\}"/);
   assert.match(workflow, /Expected an mcp-vX\.Y\.Z tag/);
@@ -20,4 +27,20 @@ test("publish-mcp workflow enforces mcp tag parity against package and server me
   assert.match(workflow, /steps\.mcp-metadata\.outputs\.server_version/);
   assert.match(workflow, /does not match package\.json version/);
   assert.match(workflow, /does not match server\.json version/);
+});
+
+test("metadata reader emits GitHub output keys from packages/mcp", () => {
+  const result = spawnSync(process.execPath, [METADATA_SCRIPT], {
+    cwd: path.join(ROOT_DIR, "packages", "mcp"),
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, new RegExp(`^package_version=${packageJson.version.replaceAll(".", "\\.")}$`, "m"));
+  assert.match(result.stdout, new RegExp(`^server_version=${serverJson.version.replaceAll(".", "\\.")}$`, "m"));
+  assert.match(result.stdout, new RegExp(`^package_name=${packageJson.name.replace("/", "\\/")}$`, "m"));
+  assert.match(result.stdout, new RegExp(`^server_name=${serverJson.name.replace("/", "\\/")}$`, "m"));
+  const npmPackage = serverJson.packages.find((entry) => entry?.registryType === "npm");
+  assert.ok(npmPackage, "server.json must define an npm package entry");
+  assert.match(result.stdout, new RegExp(`^identifier=${npmPackage.identifier.replace("/", "\\/")}$`, "m"));
 });


### PR DESCRIPTION
## Summary
- replace the inline publish-workflow metadata heredoc with a checked-in Node script
- keep MCP metadata output generation explicit and testable without YAML indentation fragility
- extend workflow tests to execute the metadata reader and assert emitted GitHub output keys

## Verification
- node --test scripts/tests/publish-mcp-workflow.test.mjs scripts/tests/mcp-publish-reliability.test.mjs
- node --test scripts/tests/release-matrix.test.mjs scripts/tests/rc-validation.test.mjs scripts/tests/publish-mcp-workflow.test.mjs scripts/tests/mcp-publish-reliability.test.mjs
- node ..\\..\\scripts\\read-mcp-package-metadata.mjs