### PR TITLE
ci: use trusted publishing for root release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,12 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           registry-url: "https://registry.npmjs.org"
           cache: pnpm
+
+      - name: Use latest npm for trusted publishing
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -63,8 +66,6 @@ jobs:
 
       - name: Publish to npm
         if: steps.npm-version.outputs.exists != 'true'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_GITHUB_RELEASE != '' && secrets.NPM_TOKEN_GITHUB_RELEASE || secrets.NPM_TOKEN }}
         run: npm publish "${{ steps.root-pack.outputs.tarball }}" --access public --provenance
 
       - name: Skip duplicate npm publish

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,8 @@ This repository is a public surface. Keep all docs, release notes, PRs, package 
 ## Release Workflow
 
 - Publish public packages through GitHub Actions release workflows by default.
+- When npm trusted publishing is connected, use GitHub Actions trusted publishing/OIDC only. Do not add, use, prefer, or fall back to npm publish tokens (`NPM_TOKEN`, `NODE_AUTH_TOKEN`, token selection, or local `npm publish`) unless Keesan explicitly approves an exception after trusted publishing is proven unavailable.
+- If trusted publishing fails, debug the trusted-publisher setup, workflow identity, tag/ref trigger, package mapping, runner Node/npm version, and live npm/GitHub release state before changing release mechanics.
 - Do not publish locally unless the workflow path is unavailable and the user explicitly approves a fallback.
 - Keep the root `martin-loop` package version separate from the standalone `@martinloop/mcp` package version.
 - For MCP releases, keep `packages/mcp/package.json`, `packages/mcp/server.json`, release docs, and published package smoke tests aligned.

--- a/scripts/tests/root-release-workflow.test.mjs
+++ b/scripts/tests/root-release-workflow.test.mjs
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+test("root release workflow uses GitHub Actions trusted publishing without npm tokens", async () => {
+  const workflowPath = path.join(ROOT_DIR, ".github", "workflows", "release.yml");
+  const workflow = await readFile(workflowPath, "utf8");
+
+  assert.match(workflow, /push:\s*[\s\S]*tags:\s*[\s\S]*"v\*\.\*\.\*"/);
+  assert.match(workflow, /permissions:\s*[\s\S]*contents:\s*write/);
+  assert.match(workflow, /permissions:\s*[\s\S]*id-token:\s*write/);
+  assert.match(workflow, /node-version:\s*24/);
+  assert.match(workflow, /npm install -g npm@latest/);
+  assert.match(workflow, /npm publish "\$\{\{ steps\.root-pack\.outputs\.tarball \}\}" --access public --provenance/);
+  assert.match(workflow, /npm view "martin-loop@\$\{\{ steps\.package-version\.outputs\.version \}\}" version/);
+  assert.match(workflow, /softprops\/action-gh-release@v2/);
+
+  assert.doesNotMatch(workflow, /NODE_AUTH_TOKEN/);
+  assert.doesNotMatch(workflow, /NPM_TOKEN/);
+  assert.doesNotMatch(workflow, /secrets\./);
+});


### PR DESCRIPTION
## Summary
- remove npm token usage from the root release workflow
- run root releases on Node 24 with latest npm for GitHub Actions trusted publishing
- add a guard test that blocks token-based root release workflow drift
- document the trusted-publishing-only rule in repo agent instructions

## Verification
- pnpm exec node --test scripts/tests/root-release-workflow.test.mjs
- pnpm exec node --test scripts/tests/*.mjs
- pnpm oss:validate
- git diff --check
- rg scan confirmed the root release workflow has no NODE_AUTH_TOKEN, NPM_TOKEN, token-selection, or npm secret usage