### PR TITLE
docs(mcp): clean public v0.2.0 release notes

### DIFF
--- a/docs/release/MCP-0.2.0-RELEASE-NOTES.md
+++ b/docs/release/MCP-0.2.0-RELEASE-NOTES.md
@@ -1,27 +1,25 @@
 # @martinloop/mcp v0.2.0
 
-`0.2.0` is the public cockpit expansion after the `0.1.4` operator foundation. `0.1.4` gave MCP hosts the safe operator lane: doctor, preflight, governed run, inspect, and status. `0.2.0` keeps that execution contract intact and adds a read-only cockpit so hosts can review local run evidence without widening write access.
+`0.2.0` turns the Martin Loop MCP server from a governed execution lane into a small local cockpit for reviewing governed agent runs.
 
-The headline: `martin_run` is still the only write-capable MCP tool. Everything new in `0.2.0` is inspection, review, or triage support over persisted Martin Loop run records.
+`0.1.4` introduced the safe operator foundation: check the environment, preflight a contract, run a governed coding task, and inspect saved results. `0.2.0` keeps that contract intact and adds read-only review surfaces so MCP hosts can show what happened after a run: recent runs, one-run dossiers, individual attempts, verifier results, and guided review prompts.
+
+The important safety boundary is unchanged: `martin_run` is still the only tool that can execute work. The new `0.2.0` additions are read-only inspection and review helpers.
 
 ## What Changed From `0.1.4`
 
 | Area | `0.1.4` | `0.2.0` |
 | --- | --- | --- |
-| Operator readiness | `martin_doctor`, `martin_preflight` | unchanged |
+| Environment checks | `martin_doctor` | unchanged |
+| Run preflight | `martin_preflight` | unchanged |
 | Governed execution | `martin_run` | unchanged write boundary |
-| Basic inspection | `martin_inspect`, `martin_status` | unchanged |
-| Run cockpit | not included | `martin_list_runs`, `martin_get_run`, `martin_get_attempt`, `martin_get_verification_results`, `martin_run_dossier` |
-| MCP discovery | tools only | tools plus resources, resource templates, and prompts |
-| Release hardening | package smoke and published smoke | smoke gates now assert all 10 tools and discovery surfaces |
+| Basic run inspection | `martin_inspect`, `martin_status` | unchanged |
+| Review cockpit | not included | run lists, dossiers, attempts, verifier results |
+| MCP discovery | tools | tools, resources, resource templates, prompts |
 
-## Why This Matters
+## Tools
 
-MCP hosts can now show a practical Martin Loop cockpit: recent runs, one-run dossiers, individual attempts, verifier results, and review prompts. That makes Martin Loop easier to trust in real workflows because users can see what happened, what it cost, what passed, and what still needs review.
-
-## Added
-
-Existing `0.1.4` operator tools remain in the release surface:
+Existing tools:
 
 - `martin_doctor`
 - `martin_preflight`
@@ -32,70 +30,41 @@ Existing `0.1.4` operator tools remain in the release surface:
 New read-only cockpit tools:
 
 - `martin_list_runs` lists recent governed run summaries from the local run store.
-- `martin_get_run` returns a read-only run dossier by `loopId` or `latest`.
+- `martin_get_run` returns a run dossier by `loopId` or `latest`.
 - `martin_get_attempt` returns one attempt record by `loopId` and `attemptIndex`.
 - `martin_get_verification_results` extracts verifier completion events.
 - `martin_run_dossier` assembles summary, task, budget, attempts, and verification evidence for review.
 
-New resources:
+## Resources
 
 - `martin://runs/summary`
 - `martin://runs/latest`
 
-New resource templates:
+## Resource Templates
 
 - `martin://runs/{loopId}`
 - `martin://runs/{loopId}/attempts/{attemptIndex}`
 - `martin://runs/{loopId}/verification`
 
-New prompts:
+## Prompts
 
 - `martin_review_run`
 - `martin_triage_failures`
 
-## Hardened
-
-- Release workflow contract now explicitly permits GitHub release creation with `contents: write`.
-- Package and `server.json` metadata remain version-aligned for npm and MCP registry publication.
-- New cockpit tests cover resources, resource templates, prompts, run listing, attempt reads, verifier extraction, and dossiers.
-- Local pack smoke and install-from-pack smoke now fail if any expected `0.2.0` tool, resource, template, or prompt is missing.
-
 ## Upgrade Notes
 
