### PR TITLE
ci: remove npm auth setup from publish workflows

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -52,7 +52,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '24'
-          registry-url: 'https://registry.npmjs.org'
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24
-          registry-url: "https://registry.npmjs.org"
           cache: pnpm
 
       - name: Use latest npm for trusted publishing

--- a/scripts/tests/publish-mcp-workflow.test.mjs
+++ b/scripts/tests/publish-mcp-workflow.test.mjs
@@ -52,6 +52,10 @@ test("publish-mcp workflow covers trusted publishing, local-pack proof, and publ
   assert.match(workflow, /pnpm --filter @martinloop\/mcp smoke:published/);
   assert.match(workflow, /softprops\/action-gh-release@v2/);
   assert.match(workflow, /body_path:\s*docs\/release\/MCP-\$\{\{ steps\.mcp-metadata\.outputs\.package_version \}\}-RELEASE-NOTES\.md/);
+  assert.doesNotMatch(workflow, /registry-url/);
+  assert.doesNotMatch(workflow, /NODE_AUTH_TOKEN/);
+  assert.doesNotMatch(workflow, /NPM_TOKEN/);
+  assert.doesNotMatch(workflow, /secrets\./);
 });
 
 test("metadata reader emits GitHub output keys from packages/mcp", () => {

--- a/scripts/tests/root-release-workflow.test.mjs
+++ b/scripts/tests/root-release-workflow.test.mjs
@@ -21,5 +21,6 @@ test("root release workflow uses GitHub Actions trusted publishing without npm t
 
   assert.doesNotMatch(workflow, /NODE_AUTH_TOKEN/);
   assert.doesNotMatch(workflow, /NPM_TOKEN/);
+  assert.doesNotMatch(workflow, /registry-url/);
   assert.doesNotMatch(workflow, /secrets\./);
 });


### PR DESCRIPTION
## Summary
- remove setup-node registry auth configuration from root and MCP publish workflows
- keep npm publishing on GitHub Actions trusted publishing/OIDC
- strengthen workflow tests so registry-url, NODE_AUTH_TOKEN, NPM_TOKEN, and secrets cannot creep back into publish workflows

## Verification
- pnpm exec node --test scripts/tests/root-release-workflow.test.mjs scripts/tests/publish-mcp-workflow.test.mjs
- pnpm exec node --test scripts/tests/*.mjs
- git diff --check
- rg scan confirmed no registry-url, NODE_AUTH_TOKEN, NPM_TOKEN, or secrets usage in root/MCP publish workflows