### PR TITLE
Release @martinloop/mcp 0.2.7

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -152,12 +152,5 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.release-vars.outputs.tag }}
-          body: |
-            @martinloop/mcp ${{ steps.mcp-metadata.outputs.package_version }}
-
-            Governed MCP server for AI coding agents with budgets, verifier gates, and inspectable runs.
-
-            See the MCP setup and reference docs:
-            - docs/getting-started/mcp.md
-            - docs/reference/mcp-tools.md
-            - docs/reference/mcp-compatibility.md
+          name: @martinloop/mcp ${{ steps.mcp-metadata.outputs.package_version }}
+          body_path: docs/release/MCP-${{ steps.mcp-metadata.outputs.package_version }}-RELEASE-NOTES.md

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ npx martin-loop mcp print-config --host gemini --transport stdio --profile full-
 npx martin-loop mcp print-config --host generic --transport stdio --profile github-review
 ```
 
-The root `martin-loop` package and the standalone `@martinloop/mcp` package move on separate version lines. The root package is `0.2.8`; the current standalone MCP package stays on `0.2.5`.
+The root `martin-loop` package and the standalone `@martinloop/mcp` package move on separate version lines. The root package is `0.2.8`; the current standalone MCP package is `0.2.7`.
 
 More detail: [MCP setup](./docs/getting-started/mcp.md), [MCP tool reference](./docs/reference/mcp-tools.md), and [MCP compatibility](./docs/reference/mcp-compatibility.md).
 

--- a/docs/getting-started/mcp.md
+++ b/docs/getting-started/mcp.md
@@ -2,6 +2,8 @@
 
 The `@martinloop/mcp` package exposes MartinLoop through stdio for MCP-capable hosts.
 
+`0.2.7` is the current public MCP package line. It adds a stronger guided flow for hosts and a stricter run gate so `martin_run` only starts after the matching readiness, planning, and preflight steps have happened.
+
 ## Install
 
 Run the packaged server directly:
@@ -49,6 +51,8 @@ npx martin-loop mcp print-config --host generic --transport stdio --profile gith
 4. Use `martin_run` for the governed execution step.
 5. Use `martin_status` or `martin_logs` for live posture when the host needs it.
 6. Use `martin_dossier`, `martin_eval`, or the `martin_get_*` tools for evidence review.
+
+If the host tries to skip straight to `martin_run`, MartinLoop now blocks the call and points back to the missing step. That is deliberate. It keeps the "safe by default" path visible instead of relying on convention.
 
 ## Start Safe
 

--- a/docs/reference/mcp-compatibility.md
+++ b/docs/reference/mcp-compatibility.md
@@ -7,6 +7,7 @@
 - The root `martin-loop` package provides the public CLI, SDK, demo workspace, and top-level release notes.
 - The standalone `@martinloop/mcp` package stays on its own version line.
 - The server identifier remains `io.github.Keesan12/martin-loop`.
+- The current public standalone MCP package line is `0.2.7`.
 
 ## Stability Commitments
 
@@ -43,6 +44,7 @@ Resources and prompts include version metadata so hosts can confirm which discov
 ## Safety Model
 
 - `martin_plan`, `martin_doctor`, `martin_preflight`, `martin_status`, `martin_logs`, `martin_dossier`, `martin_eval`, and the `martin_get_*` family are intended for planning and inspection.
+- `martin_run` now expects matching `martin_doctor`, `martin_plan`, and `martin_preflight` receipts for the same task before it will execute.
 - `martin_pause`, `martin_cancel`, `martin_continue`, and `martin_create_pr` are explicit follow-on helpers and stay out of the default `minimal` profile.
 - Live governed runs require a supported local agent CLI on `PATH`.
 - Stub and smoke flows use `MARTIN_LIVE=false`.

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -9,7 +9,7 @@ The `@martinloop/mcp` package exposes one primary coding execution entrypoint pl
 | `martin_doctor` | Check local MartinLoop and agent readiness. |
 | `martin_plan` | Outline scope, verification, and budget posture before spending a run. |
 | `martin_preflight` | Validate a proposed run contract before execution. |
-| `martin_run` | Execute a governed coding run. |
+| `martin_run` | Execute a governed coding run after matching doctor, plan, and preflight receipts exist. |
 
 ## Status and Run Control
 
@@ -97,5 +97,7 @@ The `@martinloop/mcp` package exposes one primary coding execution entrypoint pl
 - `diagnostic` adds deeper run-store and evaluation helpers.
 - `full-local` adds `martin_run` plus run-control helpers for local operators.
 - `github-review` adds PR-oriented helpers when the host explicitly needs them.
+
+The `0.2.7` package line also adds guide resources meant for hosts that want MartinLoop to feel built in rather than bolted on. Start with `martin://agent/next-step`, `martin://guides/command-map`, and `martin://guides/operating-rules` before you open full run JSON.
 
 For installation and host setup, see [MCP setup](../getting-started/mcp.md). For platform commitments, see [MCP compatibility](./mcp-compatibility.md).

