### PR TITLE
feat(mcp): prepare v0.2.0 cockpit release

### DIFF
--- a/docs/oss/MCP-FOR-AI-AGENTS.md
+++ b/docs/oss/MCP-FOR-AI-AGENTS.md
@@ -91,6 +91,11 @@ MARTIN_RUNS_DIR = "C:/path/to/repo/.martin/runs"
 | `martin_run` | Execute a governed coding task | `objective` | Accepts `maxUsd`, `maxIterations`, `maxTokens`, `verificationPlan`, `allowedPaths`, `deniedPaths`, `workingDirectory`, `engine`, `model`, `workspaceId`, `projectId`. Rejects unknown keys. |
 | `martin_inspect` | Summarize a saved run | none | `file` may target a `loop-record.json`, legacy `.jsonl`, or run directory under the runs root. |
 | `martin_status` | Check budget pressure or stop state | exactly one of `loopJson`, `file`, `loopId`, `latest` | `latest` must be `true` when present. `runsDir` is optional. |
+| `martin_list_runs` | List recent governed runs | none | Read-only. Accepts `runsDir` and `limit`. |
+| `martin_get_run` | Load a run dossier | exactly one of `loopId` or `latest` | Read-only. Accepts `runsDir`. |
+| `martin_get_attempt` | Load one attempt | `loopId`, `attemptIndex` | Read-only attempt evidence. |
+| `martin_get_verification_results` | Extract verifier events | exactly one of `loopId` or `latest` | Read-only verifier evidence. |
+| `martin_run_dossier` | Build a compact review dossier | exactly one of `loopId` or `latest` | Read-only summary, budget, attempts, and verifier evidence. |
 
 `martin_run` uses the current MCP schema:
 
@@ -105,7 +110,15 @@ Recommended tool order:
 1. `martin_doctor`
 2. `martin_preflight`
 3. `martin_run`
-4. `martin_inspect` or `martin_status`
+4. `martin_list_runs`, `martin_run_dossier`, `martin_inspect`, or `martin_status`
+
+## Resources And Prompts
+
+`@martinloop/mcp` also exposes read-only cockpit discovery for MCP hosts:
+
+- resources: `martin://runs/summary`, `martin://runs/latest`
+- resource templates: `martin://runs/{loopId}`, `martin://runs/{loopId}/attempts/{attemptIndex}`, `martin://runs/{loopId}/verification`
+- prompts: `martin_review_run`, `martin_triage_failures`
 
 ## Safe-Root Path Model
 

--- a/docs/release/MCP-0.2.0-RELEASE-NOTES.md
+++ b/docs/release/MCP-0.2.0-RELEASE-NOTES.md
@@ -1,24 +1,71 @@
 # @martinloop/mcp v0.2.0
 
-`0.2.0` is the public cockpit expansion after the `0.1.4` operator foundation. It keeps `martin_run` as the only write-capable tool and adds read-only discovery for hosts that want to inspect governed runs before, during, and after review.
+`0.2.0` is the public cockpit expansion after the `0.1.4` operator foundation. `0.1.4` gave MCP hosts the safe operator lane: doctor, preflight, governed run, inspect, and status. `0.2.0` keeps that execution contract intact and adds a read-only cockpit so hosts can review local run evidence without widening write access.
+
+The headline: `martin_run` is still the only write-capable MCP tool. Everything new in `0.2.0` is inspection, review, or triage support over persisted Martin Loop run records.
+
+## What Changed From `0.1.4`
+
+| Area | `0.1.4` | `0.2.0` |
+| --- | --- | --- |
+| Operator readiness | `martin_doctor`, `martin_preflight` | unchanged |
+| Governed execution | `martin_run` | unchanged write boundary |
+| Basic inspection | `martin_inspect`, `martin_status` | unchanged |
+| Run cockpit | not included | `martin_list_runs`, `martin_get_run`, `martin_get_attempt`, `martin_get_verification_results`, `martin_run_dossier` |
+| MCP discovery | tools only | tools plus resources, resource templates, and prompts |
+| Release hardening | package smoke and published smoke | smoke gates now assert all 10 tools and discovery surfaces |
+
+## Why This Matters
+
+MCP hosts can now show a practical Martin Loop cockpit: recent runs, one-run dossiers, individual attempts, verifier results, and review prompts. That makes Martin Loop easier to trust in real workflows because users can see what happened, what it cost, what passed, and what still needs review.
 
 ## Added
 
-- Existing operator tools remain in the release surface: `martin_doctor`, `martin_preflight`, `martin_run`, `martin_inspect`, and `martin_status`.
+Existing `0.1.4` operator tools remain in the release surface:
+
+- `martin_doctor`
+- `martin_preflight`
+- `martin_run`
+- `martin_inspect`
+- `martin_status`
+
+New read-only cockpit tools:
+
 - `martin_list_runs` lists recent governed run summaries from the local run store.
 - `martin_get_run` returns a read-only run dossier by `loopId` or `latest`.
 - `martin_get_attempt` returns one attempt record by `loopId` and `attemptIndex`.
 - `martin_get_verification_results` extracts verifier completion events.
 - `martin_run_dossier` assembles summary, task, budget, attempts, and verification evidence for review.
-- Resources: `martin://runs/summary` and `martin://runs/latest`.
-- Resource templates: `martin://runs/{loopId}`, `martin://runs/{loopId}/attempts/{attemptIndex}`, and `martin://runs/{loopId}/verification`.
-- Prompts: `martin_review_run` and `martin_triage_failures`.
+
+New resources:
+
+- `martin://runs/summary`
+- `martin://runs/latest`
+
+New resource templates:
+
+- `martin://runs/{loopId}`
+- `martin://runs/{loopId}/attempts/{attemptIndex}`
+- `martin://runs/{loopId}/verification`
+
+New prompts:
+
+- `martin_review_run`
+- `martin_triage_failures`
 
 ## Hardened
 
 - Release workflow contract now explicitly permits GitHub release creation with `contents: write`.
 - Package and `server.json` metadata remain version-aligned for npm and MCP registry publication.
 - New cockpit tests cover resources, resource templates, prompts, run listing, attempt reads, verifier extraction, and dossiers.
+- Local pack smoke and install-from-pack smoke now fail if any expected `0.2.0` tool, resource, template, or prompt is missing.
+
+## Upgrade Notes
+
+- Existing `0.1.4` tool callers do not need to change their `martin_doctor`, `martin_preflight`, `martin_run`, `martin_inspect`, or `martin_status` calls.
+- Hosts can opt into the new cockpit surface by listing tools, resources, resource templates, and prompts through the normal MCP discovery methods.
+- The npm package name remains `@martinloop/mcp`.
+- The MCP registry server name remains `io.github.Keesan12/martin-loop`.
 
 ## What `0.2.0` does not claim
 
@@ -27,9 +74,9 @@
 - It does not add remote MCP auth, bearer-token control planes, or hosted team dashboards.
 - It does not make `martin_run` broader than the existing governed local execution contract.
 
-## Release Gates
+## Verification
 
-Before tagging `mcp-v0.2.0`, run:
+The `0.2.0` release candidate was checked with:
 
 ```powershell
 pnpm --filter @martinloop/mcp lint
@@ -41,4 +88,14 @@ pnpm --filter @martinloop/mcp verify:release
 pnpm release:matrix:local
 ```
 
-Publish through `.github/workflows/publish-mcp.yml` with tag `mcp-v0.2.0`; do not publish locally unless GitHub Actions is unavailable and the fallback is explicitly approved.
+The public PR release matrix also passed on Windows, macOS, and Ubuntu before release tagging.
+
+## Release Path
+
+Publish through `.github/workflows/publish-mcp.yml` with tag `mcp-v0.2.0`; do not publish locally unless GitHub Actions is unavailable and the fallback is explicitly approved. After publish, verify:
+
+```powershell
+npm view @martinloop/mcp version versions --json
+gh release view mcp-v0.2.0 --repo Keesan12/martin-loop
+pnpm --filter @martinloop/mcp smoke:published
+```

