### PR TITLE
Prepare martin-loop 0.2.6 root release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.2.6] — 2026-05-28
+
+### Added
+- **Audit remediation closure** — Added the root `0.2.6` public release notes for the completed OSS security and correctness follow-up slice.
+
+### Changed
+- **Runtime hardening** — Closed the remaining root-package remediation items across verifier-command blocking, context-integrity coverage, secret redaction, safe-path validation, pricing, and cache invalidation.
+- **Release proof lane** — Synced the root package version, public README surfaces, quickstart docs, and root release guard to the shipped `0.2.6` contract while keeping `@martinloop/mcp` on `0.2.5`.
+
 ## [0.2.5] — 2026-05-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ If you try MartinLoop, I would value blunt feedback on where a control layer sho
 npm install -g martin-loop
 ```
 
-This installs the public `martin-loop` CLI package. This README is synced for `martin-loop@0.2.5`.
+This installs the public `martin-loop` CLI package. This README is synced for `martin-loop@0.2.6`.
 
 Want a safe sandbox first? Run `npx martin-loop demo` and MartinLoop will copy a disposable local workspace into `./martin-loop-demo`.
 
@@ -176,16 +176,16 @@ npx martin-loop triage
 
 `triage` ranks persisted runs using failure categories such as failed verification, budget exits, human escalation, and missing verification evidence. If a saved run entry is unreadable, MartinLoop skips it and surfaces a warning instead of aborting the whole review.
 
-### What's New In 0.2.5
+### What's New In 0.2.6
 
-`martin-loop@0.2.5` ships the stable cockpit line for the standalone MCP package and the matching root-package release surface.
+`martin-loop@0.2.6` closes the public root-package remediation slice while keeping the standalone MCP package on the stable `0.2.5` line.
 
-- `martin_triage_runs` for faster review of persisted run failures and warnings
-- compact proof resources such as latest summary, proof card, budget status, verifier evidence, rollback evidence, and next-step guidance
-- degraded run-store hardening so unreadable entries surface warnings instead of taking down the review flow
+- hardened verifier blocking for destructive command bypass families and high-signal secret patterns
+- broader context-integrity scanning across task metadata and verifier output before those channels re-enter the loop
+- model-aware budget pricing, grounding cache invalidation, and safer local `martin_run` abuse controls
 - release-proof updates across README, release notes, workflow checks, and package metadata
 
-See [OSS-0.2.5 release notes](./docs/release/OSS-0.2.5-RELEASE-NOTES.md) and [MCP 0.2.5 release notes](./docs/release/MCP-0.2.5-RELEASE-NOTES.md) for the public feature contract.
+See [OSS-0.2.6 release notes](./docs/release/OSS-0.2.6-RELEASE-NOTES.md) and [MCP 0.2.5 release notes](./docs/release/MCP-0.2.5-RELEASE-NOTES.md) for the public feature contract.
 
 ### Public Package Surface
 

--- a/docs/oss/QUICKSTART.md
+++ b/docs/oss/QUICKSTART.md
@@ -1,12 +1,13 @@
 # Quickstart
 
-This quickstart covers the public OSS runtime and the standalone `@martinloop/mcp` package.
+This quickstart covers the public OSS runtime at `martin-loop@0.2.6` and the standalone `@martinloop/mcp@0.2.5` package.
 
 ## Public Release Train
 
 - 0.1.4 operator foundation.
 - 0.2.0 cockpit expansion. 0.2.0 adds resources, resource templates, prompts, and read-only cockpit inspection.
 - 0.2.5 stable cockpit line with local triage and degraded run-store hardening.
+- 0.2.6 root remediation slice for the public runtime and CLI.
 
 ## Prerequisites
 

--- a/docs/oss/README.md
+++ b/docs/oss/README.md
@@ -39,7 +39,7 @@ pnpm rc:validate
 
 ## Notes
 
-- Release focus: stable cockpit guidance for local triage, compact proof receipts, and degraded run-store hardening.
+- Release focus: root `0.2.6` remediation for the public local runtime and CLI while the standalone MCP package remains on `0.2.5`.
 
 - The root `martin-loop` package and the standalone `@martinloop/mcp` package use separate release tracks. Always verify both lines in [`../release/VERSION-LEDGER.md`](../release/VERSION-LEDGER.md) before release work.
 - `@martinloop/mcp` is published and released independently from the root package.
@@ -52,5 +52,5 @@ pnpm rc:validate
 - [QUICKSTART.md](./QUICKSTART.md)
 - [AGENT-START-HERE.md](./AGENT-START-HERE.md)
 - [EXAMPLES.md](./EXAMPLES.md)
-- [OSS-0.2.5-RELEASE-NOTES.md](../release/OSS-0.2.5-RELEASE-NOTES.md)
+- [OSS-0.2.6-RELEASE-NOTES.md](../release/OSS-0.2.6-RELEASE-NOTES.md)
 - [../../README.md](../../README.md)

--- a/docs/release/OSS-0.2.6-RELEASE-NOTES.md
+++ b/docs/release/OSS-0.2.6-RELEASE-NOTES.md
@@ -1,0 +1,17 @@
+# MartinLoop OSS `0.2.6` Release Notes
+
+`martin-loop@0.2.6` closes the public root-package remediation slice for the OSS runtime and CLI.
+
+## Included
+
+- verifier-command hardening for destructive command bypass families
+- broader context-integrity coverage across task metadata and verifier output
+- safer secret redaction, path validation, and local MCP run-rate controls
+- model-aware budget pricing and grounding cache invalidation
+- root-package release-proof updates for the `0.2.6` contract
+
+## Not Included
+
+- a new standalone MCP package release; `@martinloop/mcp` remains on `0.2.5`
+- any non-OSS deployment surfaces
+- non-public release workflows, prep artifacts, or internal release notes

--- a/docs/release/VERSION-LEDGER.md
+++ b/docs/release/VERSION-LEDGER.md
@@ -4,8 +4,8 @@ This file is the canonical version map for release work. Do not push, tag, or pu
 
 ## Root package: `martin-loop`
 
-- live npm dist-tag `latest` before `v0.2.5`: `0.2.4`
-- public GitHub `main` target for the `v0.2.5` release: `0.2.5`
+- live npm dist-tag `latest` before `v0.2.6`: `0.2.5`
+- public GitHub `main` target for the `v0.2.6` release: `0.2.6`
 - release rule: treat the root package as its own semver line and do not infer standalone MCP versioning from it
 
 ## Standalone MCP package: `@martinloop/mcp`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "martin-loop",
   "private": false,
-  "version": "0.2.5",
+  "version": "0.2.6",
   "type": "module",
   "description": "Open-source control plane for AI coding agents with budget caps, verifier gates, and audit trails.",
   "packageManager": "pnpm@10.33.0",

--- a/packages/cli/tests/cli.test.ts
+++ b/packages/cli/tests/cli.test.ts
@@ -7,6 +7,8 @@ import { describe, expect, it } from "vitest";
 import { createLoopRecord } from "../../contracts/src/index.js";
 import { executeCli, parseCliArguments } from "../src/index.js";
 
+const CLI_EXEC_TIMEOUT_MS = 15_000;
+
 describe("parseCliArguments", () => {
   it("parses a run command into a typed request", () => {
     const parsed = parseCliArguments([
@@ -65,7 +67,7 @@ describe("parseCliArguments", () => {
 });
 
 describe("executeCli", () => {
-  it("resolves effectivePolicy from config and applies it to the run", async () => {
+  it("resolves effectivePolicy from config and applies it to the run", { timeout: CLI_EXEC_TIMEOUT_MS }, async () => {
     const directory = await mkdtemp(join(tmpdir(), "martin-cli-config-"));
     const configPath = join(directory, "martin.config.yaml");
 
@@ -139,7 +141,7 @@ describe("executeCli", () => {
     }
   });
 
-  it("surfaces effective governance policy metadata in run output", async () => {
+  it("surfaces effective governance policy metadata in run output", { timeout: CLI_EXEC_TIMEOUT_MS }, async () => {
     const configPath = join(process.env.INIT_CWD ?? process.cwd(), "martin.config.yaml");
     const prevLive = process.env.MARTIN_LIVE;
     process.env.MARTIN_LIVE = "false";
@@ -192,7 +194,7 @@ describe("executeCli", () => {
     expect(payload.loop.task.verificationPlan).toEqual(["pnpm test"]);
   });
 
-  it("supports verify-only runs without invoking a coding adapter", async () => {
+  it("supports verify-only runs without invoking a coding adapter", { timeout: CLI_EXEC_TIMEOUT_MS }, async () => {
     const directory = await mkdtemp(join(tmpdir(), "martin-cli-verify-only-"));
 
     try {
@@ -223,7 +225,7 @@ describe("executeCli", () => {
     }
   });
 
-  it("resolves a relative --config path from INIT_CWD for filtered dev runs", async () => {
+  it("resolves a relative --config path from INIT_CWD for filtered dev runs", { timeout: CLI_EXEC_TIMEOUT_MS }, async () => {
     const directory = await mkdtemp(join(tmpdir(), "martin-cli-init-cwd-"));
     const packageDirectory = join(directory, "packages", "cli");
     const configPath = join(directory, "martin.config.example.yaml");

--- a/packages/core/tests/runtime.test.ts
+++ b/packages/core/tests/runtime.test.ts
@@ -21,6 +21,8 @@ import {
   type MartinAdapterRequest
 } from "../src/index";
 
+const RUNTIME_REPO_FIXTURE_TIMEOUT_MS = 15_000;
+
 describe("distillContext", () => {
   it("keeps the latest attempts and exposes the remaining budget envelope", () => {
     const loop = createLoopRecord({
@@ -1372,7 +1374,10 @@ const store: import("../src/index").RunStore = {
     expect(patchDecision.reasonCodes).toContain("grounding_failure");
   });
 
-  it("restores the pre-attempt repo boundary for discarded verifier regressions and preserves pre-existing dirty files", async () => {
+  it(
+    "restores the pre-attempt repo boundary for discarded verifier regressions and preserves pre-existing dirty files",
+    { timeout: RUNTIME_REPO_FIXTURE_TIMEOUT_MS },
+    async () => {
     const runsRoot = await mkdtemp(join(tmpdir(), "martin-patch-rollback-"));
     const repoRoot = join(runsRoot, "repo");
     await mkdir(join(repoRoot, "src"), { recursive: true });
@@ -1468,9 +1473,13 @@ const store: import("../src/index").RunStore = {
     expect(rollbackOutcome.status).toBe("restored");
     expect(rollbackOutcome.deletedFiles).toContain("src/ghost-new-file.ts");
     expect(rollbackOutcome.after.trackedDirtyFiles).toEqual(["src/real.ts"]);
-  });
+    }
+  );
 
-  it("restores forbidden file changes on the filesystem safety-block path and persists rollback artifacts", async () => {
+  it(
+    "restores forbidden file changes on the filesystem safety-block path and persists rollback artifacts",
+    { timeout: RUNTIME_REPO_FIXTURE_TIMEOUT_MS },
+    async () => {
     const runsRoot = await mkdtemp(join(tmpdir(), "martin-patch-scope-rollback-"));
     const repoRoot = join(runsRoot, "repo");
     await mkdir(join(repoRoot, "src"), { recursive: true });
@@ -1562,7 +1571,8 @@ const store: import("../src/index").RunStore = {
     expect(patchDecision.reasonCodes).toContain("scope_violation");
     expect(rollbackOutcome.status).toBe("restored");
     expect(rollbackOutcome.deletedFiles).toContain("apps/leak.ts");
-  });
+    }
+  );
 
   it("writes consistent admission and settlement ledger payloads across mixed adapter types", async () => {
     const runsRoot = await mkdtemp(join(tmpdir(), "martin-adapter-ledger-"));

--- a/scripts/tests/root-release-guard.test.mjs
+++ b/scripts/tests/root-release-guard.test.mjs
@@ -14,12 +14,12 @@ const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../
 test("runRootReleaseGuard accepts the current OSS-safe root package shape", async () => {
   const result = await runRootReleaseGuard({
     rootDir: ROOT_DIR,
-    tag: "v0.2.5",
+    tag: "v0.2.6",
   });
 
   assert.equal(result.name, "martin-loop");
-  assert.equal(result.version, "0.2.5");
-  assert.equal(result.tag, "v0.2.5");
+  assert.equal(result.version, "0.2.6");
+  assert.equal(result.tag, "v0.2.6");
   assert.equal(result.packChecked, false);
 });
 


### PR DESCRIPTION
## Summary
- prepare the public root package release for martin-loop@0.2.6
- keep the standalone MCP package on @martinloop/mcp@0.2.5
- align public release notes, docs, and version guards for the root-only release slice

## Verification
- pnpm install --frozen-lockfile
- pnpm lint
- pnpm test
- pnpm build
- pnpm public:git-surface
- pnpm oss:validate
- pnpm public:smoke
- pnpm rc:validate