--- a/docs/release/MCP-0.2.7-RELEASE-NOTES.md
+++ b/docs/release/MCP-0.2.7-RELEASE-NOTES.md
@@ -1,0 +1,60 @@
+# @martinloop/mcp 0.2.7
+
+`@martinloop/mcp@0.2.7` is a usability and review release for the standalone MartinLoop MCP server.
+
+The package already had the core pieces for governed coding work. This release makes that flow easier to adopt in real hosts and harder to use incorrectly.
+
+## What changed
+
+- `martin_run` now refuses to start until matching `martin_doctor`, `martin_plan`, and `martin_preflight` receipts exist for the same task
+- guide resources now cover command mapping, IDE onboarding, and the operating rules MartinLoop expects hosts to follow
+- the review loop is easier to navigate through dossier, eval, triage, and publish-readiness helpers
+- package metadata, server metadata, and public docs now describe the same `0.2.7` MCP surface
+
+## Why it matters
+
+This release is about trust and flow.
+
+If an MCP host is going to drive real coding work, it should not have to guess which MartinLoop step comes next, and it should not be able to skip straight to execution by accident. `0.2.7` makes the guided path much clearer while keeping the server local-first and stdio-first.
+
+## Recommended flow
+
+1. `martin_doctor`
+2. `martin_plan`
+3. `martin_preflight`
+4. `martin_run`
+5. `martin_status` or `martin_logs`
+6. `martin_dossier`
+7. `martin_eval`
+
+For a fresh machine, start with the root CLI first:
+
+```sh
+npx martin-loop start
+npx martin-loop tour
+npx martin-loop doctor
+```
+
+Then install the standalone server:
+
+```sh
+codex mcp add martin-loop -- npx -y @martinloop/mcp
+```
+
+## Docs
+
+- [MCP setup](../getting-started/mcp.md)
+- [MCP tool reference](../reference/mcp-tools.md)
+- [MCP compatibility](../reference/mcp-compatibility.md)
+- [Package README](../../packages/mcp/README.md)
+
+## Verification
+
+```sh
+pnpm --filter @martinloop/mcp lint
+pnpm --filter @martinloop/mcp test
+pnpm --filter @martinloop/mcp build
+pnpm --filter @martinloop/mcp smoke:pack
+pnpm --filter @martinloop/mcp smoke:published:pack
+pnpm --filter @martinloop/mcp verify:release
+```

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,10 +1,24 @@
 # @martinloop/mcp
 
-Governed MCP server for AI coding agents with budgets, onboarding guides, run receipts, and review-ready evidence.
+Governed MCP server for AI coding agents with budgets, receipts, and review-ready evidence.
 