--- a/docs/release/MCP-0.2.0-RELEASE-NOTES.md
+++ b/docs/release/MCP-0.2.0-RELEASE-NOTES.md
@@ -1,0 +1,44 @@
+# @martinloop/mcp v0.2.0
+
+`0.2.0` is the public cockpit expansion after the `0.1.4` operator foundation. It keeps `martin_run` as the only write-capable tool and adds read-only discovery for hosts that want to inspect governed runs before, during, and after review.
+
+## Added
+
+- Existing operator tools remain in the release surface: `martin_doctor`, `martin_preflight`, `martin_run`, `martin_inspect`, and `martin_status`.
+- `martin_list_runs` lists recent governed run summaries from the local run store.
+- `martin_get_run` returns a read-only run dossier by `loopId` or `latest`.
+- `martin_get_attempt` returns one attempt record by `loopId` and `attemptIndex`.
+- `martin_get_verification_results` extracts verifier completion events.
+- `martin_run_dossier` assembles summary, task, budget, attempts, and verification evidence for review.
+- Resources: `martin://runs/summary` and `martin://runs/latest`.
+- Resource templates: `martin://runs/{loopId}`, `martin://runs/{loopId}/attempts/{attemptIndex}`, and `martin://runs/{loopId}/verification`.
+- Prompts: `martin_review_run` and `martin_triage_failures`.
+
+## Hardened
+
+- Release workflow contract now explicitly permits GitHub release creation with `contents: write`.
+- Package and `server.json` metadata remain version-aligned for npm and MCP registry publication.
+- New cockpit tests cover resources, resource templates, prompts, run listing, attempt reads, verifier extraction, and dossiers.
+
+## What `0.2.0` does not claim
+
+- It does not include the removed `0.2.5` branch or skipped stable-cockpit work.
+- It does not publish private Pro, Growth, Enterprise, Internal, hosted control-plane, autonomy, or router features.
+- It does not add remote MCP auth, bearer-token control planes, or hosted team dashboards.
+- It does not make `martin_run` broader than the existing governed local execution contract.
+
+## Release Gates
+
+Before tagging `mcp-v0.2.0`, run:
+
+```powershell
+pnpm --filter @martinloop/mcp lint
+pnpm --filter @martinloop/mcp test
+pnpm --filter @martinloop/mcp build
+pnpm --filter @martinloop/mcp smoke:pack
+pnpm --filter @martinloop/mcp smoke:published:pack
+pnpm --filter @martinloop/mcp verify:release
+pnpm release:matrix:local
+```
+
+Publish through `.github/workflows/publish-mcp.yml` with tag `mcp-v0.2.0`; do not publish locally unless GitHub Actions is unavailable and the fallback is explicitly approved.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -2,20 +2,25 @@
 
 Governed MCP server for AI coding agents that need hard spend limits, verifier gates, scoped file edits, and inspectable run records.
 
-`@martinloop/mcp@0.1.4` exposes five stdio tools:
+`@martinloop/mcp@0.2.0` exposes ten stdio tools plus read-only MCP resources, resource templates, and prompts:
 
 - `martin_doctor`
 - `martin_preflight`
 - `martin_run`
 - `martin_inspect`
 - `martin_status`
+- `martin_list_runs`
+- `martin_get_run`
+- `martin_get_attempt`
+- `martin_get_verification_results`
+- `martin_run_dossier`
 
 Recommended flow:
 
 1. `martin_doctor`
 2. `martin_preflight`
 3. `martin_run`
-4. `martin_inspect` or `martin_status`
+4. `martin_list_runs`, `martin_run_dossier`, `martin_inspect`, or `martin_status`
 
 ## What This Server Is For
 
@@ -95,6 +100,31 @@ MARTIN_LIVE=false npx -y @martinloop/mcp
 | `martin_run` | Run a governed coding loop | `objective` | `workingDirectory`, `engine`, `model`, `maxUsd`, `maxIterations`, `maxTokens`, `verificationPlan`, `allowedPaths`, `deniedPaths`, `workspaceId`, `projectId` | Unknown arguments are rejected. |
 | `martin_inspect` | Read a saved run record or run folder | none | `file`, `runsDir` | `file` may point to a `loop-record.json`, legacy `.jsonl`, or a run directory under the runs root. |
 | `martin_status` | Report budget pressure and stop conditions | exactly one of `loopJson`, `file`, `loopId`, or `latest` | `runsDir` | `latest` must be `true` when used. |
+| `martin_list_runs` | List recent run summaries | none | `runsDir`, `limit` | Read-only cockpit view over local run records. |
+| `martin_get_run` | Load a run dossier | exactly one of `loopId` or `latest` | `runsDir` | Read-only task, budget, cost, and attempt details. |
+| `martin_get_attempt` | Load one attempt | `loopId`, `attemptIndex` | `runsDir` | Read-only attempt evidence. |
+| `martin_get_verification_results` | Extract verifier events | exactly one of `loopId` or `latest` | `runsDir` | Read-only verifier completion summaries. |
+| `martin_run_dossier` | Build a compact review dossier | exactly one of `loopId` or `latest` | `runsDir` | Summary, budget, attempts, and verification evidence. |
+
+## Discovery Surface
+
+`0.2.0` adds read-only cockpit discovery for MCP hosts that support resources and prompts.
+
+Resources:
+
+- `martin://runs/summary`
+- `martin://runs/latest`
+
+Resource templates:
+
+- `martin://runs/{loopId}`
+- `martin://runs/{loopId}/attempts/{attemptIndex}`
+- `martin://runs/{loopId}/verification`
+
+Prompts:
+
+- `martin_review_run`
+- `martin_triage_failures`
 
 ## Safe-Root Path Model
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@martinloop/mcp",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "mcpName": "io.github.Keesan12/martin-loop",
   "private": false,
   "type": "module",
@@ -24,7 +24,9 @@
     "claude",
     "codex",
     "martin_doctor",
