### PR TITLE
Fix doctor version banner after 0.2.6 release

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -49,6 +49,13 @@ import { CliCommandError, renderCliError, renderCliSuccess } from "./ux.js";
 
 const require = createRequire(import.meta.url);
 const packageJson = require("../package.json") as { version: string };
+const rootPackageVersion = (() => {
+  try {
+    return (require("../../../package.json") as { version?: string }).version ?? packageJson.version;
+  } catch {
+    return packageJson.version;
+  }
+})();
 
 export type RunCommandRequest = {
   workspaceId: string;
@@ -756,7 +763,7 @@ async function executeDoctorCommand(
 
   const data = {
     command: "doctor",
-    cliVersion: packageJson.version,
+    cliVersion: rootPackageVersion,
     environment,
     config: {
       path: configPath,
@@ -779,7 +786,7 @@ async function executeDoctorCommand(
   return renderCliSuccess(outputMode, {
     data,
     human: [
-      `Martin CLI doctor (${packageJson.version})`,
+      `Martin CLI doctor (${rootPackageVersion})`,
       `Working directory: ${environment.workingDirectory} (${workingDirectoryReady ? "ready" : "missing"})`,
       `Runs root: ${environment.runsRoot} (${runsRootReady ? "ready" : "not created yet"})`,
       `Live mode: ${environment.liveMode}`,

--- a/packages/cli/tests/operator-commands.test.ts
+++ b/packages/cli/tests/operator-commands.test.ts
@@ -6,6 +6,7 @@ import { createLoopRecord, type LoopEventDraft } from "@martin/contracts";
 import { describe, expect, it } from "vitest";
 
 import { executeCli } from "../src/index.js";
+import rootPackageJson from "../../../package.json" with { type: "json" };
 
 function makeLoopRecord() {
   const loop = createLoopRecord({
@@ -111,7 +112,7 @@ describe("operator commands", () => {
 
     expect(result.exitCode).toBe(0);
     expect(payload.command).toBe("doctor");
-    expect(payload.cliVersion).toBeTypeOf("string");
+    expect(payload.cliVersion).toBe(rootPackageJson.version);
     expect(payload.starterTools).toContain("martin_doctor");
     expect(payload.environment.runsRoot).toBeTypeOf("string");
   });


### PR DESCRIPTION
## Summary
- make martin-loop doctor report the published root package version instead of the internal CLI workspace version
- keep a safe fallback to the CLI package manifest if the root manifest is unavailable
- add regression coverage for the doctor version payload

## Verification
- pnpm --filter @martin/cli test
- pnpm --filter @martin/cli lint
- pnpm build
- pnpm public:smoke