### PR TITLE
fix(mcp): cap registry description length

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -4,7 +4,7 @@
   "mcpName": "io.github.keesan12/martin-loop",
   "private": false,
   "type": "module",
-  "description": "Governed MCP server for AI coding agents with budgets, verifier gates, policy checks, and audit trails.",
+  "description": "Governed MCP server for AI coding agents with budgets, verifier gates, and inspectable runs.",
   "license": "MIT",
   "author": "Vakeesan Mahalingam and Gobi Shanthan",
   "homepage": "https://martinloop.com/",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.keesan12/martin-loop",
   "title": "Martin Loop",
-  "description": "Governed MCP server for AI coding agents with budgets, verifier gates, policy checks, and audit trails.",
+  "description": "Governed MCP server for AI coding agents with budgets, verifier gates, and inspectable runs.",
   "repository": {
     "url": "https://github.com/Keesan12/martin-loop",
     "source": "github"

--- a/scripts/tests/mcp-publish-reliability.test.mjs
+++ b/scripts/tests/mcp-publish-reliability.test.mjs
@@ -18,6 +18,8 @@ test("MCP package metadata stays aligned with server metadata", () => {
   assert.equal(packageJson.version, npmPackage.version);
   assert.equal(packageJson.name, npmPackage.identifier);
   assert.equal(packageJson.mcpName, serverJson.name);
+  assert.equal(packageJson.description, serverJson.description);
+  assert.ok(serverJson.description.length <= 100, "server.json description must stay within the registry length limit");
 });
 
 test("publish-mcp workflow keeps bounded npm view and smoke retries with backoff", async () => {


### PR DESCRIPTION
## Summary
- shorten the MCP description to satisfy the registry length cap
- keep package and server descriptions aligned in source
- add a reliability assertion that the registry-facing description stays within the limit

## Verification
- node --test scripts/tests/mcp-publish-reliability.test.mjs scripts/tests/publish-mcp-workflow.test.mjs
- pnpm --filter @martinloop/mcp test
- pnpm --filter @martinloop/mcp smoke:pack