-`@martinloop/mcp` is local-first and stdio-first. It gives MCP hosts a clean way to plan work, verify readiness, run a governed task, inspect receipts, and hand a review summary back to a human.
+`@martinloop/mcp` is the standalone MartinLoop server for MCP hosts. It stays local-first and stdio-first, and it gives hosts one clear execution path: check readiness, plan the work, preflight the contract, run it, and inspect the result with enough evidence to decide what happens next.
 
 The root `martin-loop` package and the standalone `@martinloop/mcp` package move on separate version lines. For the current root release, see [MartinLoop 0.2.8 release notes](../../docs/release/OSS-0.2.8-RELEASE-NOTES.md).
+
+## What is new in 0.2.7
+
+- better onboarding inside MCP, including guide resources for command mapping, IDE setup, and operating rules
+- a stricter governed run sequence, so `martin_run` refuses to start until matching `martin_doctor`, `martin_plan`, and `martin_preflight` receipts exist for the same task
+- cleaner review and handoff surfaces, especially around dossier, eval, and publish-readiness guidance
+
+If you are installing MartinLoop for the first time, start with the root CLI first:
+
+```sh
+npx martin-loop start
+npx martin-loop tour
+npx martin-loop doctor
+```
 
 ## Install
 
@@ -49,7 +63,7 @@ Registry/server identifier: `io.github.Keesan12/martin-loop`
 7. `martin_eval`
 8. `martin_pr_summary` or `martin_review_pr` when a host is preparing GitHub review output
 
-`martin_run` is the primary coding execution entrypoint. Expanded profiles can also expose run-control helpers and GitHub review helpers when the host genuinely needs them.
+`martin_run` is the primary coding execution entrypoint. In `0.2.7`, it hard-blocks until the matching readiness, planning, and preflight receipts exist for the same task. That keeps the default flow honest for both humans and agents.
 
 ## Profiles
 
@@ -134,6 +148,7 @@ Registry/server identifier: `io.github.Keesan12/martin-loop`
 ## Runtime Model
 
 - `martin_run` is the primary coding execution entrypoint.
+- `martin_run` now blocks until the same task has matching `martin_doctor`, `martin_plan`, and `martin_preflight` receipts.
 - `martin_plan`, `martin_doctor`, `martin_preflight`, `martin_status`, `martin_logs`, `martin_dossier`, `martin_eval`, and the `martin_get_*` family are planning or inspection surfaces.
 - `martin_pause`, `martin_cancel`, `martin_continue`, and `martin_create_pr` are explicit follow-on control helpers and stay out of the default `minimal` profile.
 - Live runs require `claude` or `codex` on `PATH`.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@martinloop/mcp",
-  "version": "0.2.5",
+  "version": "0.2.7",
   "mcpName": "io.github.Keesan12/martin-loop",
   "private": false,
   "type": "module",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/Keesan12/martin-loop",
     "source": "github"
   },
-  "version": "0.2.5",
+  "version": "0.2.7",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@martinloop/mcp",
-      "version": "0.2.5",
+      "version": "0.2.7",
       "transport": {
         "type": "stdio"
       }

--- a/packages/mcp/src/package-version.ts
+++ b/packages/mcp/src/package-version.ts
@@ -1,3 +1,3 @@
 // Keep this aligned with packages/mcp/package.json during version bumps so the
 // runtime does not depend on package.json being present in every hosted bundle.
-export const MARTIN_MCP_PACKAGE_VERSION = "0.2.5";
+export const MARTIN_MCP_PACKAGE_VERSION = "0.2.7";

