### PR TITLE
ci: harden root npm publish token fallback

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,9 +63,42 @@ jobs:
 
       - name: Publish to npm
         if: steps.npm-version.outputs.exists != 'true'
+        id: npm-publish
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_GITHUB_RELEASE != '' && secrets.NPM_TOKEN_GITHUB_RELEASE || secrets.NPM_TOKEN }}
-        run: npm publish "${{ steps.root-pack.outputs.tarball }}" --access public --provenance
+          NPM_TOKEN_GITHUB_RELEASE: ${{ secrets.NPM_TOKEN_GITHUB_RELEASE }}
+          NPM_TOKEN_AUTOMATION: ${{ secrets.NPM_TOKEN_AUTOMATION }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          for token_name in NPM_TOKEN_GITHUB_RELEASE NPM_TOKEN_AUTOMATION NPM_TOKEN; do
+            token="${!token_name:-}"
+            if [ -z "$token" ]; then
+              echo "$token_name is not configured; skipping."
+              continue
+            fi
+
+            echo "::add-mask::$token"
+            if ! NODE_AUTH_TOKEN="$token" npm whoami --registry=https://registry.npmjs.org >/dev/null 2>&1; then
+              echo "::warning::$token_name failed npm whoami; trying the next configured token."
+              continue
+            fi
+
+            echo "Publishing with npm auth token: $token_name"
+            if NODE_AUTH_TOKEN="$token" npm publish "${{ steps.root-pack.outputs.tarball }}" --access public --provenance; then
+              echo "token_source=$token_name" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+
+            if npm view "martin-loop@${{ steps.package-version.outputs.version }}" version >/dev/null 2>&1; then
+              echo "token_source=$token_name" >> "$GITHUB_OUTPUT"
+              echo "martin-loop@${{ steps.package-version.outputs.version }} became visible on npm after publish returned non-zero."
+              exit 0
+            fi
+
+            echo "::warning::$token_name authenticated but could not publish martin-loop@${{ steps.package-version.outputs.version }}; trying the next configured token."
+          done
+
+          echo "::error::No configured npm token could publish martin-loop@${{ steps.package-version.outputs.version }}."
+          exit 1
 
       - name: Skip duplicate npm publish
         if: steps.npm-version.outputs.exists == 'true'

--- a/scripts/tests/root-release-workflow.test.mjs
+++ b/scripts/tests/root-release-workflow.test.mjs
@@ -1,0 +1,27 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+test("root release workflow validates npm auth before publishing", async () => {
+  const workflowPath = path.join(ROOT_DIR, ".github", "workflows", "release.yml");
+  const workflow = await readFile(workflowPath, "utf8");
+
+  assert.match(workflow, /push:\s*[\s\S]*tags:\s*[\s\S]*"v\*\.\*\.\*"/);
+  assert.match(workflow, /permissions:\s*[\s\S]*contents:\s*write/);
+  assert.match(workflow, /permissions:\s*[\s\S]*id-token:\s*write/);
+  assert.match(workflow, /id: npm-publish/);
+  assert.match(workflow, /NPM_TOKEN_GITHUB_RELEASE/);
+  assert.match(workflow, /NPM_TOKEN_AUTOMATION/);
+  assert.match(workflow, /NPM_TOKEN:/);
+  assert.match(workflow, /for token_name in NPM_TOKEN_GITHUB_RELEASE NPM_TOKEN_AUTOMATION NPM_TOKEN/);
+  assert.match(workflow, /npm whoami --registry=https:\/\/registry\.npmjs\.org/);
+  assert.match(workflow, /failed npm whoami; trying the next configured token/);
+  assert.match(workflow, /authenticated but could not publish/);
+  assert.match(workflow, /npm publish "\$\{\{ steps\.root-pack\.outputs\.tarball \}\}" --access public --provenance/);
+  assert.match(workflow, /npm view "martin-loop@\$\{\{ steps\.package-version\.outputs\.version \}\}" version/);
+  assert.match(workflow, /softprops\/action-gh-release@v2/);
+});


### PR DESCRIPTION
## Summary
- make the root release workflow verify npm auth before publishing
- try configured publish tokens in order instead of failing on a stale token
- add a workflow guard test for the root release publish path

## Verification
- pnpm exec node --test scripts/tests/root-release-workflow.test.mjs
- pnpm exec node --test scripts/tests/*.mjs
- pnpm oss:validate
- git diff --check
- public-surface forbidden-term scan over README.md, CHANGELOG.md, package.json, release workflow, and the new workflow test