### PR TITLE
Fix proof-mode stability and public test isolation

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "scripts": {
     "build": "pnpm --filter @martin/cli build && pnpm --filter @martinloop/mcp build && node ./scripts/build-public-facade.mjs",
     "prepack": "pnpm build && node ./scripts/root-release-guard.mjs --pack",
-    "test": "pnpm -r test && node --test scripts/tests/*.mjs",
+    "test": "pnpm -r --workspace-concurrency=1 test && node --test scripts/tests/*.mjs",
     "lint": "pnpm -r lint",
     "oss:validate": "node ./scripts/oss-boundary.mjs",
     "public:copy-scan": "node ./scripts/public-copy-scan.mjs",

--- a/packages/core/tests/runtime.test.ts
+++ b/packages/core/tests/runtime.test.ts
@@ -762,7 +762,10 @@ describe("runMartin", () => {
     });
   });
 
-  it("challenge 11: discards the attempt and exits with human escalation when a forbidden path write is detected", async () => {
+  it(
+    "challenge 11: discards the attempt and exits with human escalation when a forbidden path write is detected",
+    { timeout: RUNTIME_REPO_FIXTURE_TIMEOUT_MS },
+    async () => {
     const runsRoot = await mkdtemp(join(tmpdir(), "martin-safety-filesystem-"));
     const repoRoot = join(runsRoot, "repo");
     await mkdir(repoRoot, { recursive: true });
@@ -843,9 +846,13 @@ describe("runMartin", () => {
       blocked: true,
       attemptIndex: 1
     });
-  });
+    }
+  );
 
-  it("challenge 13: blocks dependency-related changes without approval and persists leash.json", async () => {
+  it(
+    "challenge 13: blocks dependency-related changes without approval and persists leash.json",
+    { timeout: RUNTIME_REPO_FIXTURE_TIMEOUT_MS },
+    async () => {
     const runsRoot = await mkdtemp(join(tmpdir(), "martin-safety-dependency-"));
     const repoRoot = join(runsRoot, "repo");
     await mkdir(repoRoot, { recursive: true });
@@ -940,9 +947,13 @@ describe("runMartin", () => {
         })
       ])
     );
-  });
+    }
+  );
 
