### PR TITLE
Refresh GitHub Actions runtimes

### DIFF
--- a/.github/workflows/martinloop-budget-gate.yml
+++ b/.github/workflows/martinloop-budget-gate.yml
@@ -11,15 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10.33.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: pnpm

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -149,7 +149,7 @@ jobs:
           done
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.release-vars.outputs.tag }}
           body: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,15 +14,15 @@ jobs:
     name: Publish to npm
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10.33.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm
@@ -103,7 +103,7 @@ jobs:
           exit 1
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: ${{ steps.root-pack.outputs.tarball }}
           body: ${{ steps.changelog.outputs.body }}

--- a/scripts/tests/publish-mcp-workflow.test.mjs
+++ b/scripts/tests/publish-mcp-workflow.test.mjs
@@ -50,7 +50,10 @@ test("publish-mcp workflow covers trusted publishing, local-pack proof, and publ
   assert.match(workflow, /npm publish --access public --provenance/);
   assert.match(workflow, /npm view "@martinloop\/mcp@\$\{\{ steps\.mcp-metadata\.outputs\.package_version \}\}" version/);
   assert.match(workflow, /pnpm --filter @martinloop\/mcp smoke:published/);
-  assert.match(workflow, /softprops\/action-gh-release@v2/);
+  assert.match(workflow, /actions\/checkout@v6/);
+  assert.match(workflow, /pnpm\/action-setup@v6/);
+  assert.match(workflow, /actions\/setup-node@v6/);
+  assert.match(workflow, /softprops\/action-gh-release@v3/);
   assert.match(workflow, /body:\s*\|/);
   assert.match(workflow, /docs\/getting-started\/mcp\.md/);
   assert.match(workflow, /docs\/reference\/mcp-tools\.md/);

--- a/scripts/tests/root-release-workflow.test.mjs
+++ b/scripts/tests/root-release-workflow.test.mjs
@@ -17,7 +17,10 @@ test("root release workflow uses GitHub Actions trusted publishing without npm t
   assert.match(workflow, /npm install -g npm@latest/);
   assert.match(workflow, /npm publish "\$\{\{ steps\.root-pack\.outputs\.tarball \}\}" --access public --provenance/);
   assert.match(workflow, /npm view "martin-loop@\$\{\{ steps\.package-version\.outputs\.version \}\}" version/);
-  assert.match(workflow, /softprops\/action-gh-release@v2/);
+  assert.match(workflow, /actions\/checkout@v6/);
+  assert.match(workflow, /pnpm\/action-setup@v6/);
+  assert.match(workflow, /actions\/setup-node@v6/);
+  assert.match(workflow, /softprops\/action-gh-release@v3/);
 
   assert.doesNotMatch(workflow, /NODE_AUTH_TOKEN/);
   assert.doesNotMatch(workflow, /NPM_TOKEN/);

--- a/scripts/tests/workflow-action-runtime.test.mjs
+++ b/scripts/tests/workflow-action-runtime.test.mjs
@@ -1,0 +1,24 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+test("release-facing workflows avoid deprecated Node 20 action wrappers", async () => {
+  const workflowFiles = [
+    ".github/workflows/release.yml",
+    ".github/workflows/publish-mcp.yml",
+    ".github/workflows/martinloop-budget-gate.yml",
+  ];
+
+  for (const relativePath of workflowFiles) {
+    const workflow = await readFile(path.join(ROOT_DIR, relativePath), "utf8");
+
+    assert.doesNotMatch(workflow, /actions\/checkout@v4/);
+    assert.doesNotMatch(workflow, /actions\/setup-node@v4/);
+    assert.doesNotMatch(workflow, /pnpm\/action-setup@v4/);
+    assert.doesNotMatch(workflow, /softprops\/action-gh-release@v2/);
+  }
+});


### PR DESCRIPTION
## Summary
- refresh release-facing GitHub Actions steps to Node 24-compatible action lines
- upgrade `release.yml`, `publish-mcp.yml`, and `martinloop-budget-gate.yml` to current action majors without changing the budget-gate job's pinned Node runtime
- add a workflow guard test so deprecated action wrappers do not creep back in

## Validation
- `node --test scripts/tests/root-release-workflow.test.mjs scripts/tests/publish-mcp-workflow.test.mjs scripts/tests/mcp-publish-reliability.test.mjs scripts/tests/workflow-action-runtime.test.mjs`
- `rg -n "actions/checkout@v4|actions/setup-node@v4|pnpm/action-setup@v4|softprops/action-gh-release@v2|actions/checkout@v6|actions/setup-node@v6|pnpm/action-setup@v6|softprops/action-gh-release@v3" .github/workflows`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive validation test to prevent accidental use of deprecated GitHub Actions versions in release workflows.
  * Updated all test suites to verify the updated build and automation tool versions are properly configured.

* **Chores**
  * Updated multiple CI/CD pipeline actions to more recent versions across all release and publishing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->