### PR TITLE
docs: add community templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,19 +8,35 @@ body:
     id: summary
     attributes:
       label: What happened?
-      description: Describe the bug and what you expected instead.
+      description: Describe the bug in one or two paragraphs.
       placeholder: MartinLoop marked a run complete even though the verifier failed.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect?
+      description: Tell us what should have happened instead.
+      placeholder: The run should have stopped with a verification_failed status and a clear next action.
     validations:
       required: true
   - type: textarea
     id: repro
     attributes:
       label: Reproduction
-      description: Share the smallest set of steps or commands that reproduce it.
+      description: Share the smallest set of steps or commands that reproduce it. A tiny repo or gist is ideal.
       placeholder: |
         1. Run `npx martin-loop doctor`
         2. Run `npx martin-loop run ...`
         3. Observe ...
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: MartinLoop version
+      description: Run `npx martin-loop --version` if you are not sure.
+      placeholder: "0.2.7"
     validations:
       required: true
   - type: textarea
@@ -37,3 +53,12 @@ body:
       label: Logs or evidence
       description: Paste the relevant error output, receipts, or screenshots.
       render: shell
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and discussions.
+          required: true
+        - label: I removed secrets, tokens, and non-public workspace details from logs.
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -21,8 +21,25 @@ body:
     validations:
       required: true
   - type: textarea
+    id: workflow
+    attributes:
+      label: Example workflow
+      description: Show the command, API, MCP flow, or contributor workflow you want to exist.
+      placeholder: |
+        martin-loop preflight "..."
+        martin-loop run "..." --verify "pnpm test" --budget-usd 3
+  - type: textarea
     id: context
     attributes:
       label: Extra context
       description: Tell us which tools, hosts, or environments this matters for.
       placeholder: Codex CLI, Claude Code, GitHub Actions, MCP host, local repo loop...
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and discussions.
+          required: true
+        - label: This request is about local MartinLoop behavior, docs, examples, or integrations.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## Summary
+
+<!-- What changed, and why? Keep it short. -->
+
+## Related issue
+
+<!-- Example: Closes #71 -->
+
+## Verification
+
+<!-- List the exact commands or manual checks you ran. If a check was not run, say why. -->
+
+- [ ] `pnpm test`
+- [ ] `pnpm lint`
+- [ ] `pnpm build`
+- [ ] Manual check:
+
+## Risk and rollback
+
+<!-- Note risky files, dependency changes, config changes, or migration concerns. Say how to back out safely. -->
+
+## Checklist
+
+- [ ] I kept the change focused and easy to review.
+- [ ] I updated docs or examples if behavior changed.
+- [ ] I did not include secrets, tokens, local paths, or non-public workspace details.


### PR DESCRIPTION
## Summary

Adds contributor-facing GitHub templates for incoming bug reports, feature requests, and pull requests.

Closes #71.

## Verification

- [x] `pnpm public:copy-scan`
- [x] `pnpm public:git-surface`
- [x] `git diff --check`
- [x] Template structure check with Node
- [x] `pnpm test`
- [x] `pnpm lint`
- [x] `pnpm build`

## Notes

- Bug reports now ask for current vs expected behavior, repro steps, version, environment, evidence, and a short safety checklist.
- Feature requests now ask for problem, proposal, example workflow, context, and a short triage checklist.
- Pull requests now ask for summary, related issue, verification evidence, risk/rollback notes, and a contributor checklist.