### PR TITLE
docs: add public release guardrails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# Martin Loop OSS Agent Instructions
+
+## Project Overview
+
+Martin Loop OSS is the public local-first runtime, CLI, and MCP workspace for governed AI coding loops.
+
+This repository is a public surface. Keep all docs, release notes, PRs, package metadata, examples, screenshots, comments, and changelogs suitable for public users and external review.
+
+## Setup And Commands
+
+- Use `pnpm@10.33.0`.
+- Install dependencies with `pnpm install --frozen-lockfile`.
+- Run the full test suite with `pnpm test`.
+- Run the release matrix locally with `pnpm release:matrix:local`.
+- Validate MCP release readiness with `pnpm --filter @martinloop/mcp verify:release`.
+- Validate public package boundaries with `pnpm oss:validate`.
+
+## Public Repo Surface Standard
+
+- Rule: every public-facing repo file, release note, package README, GitHub release, npm metadata entry, public PR description, doc, example, screenshot, and changelog must be clean client-facing copy.
+- Guardrail: preserve internal work and ideas in private handoffs, planning docs, release playbooks, or internal repos. Before publishing, editing, merging, or summarizing public material, scan for and remove internal repo names, local machine paths, private roadmap language, removed-branch/process notes, workflow plumbing, paid-tier plans, private implementation commentary, customer-sensitive details, and workspace chatter.
+- Verification: final public-surface status must name the surface checked and the guardrail used, such as `pnpm exec node --test scripts/tests/mcp-release-docs.test.mjs`, a forbidden-term scan, `gh release view`, `npm view`, `rg`, or `pnpm oss:validate`.
+
+## Release Workflow
+
+- Publish public packages through GitHub Actions release workflows by default.
+- Do not publish locally unless the workflow path is unavailable and the user explicitly approves a fallback.
+- Keep the root `martin-loop` package version separate from the standalone `@martinloop/mcp` package version.
+- For MCP releases, keep `packages/mcp/package.json`, `packages/mcp/server.json`, release docs, and published package smoke tests aligned.
+
+## Code Style
+
+- Prefer small, auditable changes.
+- Keep public-facing language concise, user-centered, client-facing, and free of workspace/process chatter.
+- Use existing scripts and tests before adding new release machinery.
+
+## Safety And Security
+
+- Treat credentials, local paths, private URLs, workspace names, and unpublished roadmap details as non-public.
+- Do not add secrets, tokens, or machine-specific paths to tracked files.
+- If a public artifact appears contaminated, clean or close it before merging.

--- a/scripts/oss-boundary.mjs
+++ b/scripts/oss-boundary.mjs
@@ -20,6 +20,7 @@ const ALLOWED_TOP_LEVEL_ENTRIES = [
   "packages",
   "scripts",
   ".gitignore",
+  "AGENTS.md",
   "CHANGELOG.md",
   "CODE_OF_CONDUCT.md",
   "CONTRIBUTING.md",


### PR DESCRIPTION
## Summary
- Add a public repo `AGENTS.md` so future agents working in this repo inherit the public-surface hygiene standard.
- Make `AGENTS.md` an intentional allowed top-level public file in the OSS boundary validator.
- Standardize the rule that public repo surfaces must stay clean, client-facing, and free of non-public workspace/process language.

## Verification
- `pnpm oss:validate`
- `pnpm exec node --test scripts/tests/mcp-release-docs.test.mjs`
- `git diff --check`