### PR TITLE
fix: ensure --budget alias properly overrides yaml config

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -961,7 +961,7 @@ async function resolveGuardrails(
     maxTokens: config?.budget?.maxTokens ?? request.budget.maxTokens
   };
 
-  if (hasFlag(tokens, "--budget-usd")) {
+  if (hasFlag(tokens, "--budget-usd") || hasFlag(tokens, "--budget")) {
     budget.maxUsd = request.budget.maxUsd;
   }
   if (hasFlag(tokens, "--soft-limit-usd")) {


### PR DESCRIPTION
When a martin.config.yaml file is present, the \--budget\ CLI alias was ignored because the resolver explicitly only checked for \--budget-usd\. This adds \--budget\ to the check to ensure the CLI flag properly overrides the file defaults.