--- a/scripts/tests/mcp-release-docs.test.mjs
+++ b/scripts/tests/mcp-release-docs.test.mjs
@@ -133,6 +133,7 @@ test("MCP public docs exist in the cleaned docs tree", async () => {
     "docs/getting-started/mcp.md",
     "docs/reference/mcp-tools.md",
     "docs/reference/mcp-compatibility.md",
+    `docs/release/MCP-${packageJson.version}-RELEASE-NOTES.md`,
     "packages/mcp/README.md",
     "packages/cli/README.md",
   ]) {
@@ -210,6 +211,7 @@ test("MCP public docs avoid deleted release-workspace language", async () => {
     readRepoFile(path.join("docs", "getting-started", "mcp.md")),
     readRepoFile(path.join("docs", "reference", "mcp-tools.md")),
     readRepoFile(path.join("docs", "reference", "mcp-compatibility.md")),
+    readRepoFile(path.join("docs", "release", `MCP-${packageJson.version}-RELEASE-NOTES.md`)),
     readRepoFile(path.join("docs", "release", `OSS-${rootPackageJson.version}-RELEASE-NOTES.md`)),
   ]);
 
@@ -242,4 +244,16 @@ test("root release note captures onboarding and governance changes", async () =>
   assert.match(releaseNotes, /doctor/i);
   assert.match(releaseNotes, /preflight/i);
   assert.match(releaseNotes, /--unsafe-allow-unguarded-run/);
+});
+
+test("MCP release note matches the current package line and the governed flow", async () => {
+  const releaseNotes = await readRepoFile(path.join("docs", "release", `MCP-${packageJson.version}-RELEASE-NOTES.md`));
+
+  assert.match(releaseNotes, new RegExp(`@martinloop/mcp ${packageJson.version.replaceAll(".", "\\.")}`));
+  assert.match(releaseNotes, /martin_run/i);
+  assert.match(releaseNotes, /martin_doctor/i);
+  assert.match(releaseNotes, /martin_plan/i);
+  assert.match(releaseNotes, /martin_preflight/i);
+  assert.match(releaseNotes, /local-first/i);
+  assert.match(releaseNotes, /stdio-first/i);
 });

--- a/scripts/tests/publish-mcp-workflow.test.mjs
+++ b/scripts/tests/publish-mcp-workflow.test.mjs
@@ -54,10 +54,8 @@ test("publish-mcp workflow covers trusted publishing, local-pack proof, and publ
   assert.match(workflow, /pnpm\/action-setup@v6/);
   assert.match(workflow, /actions\/setup-node@v6/);
   assert.match(workflow, /softprops\/action-gh-release@v3/);
-  assert.match(workflow, /body:\s*\|/);
-  assert.match(workflow, /docs\/getting-started\/mcp\.md/);
-  assert.match(workflow, /docs\/reference\/mcp-tools\.md/);
-  assert.match(workflow, /docs\/reference\/mcp-compatibility\.md/);
+  assert.match(workflow, /name:\s*@martinloop\/mcp/);
+  assert.match(workflow, /body_path:\s*docs\/release\/MCP-\$\{\{\s*steps\.mcp-metadata\.outputs\.package_version\s*\}\}-RELEASE-NOTES\.md/);
   assert.doesNotMatch(workflow, /registry-url/);
   assert.doesNotMatch(workflow, /NODE_AUTH_TOKEN/);
   assert.doesNotMatch(workflow, /NPM_TOKEN/);


### PR DESCRIPTION
## Summary
- bump the standalone MCP package to 0.2.7
- align package metadata, server metadata, and public docs
- publish from a dedicated MCP release note instead of inline workflow copy

## Verification
- pnpm install --frozen-lockfile
- pnpm lint
- pnpm test
- pnpm build
- pnpm public:git-surface
- pnpm oss:validate
- pnpm public:smoke
- pnpm release:validate:platforms
- pnpm --filter @martinloop/mcp smoke:pack
- pnpm --filter @martinloop/mcp smoke:published:pack
- pnpm --filter @martinloop/mcp verify:release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stricter governed execution flow: `martin_run` now requires matching doctor, plan, and preflight steps before execution.
  * Enhanced onboarding resources and step-by-step guidance for integration.

* **Documentation**
  * Updated release notes for version 0.2.7.
  * Clarified MCP tool reference and compatibility guidelines.

* **Chores**
  * Version bump to 0.2.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->