-    "martin_preflight"
+    "martin_preflight",
+    "martin_list_runs",
+    "martin_run_dossier"
   ],
   "bin": {
     "mcp": "./dist/server.js",

--- a/packages/mcp/scripts/smoke-package.mjs
+++ b/packages/mcp/scripts/smoke-package.mjs
@@ -11,7 +11,25 @@ import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 
 import { buildStandaloneMcpPackage } from "./build-package-lib.mjs";
 
-const REQUIRED_TOOLS = ["martin_inspect", "martin_run", "martin_status"];
+const REQUIRED_TOOLS = [
+  "martin_doctor",
+  "martin_preflight",
+  "martin_run",
+  "martin_inspect",
+  "martin_status",
+  "martin_list_runs",
+  "martin_get_run",
+  "martin_get_attempt",
+  "martin_get_verification_results",
+  "martin_run_dossier",
+];
+const REQUIRED_RESOURCES = ["martin://runs/summary", "martin://runs/latest"];
+const REQUIRED_RESOURCE_TEMPLATES = [
+  "martin://runs/{loopId}",
+  "martin://runs/{loopId}/attempts/{attemptIndex}",
+  "martin://runs/{loopId}/verification",
+];
+const REQUIRED_PROMPTS = ["martin_review_run", "martin_triage_failures"];
 export const PUBLISHED_PACKAGE_SPEC = "@martinloop/mcp";
 const REQUIRED_TARBALL_FILES = [
   "README.md",
@@ -124,12 +142,23 @@ export async function runStandaloneMcpSmoke(options = {}) {
     await client.connect(transport);
     const tools = await client.listTools();
     const toolNames = tools.tools.map((tool) => tool.name).sort();
+    const resources = await client.listResources();
+    const resourceUris = resources.resources.map((resource) => resource.uri).sort();
+    const resourceTemplates = await client.listResourceTemplates();
+    const resourceTemplateUris = resourceTemplates.resourceTemplates
+      .map((resourceTemplate) => resourceTemplate.uriTemplate)
+      .sort();
+    const prompts = await client.listPrompts();
+    const promptNames = prompts.prompts.map((prompt) => prompt.name).sort();
 
     for (const toolName of REQUIRED_TOOLS) {
       if (!toolNames.includes(toolName)) {
         throw new Error(`Missing expected tool "${toolName}" in packaged MCP server.`);
       }
     }
+    assertIncludesAll(resourceUris, REQUIRED_RESOURCES, "resource");
+    assertIncludesAll(resourceTemplateUris, REQUIRED_RESOURCE_TEMPLATES, "resource template");
+    assertIncludesAll(promptNames, REQUIRED_PROMPTS, "prompt");
 
     const statusResult = await client.callTool({
       name: "martin_status",
@@ -151,6 +180,9 @@ export async function runStandaloneMcpSmoke(options = {}) {
       packedDependencies: packedManifest.dependencies ?? {},
       packedServerMetadata,
       statusPayload,
+      resourceUris,
+      resourceTemplateUris,
+      promptNames,
       stderr: stderrChunks.join(""),
     };
   } finally {
@@ -160,6 +192,13 @@ export async function runStandaloneMcpSmoke(options = {}) {
     if (!options.keepTempDir) {
       await removeTempDir(tempRoot);
     }
+  }
+}
+
+function assertIncludesAll(actual, expected, label) {
+  const missing = expected.filter((item) => !actual.includes(item));
+  if (missing.length > 0) {
+    throw new Error(`Missing expected MCP ${label}s: ${missing.join(", ")}`);
   }
 }
 

--- a/packages/mcp/scripts/smoke-published-package.mjs
+++ b/packages/mcp/scripts/smoke-published-package.mjs
@@ -17,7 +17,25 @@ import {
   sanitizePackageManagerEnv,
 } from "./smoke-package.mjs";
 
-const REQUIRED_TOOLS = ["martin_inspect", "martin_run", "martin_status"];
+const REQUIRED_TOOLS = [
+  "martin_doctor",
+  "martin_preflight",
+  "martin_run",
+  "martin_inspect",
+  "martin_status",
+  "martin_list_runs",
+  "martin_get_run",
+  "martin_get_attempt",
+  "martin_get_verification_results",
+  "martin_run_dossier",
+];
+const REQUIRED_RESOURCES = ["martin://runs/summary", "martin://runs/latest"];
+const REQUIRED_RESOURCE_TEMPLATES = [
+  "martin://runs/{loopId}",
+  "martin://runs/{loopId}/attempts/{attemptIndex}",
+  "martin://runs/{loopId}/verification",
+];
+const REQUIRED_PROMPTS = ["martin_review_run", "martin_triage_failures"];
 const INSTALLED_PACKAGE_PATH = path.join("node_modules", ...PUBLISHED_PACKAGE_SPEC.split("/"));
 
 export async function runPublishedMcpSmoke(options = {}) {
@@ -160,11 +178,23 @@ export async function runPublishedMcpSmoke(options = {}) {
 
     const tools = await client.listTools();
     const toolNames = tools.tools.map((tool) => tool.name).sort();
+    const resources = await client.listResources();
+    const resourceUris = resources.resources.map((resource) => resource.uri).sort();
+    const resourceTemplates = await client.listResourceTemplates();
+    const resourceTemplateUris = resourceTemplates.resourceTemplates
+      .map((resourceTemplate) => resourceTemplate.uriTemplate)
+      .sort();
+    const prompts = await client.listPrompts();
+    const promptNames = prompts.prompts.map((prompt) => prompt.name).sort();
+
     for (const toolName of REQUIRED_TOOLS) {
       if (!toolNames.includes(toolName)) {
         throw new Error(`Missing expected tool "${toolName}" in published MCP server.`);
       }
     }
+    assertIncludesAll(resourceUris, REQUIRED_RESOURCES, "resource");
+    assertIncludesAll(resourceTemplateUris, REQUIRED_RESOURCE_TEMPLATES, "resource template");
+    assertIncludesAll(promptNames, REQUIRED_PROMPTS, "prompt");
 
     const canonicalInspect = await client.callTool({
       name: "martin_inspect",
@@ -177,6 +207,14 @@ export async function runPublishedMcpSmoke(options = {}) {
     const latestStatus = await client.callTool({
       name: "martin_status",
       arguments: { latest: true },
+    });
+    const listRuns = await client.callTool({
+      name: "martin_list_runs",
+      arguments: {},
+    });
+    const runDossier = await client.callTool({
+      name: "martin_run_dossier",
+      arguments: { loopId: canonicalLoop.loopId },
     });
     const runResult = await client.callTool({
       name: "martin_run",
@@ -197,6 +235,9 @@ export async function runPublishedMcpSmoke(options = {}) {
       npxCommand: packageSpec.startsWith("@") ? `npx ${packageSpec}` : `npm exec --yes --package "${packageSpec}" -- mcp`,
       launchCommand: `${JSON.stringify(process.execPath)} ${JSON.stringify(path.join(installedPackageDir, "dist", "server.js"))}`,
       toolNames,
+      resourceUris,
+      resourceTemplateUris,
+      promptNames,
       installedManifest: {
         name: installedManifest.name,
         version: installedManifest.version,
@@ -206,6 +247,8 @@ export async function runPublishedMcpSmoke(options = {}) {
       canonicalInspect: JSON.parse(readTextContent(canonicalInspect)),
       jsonlInspect: JSON.parse(readTextContent(jsonlInspect)),
       latestStatus: JSON.parse(readTextContent(latestStatus)),
+      listRuns: JSON.parse(readTextContent(listRuns)),
+      runDossier: JSON.parse(readTextContent(runDossier)),
       runResult: JSON.parse(readTextContent(runResult)),
       stderr: stderrChunks.join(""),
     };
@@ -216,6 +259,13 @@ export async function runPublishedMcpSmoke(options = {}) {
     if (!options.keepTempDir) {
       await removeTempDir(tempRoot);
     }
+  }
+}
+
+function assertIncludesAll(actual, expected, label) {
+  const missing = expected.filter((item) => !actual.includes(item));
+  if (missing.length > 0) {
+    throw new Error(`Missing expected MCP ${label}s: ${missing.join(", ")}`);
   }
 }
 

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/Keesan12/martin-loop",
     "source": "github"
   },
-  "version": "0.1.4",
+  "version": "0.2.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@martinloop/mcp",
-      "version": "0.1.4",
+      "version": "0.2.0",
       "transport": {
         "type": "stdio"
       }

--- a/packages/mcp/src/prompts.ts
+++ b/packages/mcp/src/prompts.ts
@@ -1,0 +1,89 @@
+import type { GetPromptResult, ListPromptsResult } from "@modelcontextprotocol/sdk/types.js";
+
+export function listMartinPrompts(): ListPromptsResult["prompts"] {
+  return [
+    {
+      name: "martin_review_run",
+      description: "Review a Martin Loop run for governance, verification, and release-readiness evidence.",
+      arguments: [
+        {
+          name: "loopId",
+          description: "Run loopId to review.",
+          required: true
+        },
+        {
+          name: "objective",
+          description: "Review objective or release question.",
+          required: false
+        }
+      ]
+    },
+    {
+      name: "martin_triage_failures",
+      description: "Triage failed Martin runs and propose the next safest bounded action.",
+      arguments: [
+        {
+          name: "loopId",
+          description: "Optional run loopId to triage. If omitted, use latest run resources.",
+          required: false
+        }
+      ]
+    }
+  ];
+}
+
+export function getMartinPrompt(name: string, args: Record<string, unknown> = {}): GetPromptResult {
+  if (name === "martin_review_run") {
+    const loopId = requireOptionalText(args.loopId, "loopId") ?? "latest";
+    const objective = requireOptionalText(args.objective, "objective") ?? "Assess whether the run is safe to ship.";
+    return {
+      description: "Review Martin Loop run evidence.",
+      messages: [
+        {
+          role: "user",
+          content: {
+            type: "text",
+            text: [
+              `Review Martin Loop run ${loopId}.`,
+              `Objective: ${objective}`,
+              "Use martin://runs/{loopId}, martin://runs/{loopId}/verification, and the read-only tools before making a shipping recommendation.",
+              "Call out missing verifier proof, budget pressure, safety-leash violations, and whether human review is required."
+            ].join("\n")
+          }
+        }
+      ]
+    };
+  }
+
+  if (name === "martin_triage_failures") {
+    const loopId = requireOptionalText(args.loopId, "loopId") ?? "latest";
+    return {
+      description: "Triage failed Martin Loop evidence.",
+      messages: [
+        {
+          role: "user",
+          content: {
+            type: "text",
+            text: [
+              `Triage Martin Loop run ${loopId}.`,
+              "Use the run dossier, attempt evidence, and verification results.",
+              "Return the smallest safe next action and do not suggest re-running until the failure class and verifier evidence are clear."
+            ].join("\n")
+          }
+        }
+      ]
+    };
+  }
+
+  throw new Error("Unknown prompt.");
+}
+
+function requireOptionalText(value: unknown, name: string): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`Invalid ${name}.`);
+  }
+  return value.trim();
+}

--- a/packages/mcp/src/resources.ts
+++ b/packages/mcp/src/resources.ts
@@ -1,0 +1,111 @@
+import type {
+  ListResourceTemplatesResult,
+  ListResourcesResult,
+  ReadResourceResult
+} from "@modelcontextprotocol/sdk/types.js";
+
+import { buildRunDossier, getAttempt, listRunSummaries, loadSelectedRun } from "./tools/cockpit-support.js";
+import { getVerificationResultsTool } from "./tools/get-verification-results.js";
+
+export interface ResourceReadOptions {
+  runsDir?: string;
+}
+
+export function listMartinResources(): ListResourcesResult["resources"] {
+  return [
+    {
+      uri: "martin://runs/summary",
+      name: "Martin run summary",
+      description: "Read-only summary of recent governed Martin Loop runs.",
+      mimeType: "application/json"
+    },
+    {
+      uri: "martin://runs/latest",
+      name: "Latest Martin run",
+      description: "Read-only dossier for the newest run in the local run store.",
+      mimeType: "application/json"
+    }
+  ];
+}
+
+export function listMartinResourceTemplates(): ListResourceTemplatesResult["resourceTemplates"] {
+  return [
+    {
+      uriTemplate: "martin://runs/{loopId}",
+      name: "Martin run dossier",
+      description: "Read-only run dossier by loopId.",
+      mimeType: "application/json"
+    },
+    {
+      uriTemplate: "martin://runs/{loopId}/attempts/{attemptIndex}",
+      name: "Martin run attempt",
+      description: "Read-only attempt evidence for a run.",
+      mimeType: "application/json"
+    },
+    {
+      uriTemplate: "martin://runs/{loopId}/verification",
+      name: "Martin verification results",
+      description: "Verifier results extracted from a run ledger.",
+      mimeType: "application/json"
+    }
+  ];
+}
+
+export async function readMartinResource(uri: string, options: ResourceReadOptions = {}): Promise<ReadResourceResult> {
+  const parsed = new URL(uri);
+  if (parsed.protocol !== "martin:") {
+    throw new Error("Unsupported resource URI.");
+  }
+
+  const segments = parsed.pathname.split("/").filter(Boolean);
+
+  if (parsed.hostname === "runs" && segments.length === 1 && segments[0] === "summary") {
+    return asJsonResource(uri, await listRunSummaries({ runsDir: options.runsDir }));
+  }
+
+  if (parsed.hostname === "runs" && segments.length === 1 && segments[0] === "latest") {
+    const loop = await loadSelectedRun({ latest: true, runsDir: options.runsDir });
+    return asJsonResource(uri, buildRunDossier(loop));
+  }
+
+  if (parsed.hostname !== "runs" || segments.length < 1) {
+    throw new Error("Unknown resource URI.");
+  }
+
+  const [loopId, child, attemptIndex] = segments;
+  if (!loopId || !/^[A-Za-z0-9._-]+$/u.test(loopId)) {
+    throw new Error("Invalid loopId.");
+  }
+
+  if (!child) {
+    const loop = await loadSelectedRun({ loopId, runsDir: options.runsDir });
+    return asJsonResource(uri, buildRunDossier(loop));
+  }
+
+  if (child === "attempts") {
+    const parsedAttempt = Number(attemptIndex);
+    if (!Number.isInteger(parsedAttempt) || parsedAttempt <= 0) {
+      throw new Error("Invalid attemptIndex.");
+    }
+    const loop = await loadSelectedRun({ loopId, runsDir: options.runsDir });
+    return asJsonResource(uri, getAttempt(loop, parsedAttempt));
+  }
+
+  if (child === "verification") {
+    return asJsonResource(uri, await getVerificationResultsTool({ loopId, runsDir: options.runsDir }));
+  }
+
+  throw new Error("Unknown resource URI.");
+}
+
+function asJsonResource(uri: string, value: unknown): ReadResourceResult {
+  return {
+    contents: [
+      {
+        uri,
+        mimeType: "application/json",
+        text: JSON.stringify(value, null, 2)
+      }
+    ]
+  };
+}

--- a/packages/mcp/src/server-validation.ts
+++ b/packages/mcp/src/server-validation.ts
@@ -3,17 +3,27 @@ import { extname, isAbsolute, relative, resolve } from "node:path";
 import { resolveRunsRoot } from "@martin/core";
 
 import type { MartinDoctorInput } from "./tools/doctor.js";
+import type { GetAttemptInput } from "./tools/get-attempt.js";
+import type { GetRunInput } from "./tools/get-run.js";
+import type { GetVerificationResultsInput } from "./tools/get-verification-results.js";
 import type { GetStatusInput } from "./tools/get-status.js";
 import type { InspectLoopInput } from "./tools/inspect-loop.js";
+import type { ListRunsInput } from "./tools/list-runs.js";
 import type { MartinPreflightInput } from "./tools/preflight.js";
 import type { RunLoopInput } from "./tools/run-loop.js";
+import type { RunDossierInput } from "./tools/run-dossier.js";
 
 type ToolName =
   | "martin_doctor"
   | "martin_preflight"
   | "martin_run"
   | "martin_inspect"
-  | "martin_status";
+  | "martin_status"
+  | "martin_list_runs"
+  | "martin_get_run"
+  | "martin_get_attempt"
+  | "martin_get_verification_results"
+  | "martin_run_dossier";
 
 export function validateToolInput(name: ToolName, args: unknown): unknown {
   switch (name) {
@@ -27,6 +37,16 @@ export function validateToolInput(name: ToolName, args: unknown): unknown {
       return validateInspectInput(args);
     case "martin_status":
       return validateStatusInput(args);
+    case "martin_list_runs":
+      return validateListRunsInput(args);
+    case "martin_get_run":
+      return validateGetRunInput(args);
+    case "martin_get_attempt":
+      return validateGetAttemptInput(args);
+    case "martin_get_verification_results":
+      return validateGetVerificationResultsInput(args);
+    case "martin_run_dossier":
+      return validateRunDossierInput(args);
     default:
       throw new Error(`Unknown tool: ${name}`);
   }
@@ -254,6 +274,72 @@ function validateStatusInput(args: unknown): GetStatusInput {
   };
 }
 
+function validateListRunsInput(args: unknown): ListRunsInput {
+  const record = requireObject(args);
+  assertAllowedKeys(record, ["runsDir", "limit"]);
+  return {
+    ...(record.runsDir !== undefined
+      ? { runsDir: resolveSafeRunsRootPath(requireString(record.runsDir, "runsDir")) }
+      : {}),
+    ...(record.limit !== undefined ? { limit: requirePositiveInteger(record.limit, "limit") } : {})
+  };
+}
+
+function validateGetRunInput(args: unknown): GetRunInput {
+  const record = requireObject(args);
+  assertAllowedKeys(record, ["loopId", "runsDir", "latest"]);
+  return validateRunSelector(record);
+}
+
+function validateGetVerificationResultsInput(args: unknown): GetVerificationResultsInput {
+  const record = requireObject(args);
+  assertAllowedKeys(record, ["loopId", "runsDir", "latest"]);
+  return validateRunSelector(record);
+}
+
+function validateRunDossierInput(args: unknown): RunDossierInput {
+  const record = requireObject(args);
+  assertAllowedKeys(record, ["loopId", "runsDir", "latest"]);
+  return validateRunSelector(record);
+}
+
+function validateGetAttemptInput(args: unknown): GetAttemptInput {
+  const record = requireObject(args);
+  assertAllowedKeys(record, ["loopId", "attemptIndex", "runsDir"]);
+  return {
+    loopId: requireLoopId(record.loopId, "loopId"),
+    attemptIndex: requirePositiveInteger(record.attemptIndex, "attemptIndex"),
+    ...(record.runsDir !== undefined
+      ? { runsDir: resolveSafeRunsRootPath(requireString(record.runsDir, "runsDir")) }
+      : {})
+  };
+}
+
+function validateRunSelector(
+  record: Record<string, unknown>
+): GetRunInput | GetVerificationResultsInput | RunDossierInput {
+  const selectors = [
+    record.loopId !== undefined ? "loopId" : null,
+    record.latest !== undefined ? "latest" : null
+  ].filter((value): value is string => value !== null);
+
+  if (selectors.length !== 1) {
+    throw new Error("Provide exactly one of loopId or latest.");
+  }
+
+  if (record.latest !== undefined && record.latest !== true) {
+    throw new Error("Invalid latest.");
+  }
+
+  return {
+    ...(record.loopId !== undefined ? { loopId: requireLoopId(record.loopId, "loopId") } : {}),
+    ...(record.latest === true ? { latest: true } : {}),
+    ...(record.runsDir !== undefined
+      ? { runsDir: resolveSafeRunsRootPath(requireString(record.runsDir, "runsDir")) }
+      : {})
+  };
+}
+
 function requireObject(value: unknown): Record<string, unknown> {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     throw new Error("Tool arguments must be an object.");
@@ -320,10 +406,14 @@ function optionalPositiveInteger(
   if (value === undefined) {
     return {};
   }
+  return { [name]: requirePositiveInteger(value, name) } as Partial<Record<typeof name, number>>;
+}
+
+function requirePositiveInteger(value: unknown, name: string): number {
   if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
     throw new Error(`Invalid ${name}.`);
   }
-  return { [name]: value } as Partial<Record<typeof name, number>>;
+  return value;
 }
 
 function optionalStringArray(value: unknown, name: string): string[] | undefined {

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -3,7 +3,7 @@
 /**
  * Martin Loop MCP Server
  *
- * Exposes five tools over the Model Context Protocol (stdio transport):
+ * Exposes a governed local MCP cockpit over stdio:
  *   martin_doctor     — inspect local readiness and run-store health
  *   martin_preflight  — normalize a proposed run contract before execution
  *   martin_run        — execute a full Martin loop on a coding task
@@ -27,14 +27,26 @@ import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {
   CallToolRequestSchema,
-  ListToolsRequestSchema
+  GetPromptRequestSchema,
+  ListPromptsRequestSchema,
+  ListResourcesRequestSchema,
+  ListResourceTemplatesRequestSchema,
+  ListToolsRequestSchema,
+  ReadResourceRequestSchema
 } from "@modelcontextprotocol/sdk/types.js";
 
 import { martinDoctorTool } from "./tools/doctor.js";
+import { getAttemptTool } from "./tools/get-attempt.js";
+import { getRunTool } from "./tools/get-run.js";
 import { getStatusTool } from "./tools/get-status.js";
+import { getVerificationResultsTool } from "./tools/get-verification-results.js";
 import { inspectLoopTool } from "./tools/inspect-loop.js";
+import { listRunsTool } from "./tools/list-runs.js";
 import { martinPreflightTool } from "./tools/preflight.js";
+import { getMartinPrompt, listMartinPrompts } from "./prompts.js";
+import { listMartinResourceTemplates, listMartinResources, readMartinResource } from "./resources.js";
 import { runLoopTool } from "./tools/run-loop.js";
+import { runDossierTool } from "./tools/run-dossier.js";
 import { sanitizeToolErrorMessage, validateToolInput } from "./server-validation.js";
 
 const require = createRequire(import.meta.url);
@@ -42,7 +54,7 @@ const packageJson = require("../package.json") as { version: string };
 
 const server = new Server(
   { name: "martin-loop", version: packageJson.version },
-  { capabilities: { tools: {} } }
+  { capabilities: { tools: {}, resources: {}, prompts: {} } }
 );
 
 // ---------------------------------------------------------------------------
@@ -280,9 +292,155 @@ server.setRequestHandler(ListToolsRequestSchema, () => ({
           { required: ["latest"] }
         ]
       }
+    },
+    {
+      name: "martin_list_runs",
+      description:
+        "List recent Martin Loop runs from the local run store with budget, verifier, and lifecycle summaries. Read-only.",
+      inputSchema: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          runsDir: {
+            type: "string",
+            description:
+              "Optional runs-root override resolved under the default Martin runs root. Defaults to MARTIN_RUNS_DIR or ~/.martin/runs."
+          },
+          limit: {
+            type: "integer",
+            exclusiveMinimum: 0,
+            description: "Maximum number of runs to return. Defaults to 20."
+          }
+        }
+      }
+    },
+    {
+      name: "martin_get_run",
+      description:
+        "Load a read-only run dossier by loopId or latest run selector, including task, budget, cost, and attempts.",
+      inputSchema: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          loopId: {
+            type: "string",
+            description: "Martin loop ID under the run store."
+          },
+          runsDir: {
+            type: "string",
+            description:
+              "Optional runs-root override resolved under the default Martin runs root. Defaults to MARTIN_RUNS_DIR or ~/.martin/runs."
+          },
+          latest: {
+            const: true,
+            description: "When true, loads the most recently updated loop record in the runs directory."
+          }
+        },
+        oneOf: [{ required: ["loopId"] }, { required: ["latest"] }]
+      }
+    },
+    {
+      name: "martin_get_attempt",
+      description:
+        "Load read-only attempt evidence for a single Martin Loop attempt by loopId and attempt index.",
+      inputSchema: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          loopId: {
+            type: "string",
+            description: "Martin loop ID under the run store."
+          },
+          attemptIndex: {
+            type: "integer",
+            exclusiveMinimum: 0,
+            description: "1-based attempt index to inspect."
+          },
+          runsDir: {
+            type: "string",
+            description:
+              "Optional runs-root override resolved under the default Martin runs root. Defaults to MARTIN_RUNS_DIR or ~/.martin/runs."
+          }
+        },
+        required: ["loopId", "attemptIndex"]
+      }
+    },
+    {
+      name: "martin_get_verification_results",
+      description:
+        "Extract verifier completion events for a run by loopId or latest selector. Read-only.",
+      inputSchema: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          loopId: {
+            type: "string",
+            description: "Martin loop ID under the run store."
+          },
+          runsDir: {
+            type: "string",
+            description:
+              "Optional runs-root override resolved under the default Martin runs root. Defaults to MARTIN_RUNS_DIR or ~/.martin/runs."
+          },
+          latest: {
+            const: true,
+            description: "When true, loads the most recently updated loop record in the runs directory."
+          }
+        },
+        oneOf: [{ required: ["loopId"] }, { required: ["latest"] }]
+      }
+    },
+    {
+      name: "martin_run_dossier",
+      description:
+        "Build a compact read-only dossier for review: summary, budget, attempts, and verification evidence.",
+      inputSchema: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          loopId: {
+            type: "string",
+            description: "Martin loop ID under the run store."
+          },
+          runsDir: {
+            type: "string",
+            description:
+              "Optional runs-root override resolved under the default Martin runs root. Defaults to MARTIN_RUNS_DIR or ~/.martin/runs."
+          },
+          latest: {
+            const: true,
+            description: "When true, loads the most recently updated loop record in the runs directory."
+          }
+        },
+        oneOf: [{ required: ["loopId"] }, { required: ["latest"] }]
+      }
     }
   ]
 }));
+
+// ---------------------------------------------------------------------------
+// Resources and prompts
+// ---------------------------------------------------------------------------
+
+server.setRequestHandler(ListResourcesRequestSchema, () => ({
+  resources: listMartinResources()
+}));
+
+server.setRequestHandler(ListResourceTemplatesRequestSchema, () => ({
+  resourceTemplates: listMartinResourceTemplates()
+}));
+
+server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
+  return readMartinResource(request.params.uri);
+});
+
+server.setRequestHandler(ListPromptsRequestSchema, () => ({
+  prompts: listMartinPrompts()
+}));
+
+server.setRequestHandler(GetPromptRequestSchema, (request) => {
+  return getMartinPrompt(request.params.name, request.params.arguments ?? {});
+});
 
 // ---------------------------------------------------------------------------
 // Tool dispatch
@@ -319,6 +477,38 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     if (name === "martin_status") {
       const input = validateToolInput("martin_status", args) as Parameters<typeof getStatusTool>[0];
       const output = await getStatusTool(input);
+      return { content: [{ type: "text", text: JSON.stringify(output, null, 2) }] };
+    }
+
+    if (name === "martin_list_runs") {
+      const input = validateToolInput("martin_list_runs", args) as Parameters<typeof listRunsTool>[0];
+      const output = await listRunsTool(input);
+      return { content: [{ type: "text", text: JSON.stringify(output, null, 2) }] };
+    }
+
+    if (name === "martin_get_run") {
+      const input = validateToolInput("martin_get_run", args) as Parameters<typeof getRunTool>[0];
+      const output = await getRunTool(input);
+      return { content: [{ type: "text", text: JSON.stringify(output, null, 2) }] };
+    }
+
+    if (name === "martin_get_attempt") {
+      const input = validateToolInput("martin_get_attempt", args) as Parameters<typeof getAttemptTool>[0];
+      const output = await getAttemptTool(input);
+      return { content: [{ type: "text", text: JSON.stringify(output, null, 2) }] };
+    }
+
+    if (name === "martin_get_verification_results") {
+      const input = validateToolInput("martin_get_verification_results", args) as Parameters<
+        typeof getVerificationResultsTool
+      >[0];
+      const output = await getVerificationResultsTool(input);
+      return { content: [{ type: "text", text: JSON.stringify(output, null, 2) }] };
+    }
+
+    if (name === "martin_run_dossier") {
+      const input = validateToolInput("martin_run_dossier", args) as Parameters<typeof runDossierTool>[0];
+      const output = await runDossierTool(input);
       return { content: [{ type: "text", text: JSON.stringify(output, null, 2) }] };
     }
 

--- a/packages/mcp/src/tools/cockpit-support.ts
+++ b/packages/mcp/src/tools/cockpit-support.ts
@@ -1,0 +1,149 @@
+import { evaluateCostGovernor, type LoopRunRecord } from "@martin/core";
+
+import { loadLoopRecordForStatus, loadLoopRecordsForInspect } from "./run-store.js";
+
+export interface RunSelectorInput {
+  loopId?: string;
+  runsDir?: string;
+  latest?: boolean;
+}
+
+export interface RunSummary {
+  loopId: string;
+  title: string;
+  objective: string;
+  status: string;
+  lifecycleState: string;
+  createdAt: string;
+  updatedAt: string;
+  attempts: number;
+  costUsd: number;
+  avoidedUsd: number;
+  pressure: string;
+  shouldStop: boolean;
+  verificationCount: number;
+}
+
+export interface VerificationResultSummary {
+  eventId?: string;
+  timestamp?: string;
+  lifecycleState?: string;
+  passed?: boolean;
+  summary?: string;
+}
+
+export function summarizeRun(loop: LoopRunRecord): RunSummary {
+  const costState = evaluateCostGovernor({
+    budget: loop.budget,
+    cost: {
+      actualUsd: loop.cost.actualUsd,
+      avoidedUsd: loop.cost.avoidedUsd ?? 0,
+      tokensIn: loop.cost.tokensIn,
+      tokensOut: loop.cost.tokensOut
+    },
+    attemptsUsed: loop.attempts.length
+  });
+
+  return {
+    loopId: loop.loopId,
+    title: loop.task.title,
+    objective: loop.task.objective,
+    status: loop.status,
+    lifecycleState: loop.lifecycleState,
+    createdAt: loop.createdAt,
+    updatedAt: loop.updatedAt,
+    attempts: loop.attempts.length,
+    costUsd: loop.cost.actualUsd,
+    avoidedUsd: loop.cost.avoidedUsd ?? 0,
+    pressure: costState.pressure,
+    shouldStop: costState.shouldStop,
+    verificationCount: extractVerificationResults(loop).length
+  };
+}
+
+export async function listRunSummaries(input: { runsDir?: string; limit?: number } = {}): Promise<RunSummary[]> {
+  const inspection = await loadLoopRecordsForInspect({ runsDir: input.runsDir });
+  const summaries = inspection.loops.map((loop) => summarizeRun(loop));
+
+  summaries.sort((left, right) => {
+    const leftTime = Date.parse(left.updatedAt ?? left.createdAt);
+    const rightTime = Date.parse(right.updatedAt ?? right.createdAt);
+    return (Number.isFinite(rightTime) ? rightTime : 0) - (Number.isFinite(leftTime) ? leftTime : 0);
+  });
+
+  return summaries.slice(0, input.limit ?? 20);
+}
+
+export async function loadSelectedRun(input: RunSelectorInput): Promise<LoopRunRecord> {
+  const selectors = [input.loopId ? "loopId" : null, input.latest ? "latest" : null].filter(Boolean);
+  if (selectors.length !== 1) {
+    throw new Error("Provide exactly one of loopId or latest.");
+  }
+
+  const source = await loadLoopRecordForStatus({
+    ...(input.loopId ? { loopId: input.loopId } : {}),
+    ...(input.latest ? { latest: true } : {}),
+    ...(input.runsDir ? { runsDir: input.runsDir } : {})
+  });
+  return source.loop;
+}
+
+export function extractVerificationResults(loop: LoopRunRecord): VerificationResultSummary[] {
+  const events = "events" in loop && Array.isArray(loop.events) ? loop.events : [];
+  return events
+    .filter((event) => event?.type === "verification.completed")
+    .map((event) => {
+      const payload = isRecord(event.payload) ? event.payload : {};
+      return {
+        ...(typeof event.eventId === "string" ? { eventId: event.eventId } : {}),
+        ...(typeof event.timestamp === "string" ? { timestamp: event.timestamp } : {}),
+        ...(typeof event.lifecycleState === "string" ? { lifecycleState: event.lifecycleState } : {}),
+        ...(typeof payload.passed === "boolean" ? { passed: payload.passed } : {}),
+        ...(typeof payload.summary === "string" ? { summary: payload.summary } : {})
+      };
+    });
+}
+
+export function getAttempt(loop: LoopRunRecord, attemptIndex: number) {
+  const attempt = loop.attempts.find((candidate) => candidate.index === attemptIndex);
+  if (!attempt) {
+    throw new Error("Attempt not found.");
+  }
+  return attempt;
+}
+
+export function buildRunDossier(loop: LoopRunRecord) {
+  return {
+    loopId: loop.loopId,
+    generatedAt: new Date().toISOString(),
+    sections: [
+      {
+        kind: "summary",
+        content: summarizeRun(loop)
+      },
+      {
+        kind: "task",
+        content: loop.task
+      },
+      {
+        kind: "budget",
+        content: {
+          budget: loop.budget,
+          cost: loop.cost
+        }
+      },
+      {
+        kind: "attempts",
+        content: loop.attempts
+      },
+      {
+        kind: "verification",
+        content: extractVerificationResults(loop)
+      }
+    ]
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}

--- a/packages/mcp/src/tools/get-attempt.ts
+++ b/packages/mcp/src/tools/get-attempt.ts
@@ -1,0 +1,14 @@
+import { getAttempt, loadSelectedRun } from "./cockpit-support.js";
+
+export interface GetAttemptInput {
+  loopId: string;
+  attemptIndex: number;
+  runsDir?: string;
+}
+
+export type GetAttemptOutput = ReturnType<typeof getAttempt>;
+
+export async function getAttemptTool(input: GetAttemptInput): Promise<GetAttemptOutput> {
+  const loop = await loadSelectedRun({ loopId: input.loopId, runsDir: input.runsDir });
+  return getAttempt(loop, input.attemptIndex);
+}

--- a/packages/mcp/src/tools/get-run.ts
+++ b/packages/mcp/src/tools/get-run.ts
@@ -1,0 +1,32 @@
+import type { LoopRunRecord } from "@martin/core";
+
+import { loadSelectedRun, summarizeRun } from "./cockpit-support.js";
+
+export interface GetRunInput {
+  loopId?: string;
+  runsDir?: string;
+  latest?: boolean;
+}
+
+export interface GetRunOutput {
+  summary: ReturnType<typeof summarizeRun>;
+  task: LoopRunRecord["task"];
+  budget: LoopRunRecord["budget"];
+  cost: LoopRunRecord["cost"];
+  attempts: LoopRunRecord["attempts"];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export async function getRunTool(input: GetRunInput): Promise<GetRunOutput> {
+  const loop = await loadSelectedRun(input);
+  return {
+    summary: summarizeRun(loop),
+    task: loop.task,
+    budget: loop.budget,
+    cost: loop.cost,
+    attempts: loop.attempts,
+    createdAt: loop.createdAt,
+    updatedAt: loop.updatedAt
+  };
+}

--- a/packages/mcp/src/tools/get-verification-results.ts
+++ b/packages/mcp/src/tools/get-verification-results.ts
@@ -1,0 +1,22 @@
+import { extractVerificationResults, loadSelectedRun, type VerificationResultSummary } from "./cockpit-support.js";
+
+export interface GetVerificationResultsInput {
+  loopId?: string;
+  runsDir?: string;
+  latest?: boolean;
+}
+
+export interface GetVerificationResultsOutput {
+  loopId: string;
+  results: VerificationResultSummary[];
+}
+
+export async function getVerificationResultsTool(
+  input: GetVerificationResultsInput
+): Promise<GetVerificationResultsOutput> {
+  const loop = await loadSelectedRun(input);
+  return {
+    loopId: loop.loopId,
+    results: extractVerificationResults(loop)
+  };
+}

--- a/packages/mcp/src/tools/list-runs.ts
+++ b/packages/mcp/src/tools/list-runs.ts
@@ -1,0 +1,16 @@
+import { listRunSummaries, type RunSummary } from "./cockpit-support.js";
+
+export interface ListRunsInput {
+  runsDir?: string;
+  limit?: number;
+}
+
+export interface ListRunsOutput {
+  runs: RunSummary[];
+}
+
+export async function listRunsTool(input: ListRunsInput): Promise<ListRunsOutput> {
+  return {
+    runs: await listRunSummaries(input)
+  };
+}

--- a/packages/mcp/src/tools/run-dossier.ts
+++ b/packages/mcp/src/tools/run-dossier.ts
@@ -1,0 +1,14 @@
+import { buildRunDossier, loadSelectedRun } from "./cockpit-support.js";
+
+export interface RunDossierInput {
+  loopId?: string;
+  runsDir?: string;
+  latest?: boolean;
+}
+
+export type RunDossierOutput = ReturnType<typeof buildRunDossier>;
+
+export async function runDossierTool(input: RunDossierInput): Promise<RunDossierOutput> {
+  const loop = await loadSelectedRun(input);
+  return buildRunDossier(loop);
+}

--- a/packages/mcp/tests/mcp-cockpit-tools.test.ts
+++ b/packages/mcp/tests/mcp-cockpit-tools.test.ts
@@ -1,0 +1,114 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { appendLoopEvent, createLoopRecord } from "@martin/contracts";
+import { describe, expect, it } from "vitest";
+
+import { getAttemptTool } from "../src/tools/get-attempt.js";
+import { getRunTool } from "../src/tools/get-run.js";
+import { getVerificationResultsTool } from "../src/tools/get-verification-results.js";
+import { listRunsTool } from "../src/tools/list-runs.js";
+import { runDossierTool } from "../src/tools/run-dossier.js";
+
+async function withRunsRoot<T>(fn: (runsRoot: string) => Promise<T>): Promise<T> {
+  const runsRoot = await mkdtemp(join(tmpdir(), "martin-mcp-tools-"));
+  const previousRunsRoot = process.env.MARTIN_RUNS_DIR;
+  process.env.MARTIN_RUNS_DIR = runsRoot;
+  try {
+    return await fn(runsRoot);
+  } finally {
+    if (previousRunsRoot === undefined) {
+      delete process.env.MARTIN_RUNS_DIR;
+    } else {
+      process.env.MARTIN_RUNS_DIR = previousRunsRoot;
+    }
+    await rm(runsRoot, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+async function writeLoop(runsRoot: string) {
+  const initial = createLoopRecord({
+    loopId: "loop_cockpit",
+    workspaceId: "ws_test",
+    projectId: "proj_test",
+    task: {
+      title: "Harden MCP cockpit",
+      objective: "Expose read-only run evidence",
+      verificationPlan: ["pnpm test"]
+    },
+    budget: {
+      maxUsd: 5,
+      softLimitUsd: 3,
+      maxIterations: 2,
+      maxTokens: 8000
+    },
+    cost: {
+      actualUsd: 1.25,
+      avoidedUsd: 0.5,
+      tokensIn: 400,
+      tokensOut: 150
+    },
+    attempts: [
+      {
+        attemptId: "attempt_1",
+        index: 1,
+        adapterId: "stub",
+        model: "test-model",
+        startedAt: "2026-05-20T15:00:00.000Z",
+        completedAt: "2026-05-20T15:02:00.000Z",
+        summary: "First verifier pass."
+      }
+    ],
+    createdAt: "2026-05-20T15:00:00.000Z",
+    updatedAt: "2026-05-20T15:03:00.000Z"
+  });
+
+  const loop = appendLoopEvent(initial, {
+    type: "verification.completed",
+    lifecycleState: "completed",
+    timestamp: "2026-05-20T15:03:00.000Z",
+    payload: { passed: true, summary: "pnpm test passed." }
+  });
+
+  await mkdir(join(runsRoot, loop.loopId), { recursive: true });
+  await writeFile(join(runsRoot, loop.loopId, "loop-record.json"), JSON.stringify(loop), "utf8");
+  return loop;
+}
+
+describe("0.2.0 read-only cockpit tools", () => {
+  it("lists runs with cost and pressure summaries", async () => {
+    await withRunsRoot(async (runsRoot) => {
+      await writeLoop(runsRoot);
+
+      const result = await listRunsTool({});
+
+      expect(result.runs).toHaveLength(1);
+      expect(result.runs[0]?.loopId).toBe("loop_cockpit");
+      expect(result.runs[0]?.pressure).toBe("healthy");
+      expect(result.runs[0]?.costUsd).toBe(1.25);
+    });
+  });
+
+  it("loads a run attempt verification result and dossier without mutating state", async () => {
+    await withRunsRoot(async (runsRoot) => {
+      await writeLoop(runsRoot);
+
+      const run = await getRunTool({ loopId: "loop_cockpit" });
+      const attempt = await getAttemptTool({ loopId: "loop_cockpit", attemptIndex: 1 });
+      const verification = await getVerificationResultsTool({ loopId: "loop_cockpit" });
+      const dossier = await runDossierTool({ loopId: "loop_cockpit" });
+
+      expect(run.task.objective).toBe("Expose read-only run evidence");
+      expect(attempt.summary).toBe("First verifier pass.");
+      expect(verification.results[0]?.passed).toBe(true);
+      expect(dossier.sections.map((section) => section.kind)).toEqual([
+        "summary",
+        "task",
+        "budget",
+        "attempts",
+        "verification"
+      ]);
+    });
+  });
+});

--- a/packages/mcp/tests/mcp-discovery.test.ts
+++ b/packages/mcp/tests/mcp-discovery.test.ts
@@ -1,0 +1,127 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { appendLoopEvent, createLoopRecord } from "@martin/contracts";
+import { describe, expect, it } from "vitest";
+
+import {
+  listMartinResourceTemplates,
+  listMartinResources,
+  readMartinResource
+} from "../src/resources.js";
+import { getMartinPrompt, listMartinPrompts } from "../src/prompts.js";
+
+async function withRunsRoot<T>(fn: (runsRoot: string) => Promise<T>): Promise<T> {
+  const runsRoot = await mkdtemp(join(tmpdir(), "martin-mcp-discovery-"));
+  const previousRunsRoot = process.env.MARTIN_RUNS_DIR;
+  process.env.MARTIN_RUNS_DIR = runsRoot;
+  try {
+    return await fn(runsRoot);
+  } finally {
+    if (previousRunsRoot === undefined) {
+      delete process.env.MARTIN_RUNS_DIR;
+    } else {
+      process.env.MARTIN_RUNS_DIR = previousRunsRoot;
+    }
+    await rm(runsRoot, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+async function writeRun(runsRoot: string) {
+  const started = createLoopRecord({
+    loopId: "loop_release_ready",
+    workspaceId: "ws_test",
+    projectId: "proj_test",
+    task: {
+      title: "Release MCP cockpit",
+      objective: "Expose read-only run cockpit evidence",
+      verificationPlan: ["pnpm test", "pnpm build"]
+    },
+    budget: {
+      maxUsd: 10,
+      softLimitUsd: 6,
+      maxIterations: 3,
+      maxTokens: 10_000
+    },
+    cost: {
+      actualUsd: 2.4,
+      avoidedUsd: 4,
+      tokensIn: 800,
+      tokensOut: 300
+    },
+    attempts: [
+      {
+        attemptId: "attempt_1",
+        index: 1,
+        adapterId: "stub",
+        model: "test-model",
+        startedAt: "2026-05-20T14:00:00.000Z",
+        completedAt: "2026-05-20T14:02:00.000Z",
+        summary: "Added read-only discovery.",
+        failureClass: "verification_failure",
+        intervention: "run_verifier"
+      }
+    ],
+    createdAt: "2026-05-20T14:00:00.000Z",
+    updatedAt: "2026-05-20T14:03:00.000Z"
+  });
+
+  const loop = appendLoopEvent(started, {
+    type: "verification.completed",
+    lifecycleState: "completed",
+    timestamp: "2026-05-20T14:03:00.000Z",
+    payload: { passed: true, summary: "All MCP release gates passed." }
+  });
+
+  await mkdir(join(runsRoot, loop.loopId), { recursive: true });
+  await writeFile(join(runsRoot, loop.loopId, "loop-record.json"), JSON.stringify(loop), "utf8");
+  return loop;
+}
+
+describe("MCP discovery resources and prompts", () => {
+  it("lists the 0.2.0 static resources and run templates", () => {
+    expect(listMartinResources().map((resource) => resource.uri)).toEqual([
+      "martin://runs/summary",
+      "martin://runs/latest"
+    ]);
+    expect(listMartinResourceTemplates().map((template) => template.uriTemplate)).toEqual([
+      "martin://runs/{loopId}",
+      "martin://runs/{loopId}/attempts/{attemptIndex}",
+      "martin://runs/{loopId}/verification"
+    ]);
+  });
+
+  it("reads run summary latest run and templated run resources", async () => {
+    await withRunsRoot(async (runsRoot) => {
+      const loop = await writeRun(runsRoot);
+
+      const summary = await readMartinResource("martin://runs/summary");
+      const latest = await readMartinResource("martin://runs/latest");
+      const run = await readMartinResource(`martin://runs/${loop.loopId}`);
+      const attempt = await readMartinResource(`martin://runs/${loop.loopId}/attempts/1`);
+      const verification = await readMartinResource(`martin://runs/${loop.loopId}/verification`);
+
+      expect(summary.contents[0]?.text).toContain("loop_release_ready");
+      expect(latest.contents[0]?.text).toContain("Release MCP cockpit");
+      expect(run.contents[0]?.text).toContain("verificationPlan");
+      expect(attempt.contents[0]?.text).toContain("Added read-only discovery");
+      expect(verification.contents[0]?.text).toContain("All MCP release gates passed");
+    });
+  });
+
+  it("lists and renders prompts for review and triage", async () => {
+    expect(listMartinPrompts().map((prompt) => prompt.name)).toEqual([
+      "martin_review_run",
+      "martin_triage_failures"
+    ]);
+
+    const review = getMartinPrompt("martin_review_run", {
+      loopId: "loop_release_ready",
+      objective: "Review MCP release readiness"
+    });
+
+    expect(review.messages[0]?.content.text).toContain("loop_release_ready");
+    expect(review.messages[0]?.content.text).toContain("Review MCP release readiness");
+  });
+});

--- a/scripts/tests/mcp-release-docs.test.mjs
+++ b/scripts/tests/mcp-release-docs.test.mjs
@@ -14,7 +14,22 @@ const EXPECTED_TOOLS = [
   "martin_preflight",
   "martin_run",
   "martin_inspect",
-  "martin_status"
+  "martin_status",
+  "martin_list_runs",
+  "martin_get_run",
+  "martin_get_attempt",
+  "martin_get_verification_results",
+  "martin_run_dossier"
+];
+
+const EXPECTED_RESOURCES_AND_PROMPTS = [
+  "martin://runs/summary",
+  "martin://runs/latest",
+  "martin://runs/{loopId}",
+  "martin://runs/{loopId}/attempts/{attemptIndex}",
+  "martin://runs/{loopId}/verification",
+  "martin_review_run",
+  "martin_triage_failures"
 ];
 
 async function readRepoFile(relativePath) {
@@ -38,7 +53,7 @@ test("current MCP release note exists for the package version", async () => {
   await access(releaseNotesPath);
 });
 
-test("MCP docs stay aligned with the 0.1.4 five-tool cockpit", async () => {
+test("MCP docs stay aligned with the 0.2.0 read-only cockpit", async () => {
   const [serverSource, readme, aiGuide, quickstart, releaseNotes, publishingDoc] = await Promise.all([
     readRepoFile(path.join("packages", "mcp", "src", "server.ts")),
     readRepoFile(path.join("packages", "mcp", "README.md")),
@@ -61,27 +76,26 @@ test("MCP docs stay aligned with the 0.1.4 five-tool cockpit", async () => {
     assert.match(releaseNotes, new RegExp(escapeRegex(toolName)));
   }
 
+  for (const discoveryName of EXPECTED_RESOURCES_AND_PROMPTS) {
+    assert.match(readme, new RegExp(escapeRegex(discoveryName)));
+    assert.match(aiGuide, new RegExp(escapeRegex(discoveryName)));
+    assert.match(releaseNotes, new RegExp(escapeRegex(discoveryName)));
+  }
+
   for (const contents of [readme, aiGuide, quickstart]) {
     assert.match(contents, new RegExp(escapeRegex(codexSnippet)));
     assert.match(contents, new RegExp(escapeRegex(claudeUnixSnippet)));
     assert.match(contents, new RegExp(escapeRegex(claudeWindowsSnippet)));
   }
 
-  for (const futureOnlyClaim of [
-    "martin_list_runs",
-    "martin_triage_runs",
-    "martin_get_run",
-    "martin_get_attempt",
-    "martin_get_verification_results",
-    "martin_run_dossier"
-  ]) {
+  for (const futureOnlyClaim of ["martin_triage_runs", "0.2.5 stable cockpit"]) {
     assert.doesNotMatch(readme, new RegExp(escapeRegex(futureOnlyClaim), "i"));
     assert.doesNotMatch(aiGuide, new RegExp(escapeRegex(futureOnlyClaim), "i"));
     assert.doesNotMatch(quickstart, new RegExp(escapeRegex(futureOnlyClaim), "i"));
   }
 
   assert.match(releaseNotes, new RegExp(`@martinloop/mcp v${packageJson.version.replaceAll(".", "\\.")}`));
-  assert.match(releaseNotes, /What `0\.1\.4` does not claim/);
+  assert.match(releaseNotes, /What `0\.2\.0` does not claim/);
   assert.match(releaseNotes, /smoke:published:pack/);
   assert.match(releaseNotes, /verify:release/);
   assert.match(publishingDoc, /smoke:published:pack/);

--- a/scripts/tests/publish-mcp-workflow.test.mjs
+++ b/scripts/tests/publish-mcp-workflow.test.mjs
@@ -39,7 +39,7 @@ test("publish-mcp workflow covers trusted publishing, local-pack proof, and publ
   assert.match(workflow, /workflow_dispatch:/);
   assert.match(workflow, /inputs:\s*[\s\S]*tag:/);
   assert.match(workflow, /permissions:\s*[\s\S]*id-token:\s*write/);
-  assert.match(workflow, /permissions:\s*[\s\S]*contents:\s*read/);
+  assert.match(workflow, /permissions:\s*[\s\S]*contents:\s*write/);
   assert.match(workflow, /pnpm install --frozen-lockfile/);
   assert.match(workflow, /pnpm --filter @martinloop\/mcp lint/);
   assert.match(workflow, /pnpm --filter @martinloop\/mcp test/);


### PR DESCRIPTION
## Summary
- prepare @martinloop/mcp 0.2.0 as the next clean release after live 0.1.4
- add read-only cockpit tools: martin_list_runs, martin_get_run, martin_get_attempt, martin_get_verification_results, martin_run_dossier
- add MCP resources, resource templates, and prompts for run review and failure triage
- harden pack and install-from-pack smokes so they assert all 10 tools plus resources/templates/prompts
- fix the publish workflow contract test to match the real contents: write permission needed for GitHub release creation

## Verification
- npm view @martinloop/mcp version versions --json confirms live latest is 0.1.4
- gh release list confirms latest MCP release is mcp-v0.1.4
- pnpm --filter @martinloop/mcp test
- pnpm --filter @martinloop/mcp lint
- pnpm --filter @martinloop/mcp build
- pnpm --filter @martinloop/mcp verify:release
- pnpm --filter @martinloop/mcp smoke:pack
- pnpm --filter @martinloop/mcp smoke:published:pack
- pnpm test
- pnpm lint
- MARTIN_RELEASE_MATRIX_OUTDIR=.artifacts/release-matrix/windows-local pnpm release:matrix:local
- git diff --cached --check

## Release note
This PR does not tag or publish. After merge, publish through GitHub Actions with tag mcp-v0.2.0 if CI is green.