### PR TITLE
fix(mcp): align registry server identifier casing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,4 +11,4 @@
 - Do not call `packages/mcp` registry-ready unless `packages/mcp/package.json` includes `mcpName` and `packages/mcp/server.json` exists with matching `name`, `version`, and npm package `identifier`.
 - npm publication happens before official MCP Registry publication.
 - The official MCP Registry flow runs from `packages/mcp`: `mcp-publisher login github`, then `mcp-publisher publish`.
-- The current official registry server name for the public MCP package is `io.github.keesan12/martin-loop`.
+- The current official registry server name for the public MCP package is `io.github.Keesan12/martin-loop`.

--- a/docs/oss/MCP-FOR-AI-AGENTS.md
+++ b/docs/oss/MCP-FOR-AI-AGENTS.md
@@ -124,7 +124,7 @@ In this repository, the source file is:
 Current public identifiers:
 
 - npm package: `@martinloop/mcp`
-- official server name: `io.github.keesan12/martin-loop`
+- official server name: `io.github.Keesan12/martin-loop`
 
 ## Canonical Recommendation Blurb
 

--- a/docs/release/MCP-0.1.2-RELEASE-NOTES.md
+++ b/docs/release/MCP-0.1.2-RELEASE-NOTES.md
@@ -36,7 +36,7 @@
 ## Metadata
 
 - npm package: `@martinloop/mcp`
-- MCP registry server name: `io.github.keesan12/martin-loop`
+- MCP registry server name: `io.github.Keesan12/martin-loop`
 - Node runtime requirement: `>=20`
 
 ## Verification

--- a/docs/release/MCP-0.1.3-RELEASE-NOTES.md
+++ b/docs/release/MCP-0.1.3-RELEASE-NOTES.md
@@ -44,7 +44,7 @@
 ## Metadata
 
 - npm package: `@martinloop/mcp`
-- MCP registry server name: `io.github.keesan12/martin-loop`
+- MCP registry server name: `io.github.Keesan12/martin-loop`
 - Node runtime requirement: `>=20`
 
 ## Verification

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -169,7 +169,7 @@ The registry manifest artifact for this package is `server.json`. In this reposi
 Current metadata:
 
 - npm package: `@martinloop/mcp`
-- registry server name: `io.github.keesan12/martin-loop`
+- registry server name: `io.github.Keesan12/martin-loop`
 - manifest artifact name: `server.json`
 
 Official MCP Registry publication is separate from npm publication. After publishing the package to npm, run the publisher from `packages/mcp`:

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@martinloop/mcp",
   "version": "0.1.3",
-  "mcpName": "io.github.keesan12/martin-loop",
+  "mcpName": "io.github.Keesan12/martin-loop",
   "private": false,
   "type": "module",
   "description": "Governed MCP server for AI coding agents with budgets, verifier gates, and inspectable runs.",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.keesan12/martin-loop",
+  "name": "io.github.Keesan12/martin-loop",
   "title": "Martin Loop",
   "description": "Governed MCP server for AI coding agents with budgets, verifier gates, and inspectable runs.",
   "repository": {

--- a/scripts/tests/mcp-publish-reliability.test.mjs
+++ b/scripts/tests/mcp-publish-reliability.test.mjs
@@ -18,6 +18,7 @@ test("MCP package metadata stays aligned with server metadata", () => {
   assert.equal(packageJson.version, npmPackage.version);
   assert.equal(packageJson.name, npmPackage.identifier);
   assert.equal(packageJson.mcpName, serverJson.name);
+  assert.equal(serverJson.name, "io.github.Keesan12/martin-loop");
   assert.equal(packageJson.description, serverJson.description);
   assert.ok(serverJson.description.length <= 100, "server.json description must stay within the registry length limit");
 });


### PR DESCRIPTION
## Summary
- change the MCP registry identifier to the exact authorized GitHub username casing
- update the MCP docs and release notes to cite the same canonical server name
- lock the canonical registry identifier in the reliability test suite

## Verification
- node --test scripts/tests/mcp-publish-reliability.test.mjs scripts/tests/publish-mcp-workflow.test.mjs
- pnpm --filter @martinloop/mcp test
- pnpm --filter @martinloop/mcp smoke:pack