-- Existing `0.1.4` tool callers do not need to change their `martin_doctor`, `martin_preflight`, `martin_run`, `martin_inspect`, or `martin_status` calls.
-- Hosts can opt into the new cockpit surface by listing tools, resources, resource templates, and prompts through the normal MCP discovery methods.
-- The npm package name remains `@martinloop/mcp`.
-- The MCP registry server name remains `io.github.Keesan12/martin-loop`.
-
-## What `0.2.0` does not claim
-
-- It does not include the removed `0.2.5` branch or skipped stable-cockpit work.
-- It does not publish private Pro, Growth, Enterprise, Internal, hosted control-plane, autonomy, or router features.
-- It does not add remote MCP auth, bearer-token control planes, or hosted team dashboards.
-- It does not make `martin_run` broader than the existing governed local execution contract.
+- Existing `0.1.4` tool callers do not need to change their current calls.
+- Hosts can opt into the new cockpit surface by listing tools, resources, resource templates, and prompts through normal MCP discovery.
+- The npm package remains `@martinloop/mcp`.
+- The MCP server name remains `io.github.Keesan12/martin-loop`.
 
 ## Verification
 
-The `0.2.0` release candidate was checked with:
+The published package was verified from npm after release. The published smoke test confirmed:
 
-```powershell
-pnpm --filter @martinloop/mcp lint
-pnpm --filter @martinloop/mcp test
-pnpm --filter @martinloop/mcp build
-pnpm --filter @martinloop/mcp smoke:pack
-pnpm --filter @martinloop/mcp smoke:published:pack
-pnpm --filter @martinloop/mcp verify:release
-pnpm release:matrix:local
-```
-
-The public PR release matrix also passed on Windows, macOS, and Ubuntu before release tagging.
-
-## Release Path
-
-Publish through `.github/workflows/publish-mcp.yml` with tag `mcp-v0.2.0`; do not publish locally unless GitHub Actions is unavailable and the fallback is explicitly approved. After publish, verify:
-
-```powershell
-npm view @martinloop/mcp version versions --json
-gh release view mcp-v0.2.0 --repo Keesan12/martin-loop
-pnpm --filter @martinloop/mcp smoke:published
-```
+- package version `@martinloop/mcp@0.2.0`
+- all 10 tools are discoverable
+- both resources are discoverable
+- all 3 resource templates are discoverable
+- both prompts are discoverable
+- local run inspection, status, run listing, dossier generation, and governed stub execution work from the installed npm artifact

--- a/scripts/tests/mcp-release-docs.test.mjs
+++ b/scripts/tests/mcp-release-docs.test.mjs
@@ -32,6 +32,25 @@ const EXPECTED_RESOURCES_AND_PROMPTS = [
   "martin_triage_failures"
 ];
 
+const FORBIDDEN_PUBLIC_RELEASE_NOTE_PATTERNS = [
+  /0\.2\.5/i,
+  /\bremoved\b/i,
+  /\bskipped\b/i,
+  /\bbranch\b/i,
+  /\bprivate\b/i,
+  /\bpro\b/i,
+  /\bgrowth\b/i,
+  /\benterprise\b/i,
+  /\binternal\b/i,
+  /hosted control-plane/i,
+  /\bautonomy\b/i,
+  /\brouter\b/i,
+  /workflow contract/i,
+  /contents:\s*write/i,
+  /do not publish locally/i,
+  /\brelease path\b/i
+];
+
 async function readRepoFile(relativePath) {
   return readFile(path.join(ROOT_DIR, relativePath), "utf8");
 }
@@ -95,11 +114,20 @@ test("MCP docs stay aligned with the 0.2.0 read-only cockpit", async () => {
   }
 
   assert.match(releaseNotes, new RegExp(`@martinloop/mcp v${packageJson.version.replaceAll(".", "\\.")}`));
-  assert.match(releaseNotes, /What `0\.2\.0` does not claim/);
-  assert.match(releaseNotes, /smoke:published:pack/);
-  assert.match(releaseNotes, /verify:release/);
+  assert.match(releaseNotes, /What Changed From `0\.1\.4`/);
+  assert.match(releaseNotes, /published package was verified from npm/i);
   assert.match(publishingDoc, /smoke:published:pack/);
   assert.match(publishingDoc, /verify:release/);
   assert.match(publishingDoc, /workflow_dispatch/i);
   assert.match(publishingDoc, /release notes/i);
+});
+
+test("public MCP release notes do not expose private roadmap or workflow plumbing", async () => {
+  const releaseNotes = await readRepoFile(
+    path.join("docs", "release", `MCP-${packageJson.version}-RELEASE-NOTES.md`)
+  );
+
+  for (const pattern of FORBIDDEN_PUBLIC_RELEASE_NOTE_PATTERNS) {
+    assert.doesNotMatch(releaseNotes, pattern);
+  }
 });


### PR DESCRIPTION
## Summary
- Rewrite the `@martinloop/mcp` v0.2.0 release notes as a public package changelog focused on user-visible behavior.
- Add a release-doc guardrail test so this release note stays focused on package features, upgrade notes, and npm verification.
- Update the live GitHub release body from the cleaned release-note file.

## Verification
- `pnpm exec node --test scripts/tests/mcp-release-docs.test.mjs`
- `pnpm --filter @martinloop/mcp verify:release`
- `git diff --check`
- Live GitHub release body scan for non-public wording