-  it("blocks deployment config changes without approval and persists the config violation artifact", async () => {
+  it(
+    "blocks deployment config changes without approval and persists the config violation artifact",
+    { timeout: RUNTIME_REPO_FIXTURE_TIMEOUT_MS },
+    async () => {
     const runsRoot = await mkdtemp(join(tmpdir(), "martin-safety-config-"));
     const repoRoot = join(runsRoot, "repo");
     await mkdir(join(repoRoot, ".github", "workflows"), { recursive: true });
@@ -1036,7 +1047,8 @@ describe("runMartin", () => {
         })
       ])
     );
-  });
+    }
+  );
 
   it("rotates to the next adapter when switch_adapter is selected", async () => {
     let primaryExecutions = 0;

--- a/packages/mcp/src/tools/run-loop.ts
+++ b/packages/mcp/src/tools/run-loop.ts
@@ -68,14 +68,16 @@ export async function runLoopTool(input: RunLoopInput): Promise<RunLoopOutput> {
   const allowedPaths = normalizeSafePathPatterns(input.allowedPaths, "allowedPaths");
   const deniedPaths = normalizeSafePathPatterns(input.deniedPaths, "deniedPaths");
   const executionMode = resolveExecutionMode();
-  const engineAvailability = await getEngineAvailability(engine, workingDirectory);
+  if (executionMode.liveMode) {
+    const engineAvailability = await getEngineAvailability(engine, workingDirectory);
 
-  if (executionMode.liveMode && !engineAvailability.launchReady) {
-    throw new MartinToolError("engine_unavailable", `Engine '${engine}' is not launch-ready.`, {
-      category: "environment",
-      suggestion: "Install the requested CLI or set MARTIN_LIVE=false for a no-spend proof run.",
-      retryable: false
-    });
+    if (!engineAvailability.launchReady) {
+      throw new MartinToolError("engine_unavailable", `Engine '${engine}' is not launch-ready.`, {
+        category: "environment",
+        suggestion: "Install the requested CLI or set MARTIN_LIVE=false for a no-spend proof run.",
+        retryable: false
+      });
+    }
   }
 
   const adapter =

--- a/packages/mcp/src/tools/run-loop.ts
+++ b/packages/mcp/src/tools/run-loop.ts
@@ -81,7 +81,7 @@ export async function runLoopTool(input: RunLoopInput): Promise<RunLoopOutput> {
   }
 
   const adapter =
-    process.env.MARTIN_LIVE === "false"
+    !executionMode.liveMode
       ? createVerifierOnlyAdapter({
           workingDirectory,
           adapterId: "direct:proof:verifier-only",

--- a/packages/mcp/tests/mcp-tools.test.ts
+++ b/packages/mcp/tests/mcp-tools.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -59,6 +59,37 @@ async function withRunsRoot<T>(fn: (runsRoot: string) => Promise<T>): Promise<T>
 
     await rm(runsRoot, { recursive: true, force: true }).catch(() => {});
   }
+}
+
+async function withPathPrefix<T>(directory: string, fn: () => Promise<T>): Promise<T> {
+  const pathKey = Object.keys(process.env).find((key) => key.toLowerCase() === "path") ?? "PATH";
+  const original = process.env[pathKey] ?? "";
+  process.env[pathKey] =
+    original.length > 0
+      ? `${directory}${process.platform === "win32" ? ";" : ":"}${original}`
+      : directory;
+
+  try {
+    return await fn();
+  } finally {
+    process.env[pathKey] = original;
+  }
+}
+
+async function installFakeCliProbe(directory: string, command: string, markerPath: string): Promise<void> {
+  if (process.platform === "win32") {
+    const commandPath = join(directory, `${command}.cmd`);
+    await writeFile(commandPath, `@echo off\r\necho invoked>>\"${markerPath}\"\r\nexit /b 0\r\n`, "utf8");
+    return;
+  }
+
+  const commandPath = join(directory, command);
+  await writeFile(
+    commandPath,
+    `#!/bin/sh\necho invoked >> \"${markerPath}\"\nexit 0\n`,
+    "utf8"
+  );
+  await chmod(commandPath, 0o755);
 }
 
 // ---------------------------------------------------------------------------
@@ -982,6 +1013,36 @@ describe("runLoopTool", () => {
       } else {
         process.env.MARTIN_LIVE = originalEnv;
       }
+    }
+  });
+
+  it("skips engine launch probing in proof mode", async () => {
+    const originalEnv = process.env.MARTIN_LIVE;
+    process.env.MARTIN_LIVE = "false";
+    const fakeCliDir = await mkdtemp(join(tmpdir(), "martin-mcp-cli-"));
+    const markerPath = join(fakeCliDir, "probe-invoked.txt");
+
+    try {
+      await installFakeCliProbe(fakeCliDir, "claude", markerPath);
+
+      await withPathPrefix(fakeCliDir, async () => {
+        const result = await runLoopTool({
+          objective: "Proof mode should not probe the requested engine",
+          maxIterations: 1
+        });
+
+        expect(result.status).toBe("completed");
+      });
+
+      await expect(stat(markerPath)).rejects.toThrow();
+    } finally {
+      if (originalEnv === undefined) {
+        delete process.env.MARTIN_LIVE;
+      } else {
+        process.env.MARTIN_LIVE = originalEnv;
+      }
+
+      await rm(fakeCliDir, { recursive: true, force: true }).catch(() => {});
     }
   });
 

--- a/packages/mcp/tests/mcp-tools.test.ts
+++ b/packages/mcp/tests/mcp-tools.test.ts
@@ -63,16 +63,20 @@ async function withRunsRoot<T>(fn: (runsRoot: string) => Promise<T>): Promise<T>
 
 async function withPathPrefix<T>(directory: string, fn: () => Promise<T>): Promise<T> {
   const pathKey = Object.keys(process.env).find((key) => key.toLowerCase() === "path") ?? "PATH";
-  const original = process.env[pathKey] ?? "";
+  const original = process.env[pathKey];
   process.env[pathKey] =
-    original.length > 0
+    original && original.length > 0
       ? `${directory}${process.platform === "win32" ? ";" : ":"}${original}`
       : directory;
 
   try {
     return await fn();
   } finally {
-    process.env[pathKey] = original;
+    if (original === undefined) {
+      delete process.env[pathKey];
+    } else {
+      process.env[pathKey] = original;
+    }
   }
 }
 

--- a/packages/mcp/vitest.config.ts
+++ b/packages/mcp/vitest.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
     }
   },
   test: {
+    fileParallelism: false,
     include: ["tests/**/*.test.ts"]
   }
 });


### PR DESCRIPTION
## Summary
- skip engine launch probing for `MARTIN_LIVE=false` proof-mode runs
- add a regression test proving proof mode does not touch the CLI launcher
- stabilize the public root test lane on Windows by running workspace package tests serially
- run MCP test files sequentially because they intentionally mutate process environment and PATH during integration coverage

## Verification
- `pnpm test`
- `pnpm lint`
- `pnpm build`
- `pnpm public:smoke`
- `pnpm --filter @martinloop/mcp verify:release`
- `pnpm audit --audit-level moderate`
- `pnpm public:copy-scan`
- `pnpm oss:validate`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Test execution now runs sequentially across workspaces (single-worker)
  * Disabled per-file parallel test execution

* **Refactor**
  * Engine availability validation now only occurs in live mode

* **Tests**
  * Added helpers to simulate a CLI probe and verify proof-mode behavior without invoking external engines
  * Updated test cases to include explicit timeouts and formatting adjustments
<!-- end of auto-generated comment: release notes by coderabbit.ai -->