### PR TITLE
Fix MCP publish workflow syntax

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -152,5 +152,5 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.release-vars.outputs.tag }}
-          name: @martinloop/mcp ${{ steps.mcp-metadata.outputs.package_version }}
-          body_path: docs/release/MCP-${{ steps.mcp-metadata.outputs.package_version }}-RELEASE-NOTES.md
+          name: "@martinloop/mcp ${{ steps.mcp-metadata.outputs.package_version }}"
+          body_path: "docs/release/MCP-${{ steps.mcp-metadata.outputs.package_version }}-RELEASE-NOTES.md"

--- a/scripts/tests/publish-mcp-workflow.test.mjs
+++ b/scripts/tests/publish-mcp-workflow.test.mjs
@@ -54,8 +54,8 @@ test("publish-mcp workflow covers trusted publishing, local-pack proof, and publ
   assert.match(workflow, /pnpm\/action-setup@v6/);
   assert.match(workflow, /actions\/setup-node@v6/);
   assert.match(workflow, /softprops\/action-gh-release@v3/);
-  assert.match(workflow, /name:\s*@martinloop\/mcp/);
-  assert.match(workflow, /body_path:\s*docs\/release\/MCP-\$\{\{\s*steps\.mcp-metadata\.outputs\.package_version\s*\}\}-RELEASE-NOTES\.md/);
+  assert.match(workflow, /name:\s*"@martinloop\/mcp/);
+  assert.match(workflow, /body_path:\s*"docs\/release\/MCP-\$\{\{\s*steps\.mcp-metadata\.outputs\.package_version\s*\}\}-RELEASE-NOTES\.md"/);
   assert.doesNotMatch(workflow, /registry-url/);
   assert.doesNotMatch(workflow, /NODE_AUTH_TOKEN/);
   assert.doesNotMatch(workflow, /NPM_TOKEN/);


### PR DESCRIPTION
## Summary
- quote the GitHub release fields in publish-mcp.yml so Actions parses the workflow
- update the workflow guard test to match the valid quoted YAML

## Verification
- pnpm --filter @martinloop/mcp verify:release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Release name formatting in the publishing workflow.

* **Tests**
  * Updated workflow tests to match the new release name format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->