### PR TITLE
fix: ship the portable public 0.2.9 hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.2.9]
+
+### Fixed
+- **No-spend proof runs now complete honestly** - `martin-loop run ... --proof` no longer misclassifies a clean verifier-only pass as `no_code_change`, which previously cascaded into a false `budget_exit`.
+- **Portable Windows Codex execution** - Windows command resolution now handles npm-style `.cmd` shims correctly, including real `codex.cmd` and verifier commands launched through npm wrappers.
+- **Hosted OpenAI defaults** - `--engine openai` now targets the hosted OpenAI endpoint by default, so local proofs do not require `MARTIN_OPENAI_BASE_URL` just to avoid a localhost misroute.
+- **Claude live runs honor provider permissions again** - the public Claude adapter no longer force-adds `--dangerously-skip-permissions` on live governed runs.
+
+### Changed
+- Public CLI guidance now consistently uses `martin-loop` in help, tour, onboarding, workflow receipts, and MCP config hints.
+- The public root tarball no longer exposes the vendored internal CLI bin surface inside `dist/vendor/cli/package.json`.
+
 ## [0.2.8]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ npm install
 npx martin-loop doctor
 npx martin-loop session-start
 npx martin-loop preflight "Summarize the demo workspace and prove tests still pass" --verify "npm test"
-MARTIN_LIVE=false npx martin-loop run "Summarize the demo workspace and prove tests still pass" --verify "npm test"
+npx martin-loop run "Summarize the demo workspace and prove tests still pass" --proof --verify "npm test"
 npx martin-loop dossier --latest
 ```
 
 `start` and `tour` walk a new operator through the product flow. `doctor`, `session-start`, and `preflight` create the local receipts MartinLoop expects before a real governed run. If you intentionally need to bypass that local gate for a one-off run, use `--unsafe-allow-unguarded-run` explicitly.
 
-Release notes for the current root package: [MartinLoop 0.2.8](./docs/release/OSS-0.2.8-RELEASE-NOTES.md).
+Release notes for the current root package: [MartinLoop 0.2.9](./docs/release/OSS-0.2.9-RELEASE-NOTES.md).
 
 ## What It Does
 
@@ -112,7 +112,7 @@ npx martin-loop mcp print-config --host gemini --transport stdio --profile full-
 npx martin-loop mcp print-config --host generic --transport stdio --profile github-review
 ```
 
-The root `martin-loop` package and the standalone `@martinloop/mcp` package move on separate version lines. The root package is `0.2.8`; the current standalone MCP package is `0.2.7`.
+The root `martin-loop` package and the standalone `@martinloop/mcp` package move on separate version lines. The root package is `0.2.9`; the current standalone MCP package is `0.2.7`.
 
 More detail: [MCP setup](./docs/getting-started/mcp.md), [MCP tool reference](./docs/reference/mcp-tools.md), and [MCP compatibility](./docs/reference/mcp-compatibility.md).
 

--- a/demo/seeded-workspace/README.md
+++ b/demo/seeded-workspace/README.md
@@ -7,7 +7,7 @@ It is intentionally small:
 
 - `npm test` is green out of the box
 - `martin.config.yaml` keeps the budget tiny
-- the first suggested MartinLoop run can stay in no-spend proof mode with `MARTIN_LIVE=false`
+- the first suggested MartinLoop run can stay in no-spend proof mode with `--proof`
 
 ## Files
 
@@ -26,7 +26,7 @@ npm test
 Safe first run:
 
 ```sh
-MARTIN_LIVE=false npx martin-loop run "Summarize the demo workspace and confirm the verifier is green" --verify "npm test"
+npx martin-loop run "Summarize the demo workspace and confirm the verifier is green" --proof --verify "npm test"
 ```
 
 Review the run evidence afterward:

--- a/docs/concepts/under-3-challenge.md
+++ b/docs/concepts/under-3-challenge.md
@@ -32,6 +32,6 @@ That makes a coding-agent result easier to trust, replay, compare, and audit.
 npx martin-loop demo
 cd martin-loop-demo
 npm install
-MARTIN_LIVE=false npx martin-loop run "Summarize the demo workspace and confirm the verifier is green" --verify "npm test"
+npx martin-loop run "Summarize the demo workspace and confirm the verifier is green" --proof --verify "npm test"
 npx martin-loop dossier --latest
 ```

--- a/docs/getting-started/codex.md
+++ b/docs/getting-started/codex.md
@@ -24,7 +24,7 @@ npx martin-loop run "fix the auth regression" \
 npx martin-loop demo
 cd martin-loop-demo
 npm install
-MARTIN_LIVE=false npx martin-loop run "Summarize the demo workspace and confirm the verifier is green" --verify "npm test"
+npx martin-loop run "Summarize the demo workspace and confirm the verifier is green" --proof --verify "npm test"
 npx martin-loop dossier --latest
 ```
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -20,7 +20,7 @@ npm install
 npx martin-loop doctor
 npx martin-loop session-start
 npx martin-loop preflight "Summarize the demo workspace and prove tests still pass" --verify "npm test"
-MARTIN_LIVE=false npx martin-loop run "Summarize the demo workspace and prove tests still pass" --verify "npm test"
+npx martin-loop run "Summarize the demo workspace and prove tests still pass" --proof --verify "npm test"
 npx martin-loop dossier --latest
 ```
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,6 +1,6 @@
 # CLI Reference
 
-The published binary is `martin-loop`. Inside the workspace you may also see the shorter development alias `martin`, but public installs should assume `martin-loop`.
+The published binary is `martin-loop`. Public installs, docs, and examples should use `martin-loop`.
 
 ## Commands
 
@@ -33,6 +33,7 @@ npx martin-loop tour
 npx martin-loop doctor
 npx martin-loop session-start
 npx martin-loop preflight "Summarize the workspace and prove tests still pass" --verify "npm test"
+npx martin-loop run "Summarize the workspace and prove tests still pass" --proof --verify "npm test"
 ```
 
 ## Run Options
@@ -43,11 +44,12 @@ npx martin-loop preflight "Summarize the workspace and prove tests still pass" -
 --budget-usd <n>        Alias for --budget
 --soft-limit-usd <n>    Soft budget threshold in USD
 --verify <cmd>          Verifier command after each attempt
+--proof                 Use the no-spend proof adapter instead of a live coding CLI
 --unsafe-allow-unguarded-run
                         Bypass the local governance gate for this one run
 --max-iterations <n>    Maximum number of attempts
 --max-tokens <n>        Maximum token budget
---engine <name>         Adapter to use: claude or codex
+--engine <name>         Adapter to use: claude, codex, or openai
 --model <name>          Override the adapter model
 --cwd <path>            Repo root for the run
 --allow-path <glob>     Restrict writes to this path pattern; repeatable

--- a/docs/reference/mcp-compatibility.md
+++ b/docs/reference/mcp-compatibility.md
@@ -47,4 +47,5 @@ Resources and prompts include version metadata so hosts can confirm which discov
 - `martin_run` now expects matching `martin_doctor`, `martin_plan`, and `martin_preflight` receipts for the same task before it will execute.
 - `martin_pause`, `martin_cancel`, `martin_continue`, and `martin_create_pr` are explicit follow-on helpers and stay out of the default `minimal` profile.
 - Live governed runs require a supported local agent CLI on `PATH`.
-- Stub and smoke flows use `MARTIN_LIVE=false`.
+- CLI proof flows use `martin-loop run ... --proof`.
+- Host-managed smoke flows can still set `MARTIN_LIVE=false` when the launcher owns the environment.

--- a/docs/reference/packages.md
+++ b/docs/reference/packages.md
@@ -6,7 +6,7 @@
 | `@martin/contracts` | Shared types for loops, policy, governance, budget, telemetry, and rollback. |
 | `@martin/core` | Runtime controller, policy engine, safety checks, grounding, persistence, and rollback logic. |
 | `@martin/adapters` | Claude CLI, Codex CLI, direct-provider, and verifier-only proof-mode adapter surfaces. |
-| `@martin/cli` | CLI implementation for `run`, `demo`, `doctor`, `triage`, `dossier`, `inspect`, `resume`, and MCP config helpers. |
+| `@martin/cli` | Workspace package that powers the public `martin-loop` binary. |
 | `@martinloop/mcp` | Standalone MCP server with governed execution plus read-only run review tools, resources, and prompts. |
 
 ## Install Targets

--- a/docs/release/OSS-0.2.8-RELEASE-NOTES.md
+++ b/docs/release/OSS-0.2.8-RELEASE-NOTES.md
@@ -24,7 +24,7 @@ npx martin-loop preflight "Summarize the demo workspace and prove tests still pa
 Then run the no-spend proof path:
 
 ```sh
-MARTIN_LIVE=false npx martin-loop run "Summarize the demo workspace and prove tests still pass" --verify "npm test"
+npx martin-loop run "Summarize the demo workspace and prove tests still pass" --proof --verify "npm test"
 npx martin-loop dossier --latest
 ```
 

--- a/docs/release/OSS-0.2.9-RELEASE-NOTES.md
+++ b/docs/release/OSS-0.2.9-RELEASE-NOTES.md
@@ -1,0 +1,45 @@
+# martin-loop 0.2.9
+
+MartinLoop `0.2.9` is an incident-response hotfix for the public root package. It repairs the proof path, tightens Windows portability, and removes a risky default from live Claude runs.
+
+## What changed
+
+- `npx martin-loop run ... --proof` now completes as a real no-spend governed proof when verification passes.
+- Windows command resolution now handles npm-style `.cmd` shims correctly for real CLIs such as `codex.cmd` and wrapped verifier commands.
+- `--engine openai` now defaults to the hosted OpenAI endpoint instead of assuming a localhost-compatible server.
+- Live Claude runs no longer force `--dangerously-skip-permissions`.
+- Public CLI help, onboarding, tour output, and MCP config guidance now consistently use `martin-loop`.
+
+## Start here
+
+```sh
+npx martin-loop start
+npx martin-loop tour
+npx martin-loop doctor
+npx martin-loop preflight "Summarize the demo workspace and confirm the verifier is green" --verify "npm test"
+```
+
+## Upgrade notes
+
+- The recommended no-spend flow is:
+
+```sh
+npx martin-loop run "Summarize the demo workspace and confirm the verifier is green" --proof --verify "npm test"
+```
+
+- Live Claude users should expect the normal Claude permission model to apply again.
+- Windows users can keep using real CLI shims on PATH instead of rewriting commands to machine-specific executables.
+- `--unsafe-allow-unguarded-run` still exists for advanced local operators, but the normal public path remains `start` -> `doctor` -> `preflight` -> `run`.
+
+## Validation
+
+`0.2.9` is intended to pass the same public release gate as the normal root release line:
+
+- `pnpm lint`
+- `pnpm test`
+- `pnpm build`
+- `pnpm public:copy-scan`
+- `pnpm public:git-surface`
+- `pnpm oss:validate`
+- `pnpm public:smoke`
+- `pnpm release:validate-local`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "martin-loop",
   "private": false,
-  "version": "0.2.8",
+  "version": "0.2.9",
   "type": "module",
   "description": "Open-source command center for governed AI coding agents with built-in onboarding, hard gates, CLI, MCP, and run receipts.",
   "packageManager": "pnpm@10.33.0",

--- a/packages/adapters/src/claude-cli.ts
+++ b/packages/adapters/src/claude-cli.ts
@@ -20,7 +20,7 @@ import type {
 } from "@martin/core";
 
 import {
-  readGitExecutionArtifacts,
+  readGitChangedFiles,
   runSubprocess,
   runVerification,
   type SpawnLike
@@ -275,6 +275,10 @@ export function createAgentCliAdapter(options: AgentCliAdapterOptions): MartinAd
 
       const args = options.argsBuilder(prompt);
       const stdinData = options.stdinBuilder?.(prompt);
+      const repoRoot = (request.context as { repoRoot?: string }).repoRoot;
+      const baselineChangedFiles = repoRoot
+        ? new Set(await readGitChangedFiles(repoRoot, 5_000, options.spawnImpl))
+        : undefined;
 
       const agentResult = await runSubprocess(options.command, args, {
         cwd: workingDirectory,
@@ -350,41 +354,34 @@ export function createAgentCliAdapter(options: AgentCliAdapterOptions): MartinAd
         options.spawnImpl
       );
 
-      // Check for zero-diff (agent ran but made no file changes)
-      const repoRoot = (request.context as { repoRoot?: string }).repoRoot;
-      let noDiff = false;
-      if (repoRoot) {
-        noDiff = await checkNoDiff(repoRoot);
-      }
-
       // Extract structured errors from stderr/stdout for better failure context
       const structuredErrors = normalizeStructuredErrors(
         extractStructuredErrors(agentResult.stderr, agentResult.stdout)
       );
-      const executionArtifacts = repoRoot
-        ? await readGitExecutionArtifacts(repoRoot, 5000, options.spawnImpl)
-        : undefined;
+      const changedFiles = repoRoot
+        ? (await readGitChangedFiles(repoRoot, 5_000, options.spawnImpl)).filter(
+            (file) => !(baselineChangedFiles?.has(file) ?? false)
+          )
+        : [];
+      const executionArtifacts = repoRoot ? { changedFiles } : undefined;
+      const noDiff = repoRoot ? changedFiles.length === 0 : false;
 
       // Scope contract enforcement: check touched files against allowedPaths/deniedPaths
       let scopeViolations: string[] = [];
       const scopeCtx = request.context as { allowedPaths?: string[]; deniedPaths?: string[] };
-      if (repoRoot && (scopeCtx.allowedPaths?.length || scopeCtx.deniedPaths?.length)) {
-        const diffResult = await runSubprocess("git", ["diff", "--name-only", "HEAD"], { cwd: repoRoot, timeoutMs: 5000 });
-        if (diffResult.exitCode === 0 && diffResult.stdout.trim()) {
-          const touchedFiles = diffResult.stdout.trim().split("\n").filter(Boolean);
-          const allowed = scopeCtx.allowedPaths ?? [];
-          const denied = scopeCtx.deniedPaths ?? [];
+      if (repoRoot && executionArtifacts && (scopeCtx.allowedPaths?.length || scopeCtx.deniedPaths?.length)) {
+        const allowed = scopeCtx.allowedPaths ?? [];
+        const denied = scopeCtx.deniedPaths ?? [];
 
-          for (const file of touchedFiles) {
-            // Check denied patterns (simple glob-like: prefix or exact)
-            if (denied.some((d) => file === d || file.startsWith(d.replace(/\*+$/, "")))) {
-              scopeViolations.push(file);
-              continue;
-            }
-            // If allowedPaths specified, file must match at least one
-            if (allowed.length > 0 && !allowed.some((a) => file === a || file.startsWith(a.replace(/\*+$/, "")))) {
-              scopeViolations.push(file);
-            }
+        for (const file of executionArtifacts.changedFiles) {
+          // Check denied patterns (simple glob-like: prefix or exact)
+          if (denied.some((d) => file === d || file.startsWith(d.replace(/\*+$/, "")))) {
+            scopeViolations.push(file);
+            continue;
+          }
+          // If allowedPaths specified, file must match at least one
+          if (allowed.length > 0 && !allowed.some((a) => file === a || file.startsWith(a.replace(/\*+$/, "")))) {
+            scopeViolations.push(file);
           }
         }
       }
@@ -502,7 +499,7 @@ export function createAgentCliAdapter(options: AgentCliAdapterOptions): MartinAd
 // ---------------------------------------------------------------------------
 
 /**
- * Spawns `claude --output-format json --print "<prompt>" --dangerously-skip-permissions [extraArgs]`.
+ * Spawns `claude --output-format json --print "<prompt>" [extraArgs]`.
  *
  * The --output-format json flag causes Claude CLI to return structured JSON
  * including real token usage counts, enabling accurate cost tracking.
@@ -528,7 +525,6 @@ export function createClaudeCliAdapter(options: ClaudeCliAdapterOptions = {}): M
       "--output-format",
       "json",
       "--print",
-      "--dangerously-skip-permissions",
       ...modelArgs,
       ...extraArgs
     ],
@@ -802,7 +798,3 @@ function extractStructuredErrors(stderr: string, stdout: string): StructuredErro
   return errors.slice(0, 10); // cap at 10 to avoid bloating prompts
 }
 
-async function checkNoDiff(repoRoot: string): Promise<boolean> {
-  const result = await runSubprocess("git", ["diff", "--name-only", "HEAD"], { cwd: repoRoot, timeoutMs: 5000 });
-  return result.exitCode === 0 && result.stdout.trim().length === 0;
-}

--- a/packages/adapters/src/cli-bridge.ts
+++ b/packages/adapters/src/cli-bridge.ts
@@ -218,7 +218,7 @@ export async function readGitChangedFiles(
 ): Promise<string[]> {
   const statusResult = await runSubprocess(
     "git",
-    ["status", "--porcelain=v1", "--untracked-files=no", "--ignore-submodules=all"],
+    ["status", "-z", "--porcelain=v1", "--untracked-files=no", "--ignore-submodules=all"],
     { cwd: repoRoot, timeoutMs, spawnImpl }
   );
 
@@ -226,11 +226,7 @@ export async function readGitChangedFiles(
     return [];
   }
 
-  return statusResult.stdout
-    .split(/\r?\n/u)
-    .map((line) => line.trimEnd())
-    .filter(Boolean)
-    .map((line) => parsePorcelainPath(line))
+  return parsePorcelainEntries(statusResult.stdout)
     .filter((entry): entry is string => typeof entry === "string" && entry.length > 0);
 }
 
@@ -392,14 +388,35 @@ function quoteWindowsCmdArg(value: string): string {
   return `"${escaped}"`;
 }
 
-function parsePorcelainPath(line: string): string | undefined {
-  const payload = line.slice(3).trim();
-  if (!payload) {
-    return undefined;
+function parsePorcelainEntries(stdout: string): string[] {
+  const entries = stdout.split("\u0000").filter((entry) => entry.length > 0);
+  const changedFiles: string[] = [];
+
+  for (let index = 0; index < entries.length; index += 1) {
+    const entry = entries[index];
+    if (entry === undefined || entry.length < 4) {
+      continue;
+    }
+
+    const status = entry.slice(0, 2);
+    const payload = entry.slice(3);
+    if (!payload) {
+      continue;
+    }
+
+    if (status.includes("R") || status.includes("C")) {
+      const renamedPath = entries[index + 1];
+      if (renamedPath && renamedPath.length > 0) {
+        changedFiles.push(renamedPath);
+        index += 1;
+        continue;
+      }
+    }
+
+    changedFiles.push(payload);
   }
 
-  const renameMarker = " -> ";
-  return payload.includes(renameMarker) ? payload.split(renameMarker).at(-1)?.trim() : payload;
+  return changedFiles;
 }
 
 export function splitCommand(command: string): string[] {

--- a/packages/adapters/src/cli-bridge.ts
+++ b/packages/adapters/src/cli-bridge.ts
@@ -218,7 +218,7 @@ export async function readGitChangedFiles(
 ): Promise<string[]> {
   const statusResult = await runSubprocess(
     "git",
-    ["status", "-z", "--porcelain=v1", "--untracked-files=no", "--ignore-submodules=all"],
+    ["status", "-z", "--porcelain=v1", "--untracked-files=all", "--ignore-submodules=all"],
     { cwd: repoRoot, timeoutMs, spawnImpl }
   );
 

--- a/packages/adapters/src/cli-bridge.ts
+++ b/packages/adapters/src/cli-bridge.ts
@@ -1,6 +1,6 @@
 import { spawn, type ChildProcess, type SpawnOptions } from "node:child_process";
-import { delimiter, extname, isAbsolute, join, resolve } from "node:path";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
+import { delimiter, dirname, extname, isAbsolute, join, resolve } from "node:path";
 
 import { diffStatsFromNumstat } from "./runtime-support.js";
 
@@ -182,16 +182,18 @@ export async function readGitExecutionArtifacts(
   changedFiles?: string[];
   diffStats?: ReturnType<typeof diffStatsFromNumstat>;
 }> {
-  const changedFilesResult = await runSubprocess(
-    "git",
-    ["diff", "--name-only", "HEAD"],
-    { cwd: repoRoot, timeoutMs, spawnImpl }
-  );
-  const numstatResult = await runSubprocess(
-    "git",
-    ["diff", "--numstat", "HEAD"],
-    { cwd: repoRoot, timeoutMs, spawnImpl }
-  );
+  const [changedFilesResult, numstatResult] = await Promise.all([
+    runSubprocess(
+      "git",
+      ["diff", "--name-only", "HEAD"],
+      { cwd: repoRoot, timeoutMs, spawnImpl }
+    ),
+    runSubprocess(
+      "git",
+      ["diff", "--numstat", "HEAD"],
+      { cwd: repoRoot, timeoutMs, spawnImpl }
+    )
+  ]);
 
   const changedFiles =
     changedFilesResult.exitCode === 0
@@ -207,6 +209,29 @@ export async function readGitExecutionArtifacts(
     ...(changedFiles.length > 0 ? { changedFiles } : {}),
     ...(diffStats ? { diffStats } : {})
   };
+}
+
+export async function readGitChangedFiles(
+  repoRoot: string,
+  timeoutMs: number,
+  spawnImpl?: SpawnLike
+): Promise<string[]> {
+  const statusResult = await runSubprocess(
+    "git",
+    ["status", "--porcelain=v1", "--untracked-files=no", "--ignore-submodules=all"],
+    { cwd: repoRoot, timeoutMs, spawnImpl }
+  );
+
+  if (statusResult.exitCode !== 0) {
+    return [];
+  }
+
+  return statusResult.stdout
+    .split(/\r?\n/u)
+    .map((line) => line.trimEnd())
+    .filter(Boolean)
+    .map((line) => parsePorcelainPath(line))
+    .filter((entry): entry is string => typeof entry === "string" && entry.length > 0);
 }
 
 export interface SpawnPlan {
@@ -240,9 +265,24 @@ export function createSpawnPlan(
 
   const extension = extname(resolvedOrUndefined).toLowerCase();
   if (extension === ".cmd" || extension === ".bat") {
+    const nodeShim = resolveWindowsNodeShim(resolvedOrUndefined);
+    if (nodeShim) {
+      return {
+        command: nodeShim.nodeCommand,
+        args: [nodeShim.scriptPath, ...args]
+      };
+    }
+
     return {
-      command: process.env.ComSpec || "cmd.exe",
-      args: ["/d", "/s", "/c", [quoteWindowsCmdArg(resolvedOrUndefined), ...args.map(quoteWindowsCmdArg)].join(" ")]
+      command: resolveWindowsPowerShellHost(),
+      args: [
+        "-NoProfile",
+        "-NonInteractive",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-Command",
+        buildPowerShellBatchInvocation(resolvedOrUndefined, args)
+      ]
     };
   }
 
@@ -292,6 +332,55 @@ function windowsPathDirectories(): string[] {
     .filter(Boolean);
 }
 
+function resolveWindowsNodeShim(
+  shimPath: string
+): { nodeCommand: string; scriptPath: string } | undefined {
+  try {
+    const contents = readFileSync(shimPath, "utf8");
+    const scriptMatch = contents.match(/"%_prog%"\s+"%dp0%\\([^"]+)"\s+%\*/iu);
+    const relativeScriptPath = scriptMatch?.[1];
+    if (!relativeScriptPath) {
+      return undefined;
+    }
+
+    const scriptPath = resolve(dirname(shimPath), relativeScriptPath.replace(/\\/gu, "/"));
+    if (!existsSync(scriptPath)) {
+      return undefined;
+    }
+
+    const bundledNode = join(dirname(shimPath), "node.exe");
+    return {
+      nodeCommand: existsSync(bundledNode) ? bundledNode : "node",
+      scriptPath
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveWindowsPowerShellHost(): string {
+  const systemRoot = process.env.SystemRoot?.trim();
+  if (systemRoot) {
+    const bundled = join(systemRoot, "System32", "WindowsPowerShell", "v1.0", "powershell.exe");
+    if (existsSync(bundled)) {
+      return bundled;
+    }
+  }
+
+  return "powershell.exe";
+}
+
+function buildPowerShellBatchInvocation(commandPath: string, args: string[]): string {
+  const quotedCommand = quotePowerShellArg(commandPath);
+  const quotedArgs = args.map(quotePowerShellArg).join(" ");
+  return quotedArgs.length > 0 ? `& ${quotedCommand} ${quotedArgs}` : `& ${quotedCommand}`;
+}
+
+function quotePowerShellArg(value: string): string {
+  const normalized = value.replace(/\r?\n/gu, " ");
+  return `'${normalized.replace(/'/gu, "''")}'`;
+}
+
 function quoteWindowsCmdArg(value: string): string {
   const normalized = value.replace(/\r?\n/gu, " ");
   const escaped = normalized
@@ -301,6 +390,16 @@ function quoteWindowsCmdArg(value: string): string {
     .replace(/!/gu, "^^!")
     .replace(/[&|<>()]/gu, (match) => `^${match}`);
   return `"${escaped}"`;
+}
+
+function parsePorcelainPath(line: string): string | undefined {
+  const payload = line.slice(3).trim();
+  if (!payload) {
+    return undefined;
+  }
+
+  const renameMarker = " -> ";
+  return payload.includes(renameMarker) ? payload.split(renameMarker).at(-1)?.trim() : payload;
 }
 
 export function splitCommand(command: string): string[] {

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -29,6 +29,7 @@ export {
 } from "./openai-compatible.js";
 export {
   createSpawnPlan,
+  readGitChangedFiles,
   type SpawnLike,
   type SpawnPlan,
   type SubprocessResult,

--- a/packages/adapters/src/openai-compatible.ts
+++ b/packages/adapters/src/openai-compatible.ts
@@ -12,15 +12,21 @@
  *   Llama 3.x, Mistral 7B, Phi-4, Gemma 3, any GGUF model.
  *
  * Usage:
+ *   # Defaults to OpenAI's hosted endpoint when MARTIN_OPENAI_BASE_URL is unset.
+ *   MARTIN_OPENAI_API_KEY=sk-...
+ *   MARTIN_OPENAI_MODEL=gpt-4.1-mini
+ *   martin-loop run "fix the bug" --engine openai
+ *
+ *   # Or route to a third-party / self-hosted OpenAI-compatible endpoint:
  *   MARTIN_OPENAI_BASE_URL=https://openrouter.ai/api
  *   MARTIN_OPENAI_API_KEY=sk-or-...
  *   MARTIN_OPENAI_MODEL=deepseek/deepseek-chat
- *   martin run "fix the bug" --engine openai
+ *   martin-loop run "fix the bug" --engine openai
  *
  * Or for Ollama:
  *   MARTIN_OPENAI_BASE_URL=http://localhost:11434
  *   MARTIN_OPENAI_MODEL=llama3.3
- *   martin run "fix the bug" --engine openai
+ *   martin-loop run "fix the bug" --engine openai
  */
 
 import type {
@@ -30,7 +36,7 @@ import type {
   MartinAdapterResult
 } from "@martin/core";
 
-import { runVerification, readGitExecutionArtifacts } from "./cli-bridge.js";
+import { readGitChangedFiles, runVerification } from "./cli-bridge.js";
 import { createAdapterCapabilities, normalizeUsage } from "./runtime-support.js";
 
 // ---------------------------------------------------------------------------
@@ -113,11 +119,11 @@ interface OpenAiResponse {
 
 export interface OpenAiCompatibleAdapterOptions {
   /** Base URL of the OpenAI-compatible API. No trailing slash. */
-  baseUrl: string;
+  baseUrl?: string;
   /** API key. Empty string for local (Ollama/LM Studio) endpoints. */
   apiKey?: string;
   /** Model identifier passed as-is to the API (e.g. "deepseek/deepseek-chat"). */
-  model: string;
+  model?: string;
   /**
    * System prompt prepended before the MartinLoop task prompt.
    * Default instructs the model to act as a focused coding assistant.
@@ -144,6 +150,9 @@ Follow these rules exactly:
 - If the task asks you to write or modify code, output the complete file content with changes applied.
 - Be precise, minimal, and test-backed in all changes.
 - State what you changed and why at the end of your response.`;
+
+const DEFAULT_OPENAI_BASE_URL = "https://api.openai.com";
+const DEFAULT_OPENAI_MODEL = "gpt-4.1-mini";
 
 function buildPrompt(request: MartinAdapterRequest): string {
   const lines: string[] = [
@@ -196,14 +205,16 @@ export function createOpenAiCompatibleAdapter(
   const verifyTimeoutMs = options.verifyTimeoutMs ?? 60_000;
   const systemPrompt = options.systemPrompt ?? DEFAULT_SYSTEM_PROMPT;
   const fetchFn = options.fetchImpl ?? globalThis.fetch;
+  const baseUrl = (options.baseUrl ?? DEFAULT_OPENAI_BASE_URL).replace(/\/$/, "");
+  const model = options.model ?? DEFAULT_OPENAI_MODEL;
 
   return {
-    adapterId: `openai-compatible:${options.model}`,
+    adapterId: `openai-compatible:${model}`,
     kind: "direct-provider",
-    label: `OpenAI-compatible: ${options.model}`,
+    label: `OpenAI-compatible: ${model}`,
     metadata: {
       providerId: "openai-compatible",
-      model: options.model,
+      model,
       transport: "http",
       capabilities: createAdapterCapabilities({
         preflight: true,
@@ -214,7 +225,8 @@ export function createOpenAiCompatibleAdapter(
 
     async execute(request: MartinAdapterRequest): Promise<MartinAdapterResult> {
       const prompt = buildPrompt(request);
-      const estimated = estimateCost(options.model, prompt.length, 2000);
+      const estimated = estimateCost(model, prompt.length, 2000);
+      const baselineChangedFiles = new Set(await readGitChangedFiles(workingDirectory, 5_000));
 
       // Preflight: bail if projected cost exceeds remaining budget
       if (
@@ -237,27 +249,27 @@ export function createOpenAiCompatibleAdapter(
       }
 
       // Call the OpenAI-compatible endpoint
-      const endpoint = `${options.baseUrl.replace(/\/$/, "")}/v1/chat/completions`;
+      const endpoint = `${baseUrl}/v1/chat/completions`;
       let responseText = "";
       let tokensIn = estimated.tokensIn;
       let tokensOut = 0;
       const controller = new AbortController();
       const timer = setTimeout(() => controller.abort(), timeoutMs);
 
-      try {
-        const headers: Record<string, string> = { "Content-Type": "application/json" };
-        if (options.apiKey) headers["Authorization"] = `Bearer ${options.apiKey}`;
-        // OpenRouter requires a site URL header for attribution
-        if (options.baseUrl.includes("openrouter")) {
-          headers["HTTP-Referer"] = "https://martinloop.com";
-          headers["X-Title"] = "MartinLoop";
-        }
+        try {
+          const headers: Record<string, string> = { "Content-Type": "application/json" };
+          if (options.apiKey) headers["Authorization"] = `Bearer ${options.apiKey}`;
+          // OpenRouter requires a site URL header for attribution
+          if (baseUrl.includes("openrouter")) {
+            headers["HTTP-Referer"] = "https://martinloop.com";
+            headers["X-Title"] = "MartinLoop";
+          }
 
         const res = await fetchFn(endpoint, {
           method: "POST",
           headers,
           body: JSON.stringify({
-            model: options.model,
+            model,
             messages: [
               { role: "system", content: systemPrompt },
               { role: "user", content: prompt }
@@ -274,7 +286,7 @@ export function createOpenAiCompatibleAdapter(
           const errMsg = body.error?.message ?? `HTTP ${res.status}`;
           return {
             status: "failed",
-            summary: `${options.model} API error: ${errMsg}`,
+            summary: `${model} API error: ${errMsg}`,
             usage: normalizeUsage({ actualUsd: 0, tokensIn: 0, tokensOut: 0, provenance: "unavailable" }),
             verification: { passed: false, summary: "API call failed before verifier." },
             failure: { message: errMsg, classHint: "infrastructure_error" as FailureClass }
@@ -290,7 +302,7 @@ export function createOpenAiCompatibleAdapter(
         }
       } catch (error: unknown) {
         const isAbort = error instanceof Error && error.name === "AbortError";
-        const message = isAbort ? `${options.model} request timed out after ${timeoutMs}ms` : String(error);
+        const message = isAbort ? `${model} request timed out after ${timeoutMs}ms` : String(error);
         return {
           status: "failed",
           summary: message,
@@ -305,7 +317,7 @@ export function createOpenAiCompatibleAdapter(
       if (!responseText.trim()) {
         return {
           status: "failed",
-          summary: `${options.model} returned an empty response.`,
+          summary: `${model} returned an empty response.`,
           usage: normalizeUsage({ actualUsd: 0, tokensIn, tokensOut: 0, provenance: "actual" }),
           verification: { passed: false, summary: "Empty response — nothing to verify." },
           failure: { message: "empty_response" }
@@ -320,9 +332,13 @@ export function createOpenAiCompatibleAdapter(
         request.context.verificationStack
       );
 
-      const execution = await readGitExecutionArtifacts(workingDirectory, 5_000);
+      const execution = {
+        changedFiles: (await readGitChangedFiles(workingDirectory, 5_000)).filter(
+          (file) => !baselineChangedFiles.has(file)
+        )
+      };
 
-      const pricing = KNOWN_MODEL_PRICING[options.model] ?? {
+      const pricing = KNOWN_MODEL_PRICING[model] ?? {
         inputPer1K: FALLBACK_INPUT_PER_1K,
         outputPer1K: FALLBACK_OUTPUT_PER_1K
       };
@@ -332,8 +348,8 @@ export function createOpenAiCompatibleAdapter(
       return {
         status: verification.passed ? "completed" : "failed",
         summary: verification.passed
-          ? `${options.model} completed the task. Verifier passed.`
-          : `${options.model} completed but verifier failed: ${verification.summary}`,
+          ? `${model} completed the task. Verifier passed.`
+          : `${model} completed but verifier failed: ${verification.summary}`,
         usage: normalizeUsage({
           actualUsd,
           tokensIn,

--- a/packages/adapters/src/verifier-only.ts
+++ b/packages/adapters/src/verifier-only.ts
@@ -29,21 +29,16 @@ export function createVerifierOnlyAdapter(
       })
     },
     async execute(request) {
-      const shouldInspectChangedFiles = request.context.mutationMode === "verify_only";
-      const baselineChangedFiles = shouldInspectChangedFiles
-        ? new Set(await readGitChangedFiles(workingDirectory, 5_000))
-        : new Set<string>();
+      const baselineChangedFiles = new Set(await readGitChangedFiles(workingDirectory, 5_000));
       const verification = await runVerification(
         request.context.verificationPlan,
         workingDirectory,
         verifyTimeoutMs,
         request.context.verificationStack
       );
-      const changedFiles = shouldInspectChangedFiles
-        ? (await readGitChangedFiles(workingDirectory, 5_000)).filter(
-            (file) => !baselineChangedFiles.has(file)
-          )
-        : [];
+      const changedFiles = (await readGitChangedFiles(workingDirectory, 5_000)).filter(
+        (file) => !baselineChangedFiles.has(file)
+      );
       const execution = { changedFiles };
 
       if (verification.passed) {

--- a/packages/adapters/src/verifier-only.ts
+++ b/packages/adapters/src/verifier-only.ts
@@ -1,6 +1,6 @@
 import type { MartinAdapter } from "@martin/core";
 
-import { readGitExecutionArtifacts, runVerification } from "./cli-bridge.js";
+import { readGitChangedFiles, runVerification } from "./cli-bridge.js";
 import { createAdapterCapabilities, normalizeUsage } from "./runtime-support.js";
 
 export interface VerifierOnlyAdapterOptions {
@@ -29,14 +29,22 @@ export function createVerifierOnlyAdapter(
       })
     },
     async execute(request) {
+      const shouldInspectChangedFiles = request.context.mutationMode === "verify_only";
+      const baselineChangedFiles = shouldInspectChangedFiles
+        ? new Set(await readGitChangedFiles(workingDirectory, 5_000))
+        : new Set<string>();
       const verification = await runVerification(
         request.context.verificationPlan,
         workingDirectory,
         verifyTimeoutMs,
         request.context.verificationStack
       );
-      const execution = await readGitExecutionArtifacts(workingDirectory, 5_000);
-      const changedFiles = execution.changedFiles ?? [];
+      const changedFiles = shouldInspectChangedFiles
+        ? (await readGitChangedFiles(workingDirectory, 5_000)).filter(
+            (file) => !baselineChangedFiles.has(file)
+          )
+        : [];
+      const execution = { changedFiles };
 
       if (verification.passed) {
         return {

--- a/packages/adapters/tests/claude-cli.test.ts
+++ b/packages/adapters/tests/claude-cli.test.ts
@@ -16,6 +16,7 @@ import {
   createClaudeCliAdapter,
   createCodexCliAdapter,
   createVerifierOnlyAdapter,
+  readGitChangedFiles,
   type SpawnLike
 } from "../src/index.js";
 import { runSubprocess, splitCommand } from "../src/cli-bridge.js";
@@ -533,8 +534,23 @@ describe("runSubprocess", () => {
   });
 });
 
+describe("readGitChangedFiles", () => {
+  it("parses NUL-delimited rename entries and keeps the destination path", async () => {
+    const calls: SpawnCall[] = [];
+    const changedFiles = await readGitChangedFiles(process.cwd(), 5_000, createScriptedSpawn(calls, [
+      {
+        stdout: ` M spaced name.ts\u0000R  old-name.ts\u0000renamed name.ts\u0000`
+      }
+    ]));
+
+    expect(calls[0]?.command).toBe("git");
+    expect(calls[0]?.args).toContain("-z");
+    expect(changedFiles).toEqual(["spaced name.ts", "renamed name.ts"]);
+  });
+});
+
 describe("createVerifierOnlyAdapter", () => {
-  it("reports verifier-created file changes instead of treating verify-only as clean", async () => {
+  it("reports verifier-created file changes in proof-mode runs", async () => {
     const directory = await mkdtemp(join(tmpdir(), "martin-verify-only-"));
 
     try {
@@ -564,7 +580,6 @@ describe("createVerifierOnlyAdapter", () => {
             verificationPlan: [
               `"${process.execPath}" -e "require('node:fs').writeFileSync('tracked.txt','changed')"`
             ],
-            mutationMode: "verify_only",
             focus: "verify only",
             remainingBudgetUsd: 8,
             remainingIterations: 1,
@@ -609,7 +624,6 @@ describe("createVerifierOnlyAdapter", () => {
             taskTitle: "verify only",
             objective: "Run verification only",
             verificationPlan: [`"${process.execPath}" -e "process.exit(0)"`],
-            mutationMode: "verify_only",
             focus: "verify only",
             remainingBudgetUsd: 8,
             remainingIterations: 1,

--- a/packages/adapters/tests/claude-cli.test.ts
+++ b/packages/adapters/tests/claude-cli.test.ts
@@ -4,7 +4,7 @@ import type { ChildProcess, SpawnOptions } from "node:child_process";
 
 import { describe, expect, it } from "vitest";
 import { spawnSync } from "node:child_process";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -101,6 +101,21 @@ function createScriptedSpawn(
 
     return child as ChildProcess;
   };
+}
+
+async function withPathPrefix<T>(directory: string, fn: () => Promise<T>): Promise<T> {
+  const pathKey = Object.keys(process.env).find((key) => key.toLowerCase() === "path") ?? "PATH";
+  const original = process.env[pathKey] ?? "";
+  process.env[pathKey] =
+    original.length > 0
+      ? `${directory}${process.platform === "win32" ? ";" : ":"}${original}`
+      : directory;
+
+  try {
+    return await fn();
+  } finally {
+    process.env[pathKey] = original;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -342,21 +357,34 @@ describe("splitCommand", () => {
 });
 
 describe("createSpawnPlan", () => {
-  it("wraps absolute Windows .cmd verifiers with cmd.exe", () => {
+  it("unwraps Windows npm-style .cmd shims into a launchable host", async () => {
     if (process.platform !== "win32") {
       expect(true).toBe(true);
       return;
     }
 
-    const pnpmPath = "C:\\Users\\Torram\\AppData\\Roaming\\npm\\pnpm.cmd";
-    const plan = createSpawnPlan(pnpmPath, ["verify:shared-baseline"], process.cwd(), false);
+    const tempRoot = await mkdtemp(join(tmpdir(), "martin-pnpm-shim-"));
+    const pnpmPath = join(tempRoot, "pnpm.cmd");
+    const scriptPath = join(tempRoot, "node_modules", "pnpm", "bin", "pnpm.cjs");
 
-    expect(plan.command.toLowerCase()).toContain("cmd.exe");
-    expect(plan.args[0]).toBe("/d");
-    expect(plan.args[1]).toBe("/s");
-    expect(plan.args[2]).toBe("/c");
-    expect(plan.args[3]).toContain("pnpm.cmd");
-    expect(plan.args[3]).toContain("verify:shared-baseline");
+    try {
+      await mkdir(join(tempRoot, "node_modules", "pnpm", "bin"), { recursive: true });
+      await writeFile(scriptPath, "console.log('pnpm shim');\n", "utf8");
+      await writeFile(
+        pnpmPath,
+        '@SETLOCAL\r\n@SET "_prog=node"\r\n"%_prog%" "%dp0%\\node_modules\\pnpm\\bin\\pnpm.cjs" %*\r\n',
+        "utf8"
+      );
+
+      const plan = createSpawnPlan(pnpmPath, ["verify:shared-baseline"], process.cwd(), false);
+
+      expect(plan.command.toLowerCase()).toMatch(/node(\.exe)?$/);
+      expect(plan.args[0]?.toLowerCase()).toContain("pnpm");
+      expect(plan.args[0]?.toLowerCase()).toContain("node_modules");
+      expect(plan.args).toContain("verify:shared-baseline");
+    } finally {
+      await rm(tempRoot, { force: true, recursive: true });
+    }
   });
 
   it("falls back to cmd.exe shell when command is not found in PATH on Windows (regression: loop_b6800tz2)", () => {
@@ -424,6 +452,85 @@ describe("runSubprocess", () => {
     expect(result.stderr).toBe("");
     expect(result.timedOut).toBe(false);
   });
+
+  it("launches Windows batch commands through a working shell path", async () => {
+    if (process.platform !== "win32") {
+      return;
+    }
+
+    const directory = await mkdtemp(join(tmpdir(), "martin-run-subprocess-batch-"));
+    const commandPath = join(directory, "fake-cli.cmd");
+
+    try {
+      await writeFile(commandPath, "@echo off\r\necho OK:%1,%2\r\n", "utf8");
+
+      const result = await runSubprocess(commandPath, ["foo", "bar"], {
+        cwd: directory,
+        timeoutMs: 5_000
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.trim()).toBe("OK:foo,bar");
+      expect(result.stderr).toBe("");
+    } finally {
+      await rm(directory, { force: true, recursive: true });
+    }
+  });
+
+  it("unwraps Windows npm-style command shims so verifier launches can run", async () => {
+    if (process.platform !== "win32") {
+      return;
+    }
+
+    const directory = await mkdtemp(join(tmpdir(), "martin-run-subprocess-shim-"));
+    const shimPath = join(directory, "fake-cli.cmd");
+    const shimModuleDirectory = join(directory, "node_modules", "fake-cli", "bin");
+    const scriptPath = join(shimModuleDirectory, "fake-cli.js");
+
+    try {
+      await mkdir(shimModuleDirectory, { recursive: true });
+      await writeFile(
+        shimPath,
+        [
+          "@ECHO off",
+          "GOTO start",
+          ":find_dp0",
+          "SET dp0=%~dp0",
+          "EXIT /b",
+          ":start",
+          "SETLOCAL",
+          "CALL :find_dp0",
+          'IF EXIST "%dp0%\\node.exe" (',
+          '  SET "_prog=%dp0%\\node.exe"',
+          ") ELSE (",
+          '  SET "_prog=node"',
+          '  SET PATHEXT=%PATHEXT:;.JS;=;%',
+          ")",
+          'endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%"  "%dp0%\\node_modules\\fake-cli\\bin\\fake-cli.js" %*',
+          ""
+        ].join("\r\n"),
+        "utf8"
+      );
+      await writeFile(
+        scriptPath,
+        'process.stdout.write(`ARGS:${process.argv.slice(2).join(",")}`);',
+        "utf8"
+      );
+
+      const result = await withPathPrefix(directory, async () =>
+        runSubprocess("fake-cli", ["alpha", "beta"], {
+          cwd: directory,
+          timeoutMs: 5_000
+        })
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.trim()).toBe("ARGS:alpha,beta");
+      expect(result.stderr).toBe("");
+    } finally {
+      await rm(directory, { force: true, recursive: true });
+    }
+  });
 });
 
 describe("createVerifierOnlyAdapter", () => {
@@ -472,6 +579,51 @@ describe("createVerifierOnlyAdapter", () => {
       await rm(directory, { force: true, recursive: true });
     }
   });
+
+  it("ignores pre-existing dirty files when the verifier itself makes no new edits", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "martin-verify-only-dirty-"));
+
+    try {
+      spawnSync("git", ["init"], { cwd: directory, stdio: "ignore" });
+      await writeFile(join(directory, "tracked.txt"), "original", "utf8");
+      spawnSync("git", ["add", "tracked.txt"], { cwd: directory, stdio: "ignore" });
+      spawnSync(
+        "git",
+        [
+          "-c",
+          "user.email=martin@example.com",
+          "-c",
+          "user.name=Martin Test",
+          "commit",
+          "-m",
+          "seed"
+        ],
+        { cwd: directory, stdio: "ignore" }
+      );
+      await writeFile(join(directory, "tracked.txt"), "pre-existing dirty change", "utf8");
+
+      const adapter = createVerifierOnlyAdapter({ workingDirectory: directory });
+      const result = await adapter.execute(
+        makeRequest({
+          context: {
+            taskTitle: "verify only",
+            objective: "Run verification only",
+            verificationPlan: [`"${process.execPath}" -e "process.exit(0)"`],
+            mutationMode: "verify_only",
+            focus: "verify only",
+            remainingBudgetUsd: 8,
+            remainingIterations: 1,
+            remainingTokens: 10_000
+          }
+        })
+      );
+
+      expect(result.verification.passed).toBe(true);
+      expect(result.execution?.changedFiles).toEqual([]);
+    } finally {
+      await rm(directory, { force: true, recursive: true });
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -507,6 +659,19 @@ describe("createClaudeCliAdapter", () => {
 
     expect(result.status).toBe("failed");
     expect(result.failure?.message).toContain("environment_mismatch");
+  });
+
+  it("does not force-skip Claude permissions by default", async () => {
+    const calls: SpawnCall[] = [];
+    const adapter = createClaudeCliAdapter({
+      spawnImpl: createScriptedSpawn(calls)
+    });
+
+    const result = await adapter.execute(makeRequest());
+
+    expect(result.status).toBe("completed");
+    expect(calls[0]?.command).toBe("claude");
+    expect(calls[0]?.args).not.toContain("--dangerously-skip-permissions");
   });
 });
 

--- a/packages/adapters/tests/claude-cli.test.ts
+++ b/packages/adapters/tests/claude-cli.test.ts
@@ -545,6 +545,7 @@ describe("readGitChangedFiles", () => {
 
     expect(calls[0]?.command).toBe("git");
     expect(calls[0]?.args).toContain("-z");
+    expect(calls[0]?.args).toContain("--untracked-files=all");
     expect(changedFiles).toEqual(["spaced name.ts", "renamed name.ts"]);
   });
 });
@@ -590,6 +591,51 @@ describe("createVerifierOnlyAdapter", () => {
 
       expect(result.verification.passed).toBe(true);
       expect(result.execution?.changedFiles).toContain("tracked.txt");
+    } finally {
+      await rm(directory, { force: true, recursive: true });
+    }
+  });
+
+  it("reports verifier-created untracked files in proof-mode runs", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "martin-verify-only-untracked-"));
+
+    try {
+      spawnSync("git", ["init"], { cwd: directory, stdio: "ignore" });
+      await writeFile(join(directory, "tracked.txt"), "original", "utf8");
+      spawnSync("git", ["add", "tracked.txt"], { cwd: directory, stdio: "ignore" });
+      spawnSync(
+        "git",
+        [
+          "-c",
+          "user.email=martin@example.com",
+          "-c",
+          "user.name=Martin Test",
+          "commit",
+          "-m",
+          "seed"
+        ],
+        { cwd: directory, stdio: "ignore" }
+      );
+
+      const adapter = createVerifierOnlyAdapter({ workingDirectory: directory });
+      const result = await adapter.execute(
+        makeRequest({
+          context: {
+            taskTitle: "verify only",
+            objective: "Create a fresh proof artifact",
+            verificationPlan: [
+              `"${process.execPath}" -e "require('node:fs').writeFileSync('proof-artifact.txt','created')"`
+            ],
+            focus: "verify only",
+            remainingBudgetUsd: 8,
+            remainingIterations: 1,
+            remainingTokens: 10_000
+          }
+        })
+      );
+
+      expect(result.verification.passed).toBe(true);
+      expect(result.execution?.changedFiles).toContain("proof-artifact.txt");
     } finally {
       await rm(directory, { force: true, recursive: true });
     }

--- a/packages/adapters/tests/openai-compatible.test.ts
+++ b/packages/adapters/tests/openai-compatible.test.ts
@@ -144,7 +144,7 @@ describe("createOpenAiCompatibleAdapter", () => {
 
       expect(result.status).toBe("failed");
       expect(result.failure?.message).toContain("network exploded");
-      expect(clearTimeoutSpy).toHaveBeenCalledTimes(1);
+      expect(clearTimeoutSpy).toHaveBeenCalled();
     } finally {
       clearTimeoutSpy.mockRestore();
     }
@@ -246,5 +246,28 @@ describe("createOpenAiCompatibleAdapter", () => {
     expect(adapter.metadata.model).toBe("llama3.3");
     expect(adapter.metadata.transport).toBe("http");
     expect(adapter.kind).toBe("direct-provider");
+  });
+
+  it("defaults to the hosted OpenAI endpoint and model when config is omitted", async () => {
+    let capturedUrl = "";
+    const adapter = createOpenAiCompatibleAdapter({
+      fetchImpl: async (input) => {
+        capturedUrl = String(input);
+        return new Response(JSON.stringify({
+          choices: [{ message: { role: "assistant", content: "Fixed." }, finish_reason: "stop" }],
+          usage: { prompt_tokens: 10, completion_tokens: 5 }
+        }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" }
+        });
+      }
+    });
+
+    const result = await adapter.execute(makeRequest() as any);
+
+    expect(result.status).toBe("completed");
+    expect(adapter.adapterId).toBe("openai-compatible:gpt-4.1-mini");
+    expect(adapter.metadata.model).toBe("gpt-4.1-mini");
+    expect(capturedUrl).toBe("https://api.openai.com/v1/chat/completions");
   });
 });

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,8 +1,8 @@
 # @martin/cli
 
-CLI implementation for MartinLoop.
+Workspace package that powers the public `martin-loop` binary.
 
-The published binary is `martin-loop`. Inside this workspace package you may also see the local development alias `martin`, but the public install target remains `martin-loop`.
+The public install target is `martin-loop`. External users should install and invoke `martin-loop`.
 
 ## Product Flow
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@martin/cli",
   "version": "0.1.0",
+  "private": true,
   "type": "module",
   "description": "Martin Loop CLI — budget-aware coding loops with failure classification and verified exits.",
   "bin": {
@@ -8,9 +9,6 @@
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "publishConfig": {
-    "access": "public"
-  },
   "scripts": {
     "prebuild": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\"",
     "build": "pnpm --filter @martin/contracts build && pnpm --filter @martin/core build && pnpm --filter @martin/adapters build && tsc -p tsconfig.build.json",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -8,7 +8,6 @@ import {
   createClaudeCliAdapter,
   createCodexCliAdapter,
   createOpenAiCompatibleAdapter,
-  createStubDirectProviderAdapter,
   createVerifierOnlyAdapter
 } from "@martin/adapters";
 import { runMartin, type MartinAdapter } from "@martin/core";
@@ -93,6 +92,7 @@ export type RunCommandRequest = {
   model?: string;
   engine?: string;
   mutationMode?: MutationMode;
+  proofMode?: boolean;
   allowedPaths?: string[];
   deniedPaths?: string[];
   acceptanceCriteria?: string[];
@@ -641,32 +641,28 @@ export function renderCliHelp(): string {
     "Martin Loop CLI",
     "",
     "Usage:",
-    "  martin run <objective> [options]",
-    "  martin-loop run <objective> [options]    (published alias)",
-    "  martin preflight <objective> [options]",
-    "  martin start [--host <codex|claude|gemini|generic>] [options]",
-    "  martin tour [--host <codex|claude|gemini|generic>]",
-    "  martin guide [start|tour|doctor|demo|session-start|plan|preflight|run|dossier|mcp] [--host <codex|claude|gemini|generic>]",
-    "  martin doctor [options]",
-    "  martin session-start [--host <claude|codex|generic>] [options]",
-    "  martin phase status|contract|preflight|run [--execute] [options]",
-    "  martin triage [options]",
-    "  martin dossier (--loop-id <id> | --file <path> | --latest) [options]",
-    "  martin runs list [options]",
-    "  martin runs get (--loop-id <id> | --file <path> | --latest) [options]",
-    "  martin runs attempt (--loop-id <id> | --file <path>) [--attempt-index <n>] [options]",
-    "  martin runs verify (--loop-id <id> | --file <path>) [options]",
-    "  martin mcp print-config --host <codex|claude|gemini|generic> [--scope <user|project|local>] [options]",
-    "  martin mcp install --host <codex|claude|gemini|generic> [--scope <user|project|local>] [--dry-run] [options]",
-    "  martin demo [--dir <path>] [--force]",
-    "  martin-loop demo [--dir <path>] [--force] (published alias)",
-    "  martin inspect --file <path>",
-    "  martin-loop inspect --file <path>        (published alias)",
-    "  martin resume <loopId>",
-    "  martin-loop resume <loopId>              (published alias)",
-    "  martin bench --suite <suiteId>",
-    "  martin challenge [--loop-id <id> | --file <path> | --latest] [--format markdown|svg]",
-    "  martin badge [--format svg|json]",
+    "  martin-loop run <objective> [options]",
+    "  martin-loop preflight <objective> [options]",
+    "  martin-loop start [--host <codex|claude|gemini|generic>] [options]",
+    "  martin-loop tour [--host <codex|claude|gemini|generic>]",
+    "  martin-loop guide [start|tour|doctor|demo|session-start|plan|preflight|run|dossier|mcp] [--host <codex|claude|gemini|generic>]",
+    "  martin-loop doctor [options]",
+    "  martin-loop session-start [--host <claude|codex|generic>] [options]",
+    "  martin-loop phase status|contract|preflight|run [--execute] [options]",
+    "  martin-loop triage [options]",
+    "  martin-loop dossier (--loop-id <id> | --file <path> | --latest) [options]",
+    "  martin-loop runs list [options]",
+    "  martin-loop runs get (--loop-id <id> | --file <path> | --latest) [options]",
+    "  martin-loop runs attempt (--loop-id <id> | --file <path>) [--attempt-index <n>] [options]",
+    "  martin-loop runs verify (--loop-id <id> | --file <path>) [options]",
+    "  martin-loop mcp print-config --host <codex|claude|gemini|generic> [--scope <user|project|local>] [options]",
+    "  martin-loop mcp install --host <codex|claude|gemini|generic> [--scope <user|project|local>] [--dry-run] [options]",
+    "  martin-loop demo [--dir <path>] [--force]",
+    "  martin-loop inspect --file <path>",
+    "  martin-loop resume <loopId>",
+    "  martin-loop bench --suite <suiteId>",
+    "  martin-loop challenge [--loop-id <id> | --file <path> | --latest] [--format markdown|svg]",
+    "  martin-loop badge [--format svg|json]",
     "",
     "Operator commands:",
     "  start        Guided onboarding for humans and MCP hosts; picks the safest next command.",
@@ -691,8 +687,8 @@ export function renderCliHelp(): string {
     "  badge        Print an agent reliability readiness badge from local evidence.",
     "",
     "Compatibility aliases:",
-    "  inspect      Legacy file-based summary view. Prefer `martin dossier` or `martin runs get`.",
-    "  resume       Legacy loop lookup alias. Prefer `martin runs get --loop-id`.",
+    "  inspect      Legacy file-based summary view. Prefer `martin-loop dossier` or `martin-loop runs get`.",
+    "  resume       Legacy loop lookup alias. Prefer `martin-loop runs get --loop-id`.",
     "",
     "Global output modes:",
     "  --json       Emit stable machine-readable JSON.",
@@ -721,10 +717,11 @@ export function renderCliHelp(): string {
     "",
     "Run options:",
     "  --engine <name>          Adapter: claude (default), codex, or openai.",
-    "                           openai routes to any OpenAI-compatible endpoint.",
-    "                           Set MARTIN_OPENAI_BASE_URL, MARTIN_OPENAI_API_KEY,",
-    "                           MARTIN_OPENAI_MODEL. Works with Ollama, OpenRouter,",
-    "                           Together.ai, LM Studio, and any local model server.",
+    "                           openai defaults to the hosted OpenAI endpoint.",
+    "                           Set MARTIN_OPENAI_API_KEY and optionally",
+    "                           MARTIN_OPENAI_MODEL. Override MARTIN_OPENAI_BASE_URL",
+    "                           for Ollama, OpenRouter, Together.ai, LM Studio,",
+    "                           or any other OpenAI-compatible endpoint.",
     "  --model <name>           Override the model.",
     "  --cwd <path>             Set the repo root used for repo-backed runs.",
     "  --budget-usd <n>         Set the hard cost cap in USD.",
@@ -732,6 +729,7 @@ export function renderCliHelp(): string {
     "  --max-iterations <n>     Set the maximum number of attempts.",
     "  --max-tokens <n>         Set the maximum total token budget.",
     "  --verify <cmd>           Shell command to run as the verifier after each attempt.",
+    "  --proof                  Use the no-spend proof adapter instead of a live coding CLI.",
     "  --verify-only            Skip the coding adapter and run the verifier only.",
     "  --unsafe-allow-unguarded-run  Override the local governance gate for this one run.",
     "  --allow-path <glob>      Restrict agent writes to this path pattern (repeatable).",
@@ -774,11 +772,10 @@ async function executeRunCommand(
   };
   const cliEnvironment = resolveCliEnvironment({
     cwd: resolvedRequest.cwd,
-    engine: resolvedRequest.engine
+    engine: resolvedRequest.engine,
+    ...(resolvedRequest.proofMode ? { liveMode: "proof" as const } : {})
   });
-  const allowUngovernedRun =
-    resolvedRequest.allowUngovernedRun === true ||
-    process.env["MARTIN_ALLOW_UNGUARDED_RUN"] === "true";
+  const allowUngovernedRun = resolvedRequest.allowUngovernedRun === true;
   if (!allowUngovernedRun) {
     const gate = await evaluateCliRunGate({
       runsRoot: cliEnvironment.runsRoot,
@@ -791,7 +788,7 @@ async function executeRunCommand(
 
     if (!gate.allowed) {
       throw new CliCommandError("policy_blocked", gate.message, {
-        suggestion: `${gate.nextCommand}${outputMode === "human" ? "\nNeed the guided walkthrough? Run `martin tour`." : ""}`,
+        suggestion: `${gate.nextCommand}${outputMode === "human" ? "\nNeed the guided walkthrough? Run `martin-loop tour`." : ""}`,
         details: {
           missingSteps: gate.missingSteps,
           nextCommand: gate.nextCommand
@@ -804,7 +801,8 @@ async function executeRunCommand(
     resolvedRequest.engine,
     cliEnvironment.workingDirectory,
     resolvedRequest.model,
-    resolvedRequest.mutationMode
+    resolvedRequest.mutationMode,
+    cliEnvironment.liveMode
   );
 
   let result: Awaited<ReturnType<typeof runMartin>>;
@@ -849,7 +847,7 @@ async function executeRunCommand(
 
     throw new CliCommandError("environment", "Martin could not start the requested execution adapter.", {
       suggestion:
-        "Run `martin doctor` to verify engine availability, or set MARTIN_LIVE=false to use the stub adapter locally.",
+        "Run `martin-loop doctor` to verify engine availability, or rerun with `--proof` for a no-spend verification pass.",
       details: {
         loopId: fallbackLoop.loopId,
         reason: error instanceof Error ? error.message : String(error)
@@ -933,13 +931,13 @@ async function executeInspectCommand(
       summary: buildPortfolioSnapshot(loops),
       compatibility: {
         alias: "inspect",
-        preferredCommand: "martin dossier"
+        preferredCommand: "martin-loop dossier"
       }
     },
     human: [
       `Inspect summary for ${sourcePath}`,
       `Loops found: ${loops.length}`,
-      "Compatibility note: `martin inspect` is still supported, but `martin dossier` and `martin runs get` are the preferred operator flows."
+      "Compatibility note: `martin-loop inspect` is still supported, but `martin-loop dossier` and `martin-loop runs get` are the preferred operator flows."
     ],
     quiet: sourcePath
   });
@@ -951,7 +949,7 @@ async function executeResumeCommand(
 ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
   if (!command.selector.loopId) {
     throw new CliCommandError("invalid_input", "resume requires a loop ID.", {
-      suggestion: "Use `martin resume <loopId>` or `martin runs get --loop-id <loopId>`."
+      suggestion: "Use `martin-loop resume <loopId>` or `martin-loop runs get --loop-id <loopId>`."
     });
   }
 
@@ -966,14 +964,14 @@ async function executeResumeCommand(
       verification,
       compatibility: {
         alias: "resume",
-        preferredCommand: "martin runs get --loop-id"
+        preferredCommand: "martin-loop runs get --loop-id"
       }
     },
     human: [
       `Loaded persisted loop ${detail.loop.loopId}`,
       `Status: ${detail.loop.status} / ${detail.loop.lifecycleState}`,
       `Verification: ${verification.status}`,
-      "Compatibility note: `martin resume` is still supported, but `martin runs get --loop-id` is the preferred operator flow."
+      "Compatibility note: `martin-loop resume` is still supported, but `martin-loop runs get --loop-id` is the preferred operator flow."
     ],
     quiet: detail.loop.loopId,
     warnings: detail.warnings
@@ -1111,14 +1109,14 @@ async function executeStartCommand(
       liveMode: environment.liveMode,
       availableHosts,
       bestNextCommand,
-      tourCommand: "martin tour",
+      tourCommand: "martin-loop tour",
       recommendedFlow: [
-        "martin tour",
-        "martin doctor",
-        "martin session-start",
-        'martin phase contract --json',
-        'martin phase preflight',
-        'martin dossier --latest'
+        "martin-loop tour",
+        "martin-loop doctor",
+        "martin-loop session-start",
+        'martin-loop phase contract --json',
+        'martin-loop phase preflight',
+        'martin-loop dossier --latest'
       ],
       hostBootstrap: buildHostBootstrapPlan({
         preferredHost: command.host,
@@ -1161,19 +1159,19 @@ async function executeGuideCommand(
       topic: command.topic ?? "overview",
       host: command.host ?? "codex",
       recommendedSequence: [
-        "martin start",
-        "martin tour",
-        "martin doctor",
-        "martin session-start",
-        "martin phase contract --json",
-        "martin phase preflight",
-        "martin run <objective> --verify <command>",
-        "martin dossier --latest"
+        "martin-loop start",
+        "martin-loop tour",
+        "martin-loop doctor",
+        "martin-loop session-start",
+        "martin-loop phase contract --json",
+        "martin-loop phase preflight",
+        "martin-loop run <objective> --verify <command>",
+        "martin-loop dossier --latest"
       ],
       commandMap
     },
     human: selected ? renderGuideTopic(selected) : renderGuideOverview(commandMap, command.host),
-    quiet: selected?.command ?? "martin start"
+    quiet: selected?.command ?? "martin-loop start"
   });
 }
 
@@ -1201,11 +1199,11 @@ async function executeTourCommand(
       command: "tour",
       host: hostBootstrap.host,
       steps,
-      demoCommand: "martin demo",
+      demoCommand: "martin-loop demo",
       hostBootstrap
     },
     human: renderTourHuman(steps, hostBootstrap),
-    quiet: "martin doctor"
+    quiet: "martin-loop doctor"
   });
 }
 
@@ -1729,6 +1727,9 @@ function parseRunRequest(rest: string[]): RunCommandRequest {
         }
         index += 1;
         break;
+      case "--proof":
+        request.proofMode = true;
+        break;
       case "--metadata":
         if (next) {
           const [key, value] = next.split("=");
@@ -1837,6 +1838,7 @@ function parseRunRequest(rest: string[]): RunCommandRequest {
     ...(request.model ? { model: request.model } : {}),
     ...(request.engine ? { engine: request.engine } : {}),
     ...(request.mutationMode ? { mutationMode: request.mutationMode } : {}),
+    ...(request.proofMode ? { proofMode: true } : {}),
     ...(request.allowedPaths?.length ? { allowedPaths: request.allowedPaths } : {}),
     ...(request.deniedPaths?.length ? { deniedPaths: request.deniedPaths } : {}),
     ...(request.acceptanceCriteria?.length ? { acceptanceCriteria: request.acceptanceCriteria } : {}),
@@ -2121,10 +2123,10 @@ function renderDemoInstructions(targetDirectory: string): string {
     "  npm test",
     "",
     "Safe first run (no provider spend):",
-    '  MARTIN_LIVE=false npx martin run "Summarize the demo workspace and confirm the verifier is green" --verify "npm test"',
+    '  npx martin-loop run "Summarize the demo workspace and confirm the verifier is green" --proof --verify "npm test"',
     "",
     "Optional live run:",
-    '  npx martin run "Add support for a discount percentage to summarizeInvoice and update the tests" --verify "npm test" --engine codex',
+    '  npx martin-loop run "Add support for a discount percentage to summarizeInvoice and update the tests" --verify "npm test" --engine codex',
     "",
     `Task ideas live in ${join(targetDirectory, "TASKS.md")}`
   ].join("\n");
@@ -2156,13 +2158,13 @@ function renderDoctorHuman(input: {
     "",
     `Best next command: ${bestNextCommand}`,
     "Agent-native path:",
-    "  martin session-start",
-    "  martin phase contract --json",
-    "  martin phase preflight",
+    "  martin-loop session-start",
+    "  martin-loop phase contract --json",
+    "  martin-loop phase preflight",
     "",
     "Human-first proof path:",
-    "  martin demo",
-    "  martin dossier --latest"
+    "  martin-loop demo",
+    "  martin-loop dossier --latest"
   ];
 }
 
@@ -2193,23 +2195,23 @@ function buildStartHuman(input: {
       : []),
     "",
     "Need the interactive product tour?",
-    "  martin tour",
+    "  martin-loop tour",
     "Need the static command map?",
-    "  martin guide",
+    "  martin-loop guide",
     "",
     "Safe local flow:",
-    "  martin doctor",
-    "  martin session-start",
-    "  martin phase contract --json",
-    "  martin phase preflight",
-    "  martin dossier --latest",
+    "  martin-loop doctor",
+    "  martin-loop session-start",
+    "  martin-loop phase contract --json",
+    "  martin-loop phase preflight",
+    "  martin-loop dossier --latest",
     "",
     "No-spend proof path:",
-    "  martin demo",
-    '  MARTIN_LIVE=false martin run "Summarize the demo workspace and confirm the verifier is green" --verify "npm test"',
+    "  martin-loop demo",
+    '  martin-loop run "Summarize the demo workspace and confirm the verifier is green" --proof --verify "npm test"',
     "",
     `Recommended MCP bootstrap: ${hostPlan.installCommand}`,
-    `Preview config: ${hostPlan.printConfigCommand}`
+    `Preview config: ${hostPlan.printConfigCommand.replace(/\bmartin\b/gu, "martin-loop")}`
   ];
 }
 
@@ -2229,49 +2231,49 @@ function buildTourSteps(host?: MartinMcpHost): Array<{
   return [
     {
       step: 1,
-      command: "martin start",
+      command: "martin-loop start",
       why: "See the safest next command for this repo and your preferred host.",
       expected: "You get the recommended flow plus one MCP bootstrap path."
     },
     {
       step: 2,
-      command: "martin doctor",
+      command: "martin-loop doctor",
       why: "Confirm the working directory, runs root, engine availability, and local policy posture.",
       expected: "Doctor prints readiness plus the best next command."
     },
     {
       step: 3,
-      command: "martin demo",
+      command: "martin-loop demo",
       why: "Create a disposable workspace so you can learn the flow without risking a real repo.",
       expected: "A local martin-loop-demo directory is created with safe task ideas."
     },
     {
       step: 4,
-      command: "martin session-start",
+      command: "martin-loop session-start",
       why: "Get the current local run state and the next governed action before doing real work.",
       expected: "Session-start prints the recommended next action and phase hints."
     },
     {
       step: 5,
-      command: "martin phase contract --json",
+      command: "martin-loop phase contract --json",
       why: "Turn the local plan into an explicit governed contract.",
       expected: "You see objective, verifiers, allowed paths, and risk posture in one payload."
     },
     {
       step: 6,
-      command: 'martin preflight "Summarize the demo workspace and confirm tests still pass" --verify "npm test"',
+      command: 'martin-loop preflight "Summarize the demo workspace and confirm tests still pass" --verify "npm test"',
       why: "Create the receipt MartinLoop requires before a governed run is allowed.",
       expected: "Preflight returns ready=true when the task is safe to run."
     },
     {
       step: 7,
-      command: 'MARTIN_LIVE=false martin run "Summarize the demo workspace and confirm tests still pass" --verify "npm test"',
+      command: 'martin-loop run "Summarize the demo workspace and confirm tests still pass" --proof --verify "npm test"',
       why: "Practice the full workflow with no model spend and the governance gate still active.",
       expected: "Martin writes a run receipt and keeps the verifier honest."
     },
     {
       step: 8,
-      command: "martin dossier --latest",
+      command: "martin-loop dossier --latest",
       why: "Review what happened, what Martin prevented, and the next safe move.",
       expected: "You get the richest single-run summary and proof surface."
     },
@@ -2340,66 +2342,66 @@ function buildGuideCommandMap(host?: MartinMcpHost): Array<{
   return [
     {
       topic: "start",
-      command: "martin start",
+      command: "martin-loop start",
       purpose: "Show the safest next MartinLoop command and the recommended host bootstrap path.",
       when: "First install or first run in a new repo.",
-      example: "martin start"
+      example: "martin-loop start"
     },
     {
       topic: "tour",
-      command: "martin tour",
+      command: "martin-loop tour",
       purpose: "Walk through the full MartinLoop flow with exact commands, expected output, and a safe demo path.",
       when: "Right after install or when onboarding a human or agent host.",
-      example: "martin tour --host codex"
+      example: "martin-loop tour --host codex"
     },
     {
       topic: "doctor",
-      command: "martin doctor",
+      command: "martin-loop doctor",
       purpose: "Check runtime readiness, engine availability, runs root, and starter MCP profile guidance.",
       when: "Before the first governed run or when setup looks wrong.",
-      example: "martin doctor --engine codex"
+      example: "martin-loop doctor --engine codex"
     },
     {
       topic: "demo",
-      command: "martin demo",
+      command: "martin-loop demo",
       purpose: "Create a disposable local sandbox so a user or agent can learn MartinLoop without touching a real repo.",
       when: "When you want a safe demo or proof path.",
-      example: "martin demo --dir ./martin-loop-demo"
+      example: "martin-loop demo --dir ./martin-loop-demo"
     },
     {
       topic: "session-start",
-      command: "martin session-start",
+      command: "martin-loop session-start",
       purpose: "Summarize local phase state, latest run evidence, and the recommended next action.",
       when: "At the start of a real coding session.",
-      example: "martin session-start --host codex"
+      example: "martin-loop session-start --host codex"
     },
     {
       topic: "plan",
-      command: "martin phase contract --json",
+      command: "martin-loop phase contract --json",
       purpose: "Compile the local phase state into an explicit governed contract before spend.",
       when: "Before preflight when MartinLoop should turn the plan into a real contract.",
-      example: "martin phase contract --json"
+      example: "martin-loop phase contract --json"
     },
     {
       topic: "preflight",
-      command: "martin phase preflight",
+      command: "martin-loop phase preflight",
       purpose: "Preview the governed run shape and block bad verifier, scope, or budget decisions before execution.",
       when: "Before any non-trivial run.",
-      example: "martin preflight \"Fix auth regression\" --verify \"pnpm test\""
+      example: "martin-loop preflight \"Fix auth regression\" --verify \"pnpm test\""
     },
     {
       topic: "run",
-      command: "martin run",
+      command: "martin-loop run",
       purpose: "Execute the governed task after the safety envelope is explicit.",
       when: "Only after doctor and preflight are sane.",
-      example: "martin run \"Fix auth regression\" --verify \"pnpm test\" --budget-usd 3"
+      example: "martin-loop run \"Fix auth regression\" --verify \"pnpm test\" --budget-usd 3"
     },
     {
       topic: "dossier",
-      command: "martin dossier --latest",
+      command: "martin-loop dossier --latest",
       purpose: "Show what happened, what Martin prevented, and what the next safe action is.",
       when: "Immediately after a run or before sharing results.",
-      example: "martin dossier --latest"
+      example: "martin-loop dossier --latest"
     },
     {
       topic: "mcp",
@@ -2419,14 +2421,14 @@ function renderGuideOverview(
     "Martin Loop guide",
     "",
     "Use this as the built-in tour after install. MartinLoop's default operating sequence is:",
-    "  1. martin start",
-    "  2. martin tour",
-    "  3. martin doctor",
-    "  4. martin session-start",
-    "  5. martin phase contract --json",
-    "  6. martin phase preflight",
-    "  7. martin run <objective> --verify <command>",
-    "  8. martin dossier --latest",
+    "  1. martin-loop start",
+    "  2. martin-loop tour",
+    "  3. martin-loop doctor",
+    "  4. martin-loop session-start",
+    "  5. martin-loop phase contract --json",
+    "  6. martin-loop phase preflight",
+    "  7. martin-loop run <objective> --verify <command>",
+    "  8. martin-loop dossier --latest",
     "",
     "Command map:",
     ...commandMap.map((entry) => `  ${entry.command} — ${entry.purpose}`),
@@ -2435,9 +2437,9 @@ function renderGuideOverview(
     `  ${commandMap.find((entry) => entry.topic === "mcp")?.example}`,
     "",
     "For a focused explanation, run:",
-    "  martin tour",
-    "  martin guide start",
-    "  martin guide mcp"
+    "  martin-loop tour",
+    "  martin-loop guide start",
+    "  martin-loop guide mcp"
   ];
 }
 
@@ -2463,14 +2465,14 @@ function selectBestNextCommand(input: {
   hasClaude: boolean;
 }): string {
   if (!input.workingDirectoryReady) {
-    return "martin demo";
+    return "martin-loop demo";
   }
 
   if (input.hasCodex || input.hasClaude) {
-    return "martin session-start";
+    return "martin-loop session-start";
   }
 
-  return "martin doctor";
+  return "martin-loop doctor";
 }
 
 async function resolveFirstRunBanner(
@@ -2526,30 +2528,30 @@ function buildHostBootstrapPlan(input: {
         process.platform === "win32"
           ? "claude mcp add --transport stdio --scope user martin-loop -- cmd /c npx -y @martinloop/mcp"
           : "claude mcp add --transport stdio --scope user martin-loop -- npx -y @martinloop/mcp",
-      printConfigCommand: "martin mcp print-config --host claude --profile minimal"
+      printConfigCommand: "martin-loop mcp print-config --host claude --profile minimal"
     };
   }
 
   if (host === "gemini") {
     return {
       host,
-      installCommand: "martin mcp install --host gemini --scope user --dry-run",
-      printConfigCommand: "martin mcp print-config --host gemini --profile minimal"
+      installCommand: "martin-loop mcp install --host gemini --scope user --dry-run",
+      printConfigCommand: "martin-loop mcp print-config --host gemini --profile minimal"
     };
   }
 
   if (host === "generic") {
     return {
       host,
-      installCommand: "martin mcp install --host generic --scope project --dry-run",
-      printConfigCommand: "martin mcp print-config --host generic --profile minimal"
+      installCommand: "martin-loop mcp install --host generic --scope project --dry-run",
+      printConfigCommand: "martin-loop mcp print-config --host generic --profile minimal"
     };
   }
 
   return {
     host: "codex",
     installCommand: "codex mcp add martin-loop -- npx -y @martinloop/mcp",
-    printConfigCommand: "martin mcp print-config --host codex --profile minimal"
+    printConfigCommand: "martin-loop mcp print-config --host codex --profile minimal"
   };
 }
 
@@ -2782,17 +2784,17 @@ function selectAdapter(
   engine: string | undefined,
   workingDirectory: string,
   modelOverride?: string,
-  mutationMode?: MutationMode
+  mutationMode?: MutationMode,
+  liveMode: "live" | "proof" = process.env.MARTIN_LIVE === "false" ? "proof" : "live"
 ): MartinAdapter {
   if (mutationMode === "verify_only") {
     return createVerifierOnlyAdapter({ workingDirectory });
   }
 
-  if (process.env.MARTIN_LIVE === "false") {
-    return createStubDirectProviderAdapter({
-      label: "Stub adapter (MARTIN_LIVE=false)",
-      providerId: "stub",
-      model: "stub"
+  if (liveMode === "proof") {
+    return createVerifierOnlyAdapter({
+      workingDirectory,
+      label: "Proof mode adapter"
     });
   }
 
@@ -2801,23 +2803,28 @@ function selectAdapter(
   }
 
   if (engine === "openai") {
-    const baseUrl = process.env["MARTIN_OPENAI_BASE_URL"] ?? "http://localhost:11434";
-    const apiKey = process.env["MARTIN_OPENAI_API_KEY"] ?? "";
-    const model = modelOverride ?? process.env["MARTIN_OPENAI_MODEL"] ?? "llama3.3";
-    return createOpenAiCompatibleAdapter({ baseUrl, apiKey, model, workingDirectory });
+    const baseUrl = process.env["MARTIN_OPENAI_BASE_URL"]?.trim() || undefined;
+    const apiKey = process.env["MARTIN_OPENAI_API_KEY"]?.trim();
+    const model = modelOverride ?? process.env["MARTIN_OPENAI_MODEL"]?.trim();
+    return createOpenAiCompatibleAdapter({
+      ...(baseUrl ? { baseUrl } : {}),
+      ...(apiKey ? { apiKey } : {}),
+      ...(model ? { model } : {}),
+      workingDirectory
+    });
   }
 
   return createClaudeCliAdapter({ workingDirectory, ...(modelOverride ? { model: modelOverride } : {}) });
 }
 
 function buildDoctorRecommendations(input: {
-  liveMode: "live" | "stub";
+  liveMode: "live" | "proof";
   engine: "claude" | "codex" | "openai" | string;
   claudeAvailable: boolean;
   codexAvailable: boolean;
   workingDirectoryReady: boolean;
 }): string[] {
-  const recommendations = ["Run `martin preflight` before non-trivial governed coding work."];
+  const recommendations = ["Run `martin-loop preflight` before non-trivial governed coding work."];
 
   if (!input.workingDirectoryReady) {
     recommendations.push("Point `--cwd` at a valid repository before running Martin.");
@@ -2825,11 +2832,12 @@ function buildDoctorRecommendations(input: {
 
   if (input.liveMode === "live" && input.engine === "openai") {
     const baseUrl = process.env["MARTIN_OPENAI_BASE_URL"];
-    const model = process.env["MARTIN_OPENAI_MODEL"];
-    if (!baseUrl) recommendations.push("Set MARTIN_OPENAI_BASE_URL (e.g. http://localhost:11434 for Ollama or https://openrouter.ai/api for OpenRouter).");
-    if (!model) recommendations.push("Set MARTIN_OPENAI_MODEL (e.g. llama3.3, deepseek/deepseek-chat, mistralai/codestral-latest).");
+    const apiKey = process.env["MARTIN_OPENAI_API_KEY"];
     if (baseUrl?.includes("openrouter") && !process.env["MARTIN_OPENAI_API_KEY"]) {
       recommendations.push("Set MARTIN_OPENAI_API_KEY for OpenRouter.");
+    }
+    if (!baseUrl && !apiKey) {
+      recommendations.push("Set MARTIN_OPENAI_API_KEY to use the default OpenAI endpoint, or set MARTIN_OPENAI_BASE_URL for a different provider.");
     }
   }
 
@@ -2838,7 +2846,7 @@ function buildDoctorRecommendations(input: {
   }
 
   if (input.liveMode === "live" && input.engine === "codex" && !input.codexAvailable) {
-    recommendations.push("Install or expose the Codex CLI on PATH, or set MARTIN_LIVE=false while iterating locally.");
+    recommendations.push("Install or expose the Codex CLI on PATH, or rerun with `--proof` for a no-spend verifier-backed pass.");
   }
 
   return recommendations;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1292,7 +1292,8 @@ async function executePreflightCommand(
   const resolvedGuardrails = await resolveGuardrails(request);
   const environment = resolveCliEnvironment({
     cwd: request.cwd,
-    engine: request.engine
+    engine: request.engine,
+    ...(request.proofMode ? { liveMode: "proof" as const } : {})
   });
   const warnings: string[] = [];
   const blockingIssues: string[] = [];
@@ -2211,7 +2212,7 @@ function buildStartHuman(input: {
     '  martin-loop run "Summarize the demo workspace and confirm the verifier is green" --proof --verify "npm test"',
     "",
     `Recommended MCP bootstrap: ${hostPlan.installCommand}`,
-    `Preview config: ${hostPlan.printConfigCommand.replace(/\bmartin\b/gu, "martin-loop")}`
+    `Preview config: ${hostPlan.printConfigCommand}`
   ];
 }
 

--- a/packages/cli/src/mcp-config.ts
+++ b/packages/cli/src/mcp-config.ts
@@ -154,7 +154,7 @@ export async function installMcpConfig(
       `Refusing to overwrite existing MCP config: ${plan.targetPath}`,
       {
         suggestion:
-          "Use `martin mcp print-config` and merge the Martin Loop block into the existing host config."
+          "Use `martin-loop mcp print-config` and merge the Martin Loop block into the existing host config."
       }
     );
   }
@@ -354,7 +354,7 @@ function buildGenericConfigSnippet(
     JSON.stringify(
       {
         version: 1,
-        generatedBy: "martin mcp print-config",
+        generatedBy: "martin-loop mcp print-config",
         host: "generic",
         transport: input.transport,
         profile: input.profile,

--- a/packages/cli/src/run-store.ts
+++ b/packages/cli/src/run-store.ts
@@ -112,7 +112,7 @@ export interface CliEnvironment {
   workingDirectory: string;
   runsRoot: string;
   engine: "claude" | "codex" | "openai";
-  liveMode: "live" | "stub";
+  liveMode: "live" | "proof";
 }
 
 export interface PersistedLoopDetail {
@@ -159,6 +159,7 @@ export function resolveCliEnvironment(input: {
   cwd?: string;
   runsDir?: string;
   engine?: string;
+  liveMode?: CliEnvironment["liveMode"];
   env?: NodeJS.ProcessEnv;
 } = {}): CliEnvironment {
   const env = input.env ?? process.env;
@@ -177,7 +178,7 @@ export function resolveCliEnvironment(input: {
     workingDirectory,
     runsRoot,
     engine,
-    liveMode: env.MARTIN_LIVE === "false" ? "stub" : "live"
+    liveMode: input.liveMode ?? (env.MARTIN_LIVE === "false" ? "proof" : "live")
   };
 }
 

--- a/packages/cli/src/workflow-state.ts
+++ b/packages/cli/src/workflow-state.ts
@@ -69,9 +69,9 @@ export async function consumeFirstRunBanner(runsRoot: string): Promise<string | 
 
   return [
     "MartinLoop quick start",
-    "  martin tour",
-    "  martin start",
-    "  martin doctor",
+    "  martin-loop tour",
+    "  martin-loop start",
+    "  martin-loop doctor",
     "",
     "MartinLoop will block real governed runs until doctor and preflight receipts exist for this repo."
   ].join("\n");
@@ -97,7 +97,7 @@ export async function evaluateCliRunGate(input: CliRunGateInput): Promise<CliRun
   if (input.mutationMode === "verify_only") {
     return {
       allowed: true,
-      nextCommand: "martin run --verify-only",
+      nextCommand: "martin-loop run --verify-only",
       message: "verify_only mode does not require a governed coding receipt chain.",
       missingSteps: []
     };
@@ -139,7 +139,7 @@ export async function evaluateCliRunGate(input: CliRunGateInput): Promise<CliRun
   if (missingSteps.length === 0) {
     return {
       allowed: true,
-      nextCommand: "martin run",
+      nextCommand: "martin-loop run",
       message: "Governed CLI workflow receipts are present for this task.",
       missingSteps
     };
@@ -160,15 +160,15 @@ function selectNextCommand(
   verificationPlan: string[]
 ): string {
   if (missingSteps.includes("doctor")) {
-    return "martin doctor";
+    return "martin-loop doctor";
   }
 
   if (missingSteps.includes("session-start")) {
-    return "martin session-start";
+    return "martin-loop session-start";
   }
 
   const verify = verificationPlan[0] ? ` --verify "${verificationPlan[0]}"` : "";
-  return `martin preflight "${objective}"${verify}`;
+  return `martin-loop preflight "${objective}"${verify}`;
 }
 
 function buildBlockedMessage(missingSteps: CliWorkflowStepName[], nextCommand: string): string {

--- a/packages/cli/tests/cli-integration.test.ts
+++ b/packages/cli/tests/cli-integration.test.ts
@@ -88,14 +88,41 @@ async function withFakeCodexCli<T>(fn: () => Promise<T>): Promise<T> {
 // MARTIN_LIVE guard
 // ---------------------------------------------------------------------------
 
-describe("MARTIN_LIVE=false — stub adapter", () => {
-  it("run command completes without spawning a real subprocess", async () => {
+describe("MARTIN_LIVE=false — no-spend proof mode", () => {
+  it("run command completes as a verifier-backed proof when --proof is passed", async () => {
+    const result = await executeCli([
+      "--json",
+      "run",
+      "--objective",
+      "Add a greeting function",
+      "--proof",
+      "--verify",
+      NOOP_VERIFIER,
+      "--max-iterations",
+      "1",
+      "--budget-usd",
+      "5",
+      "--unsafe-allow-unguarded-run"
+    ]);
+
+    expect(result.exitCode).toBe(0);
+    const payload = JSON.parse(result.stdout);
+    expect(payload.command).toBe("run");
+    expect(payload.loop.loopId).toMatch(/^loop_/u);
+    expect(payload.loop.status).toBe("completed");
+    expect(payload.loop.cost.actualUsd).toBe(0);
+    expect(payload.environment.liveMode).toBe("proof");
+  });
+
+  it("run command completes as a verifier-backed proof without spawning a live provider", async () => {
     const result = await withEnv("MARTIN_LIVE", "false", () =>
       executeCli([
         "--json",
         "run",
         "--objective",
         "Add a greeting function",
+        "--verify",
+        NOOP_VERIFIER,
         "--max-iterations",
         "1",
         "--budget-usd",
@@ -108,10 +135,12 @@ describe("MARTIN_LIVE=false — stub adapter", () => {
     const payload = JSON.parse(result.stdout);
     expect(payload.command).toBe("run");
     expect(payload.loop.loopId).toMatch(/^loop_/u);
-    expect(typeof payload.loop.attempts).toBe("object");
+    expect(payload.loop.status).toBe("completed");
+    expect(payload.loop.cost.actualUsd).toBe(0);
+    expect(payload.environment.liveMode).toBe("proof");
   });
 
-  it("returns a valid loop record structure in stub mode", async () => {
+  it("returns a valid loop record structure in proof mode", async () => {
     const result = await withEnv("MARTIN_LIVE", "false", () =>
       executeCli([
         "--json",
@@ -122,6 +151,8 @@ describe("MARTIN_LIVE=false — stub adapter", () => {
         "proj_stub",
         "--objective",
         "Write a hello world function",
+        "--verify",
+        NOOP_VERIFIER,
         "--max-iterations",
         "1",
         "--unsafe-allow-unguarded-run"
@@ -132,6 +163,7 @@ describe("MARTIN_LIVE=false — stub adapter", () => {
     expect(payload.loop.workspaceId).toBe("ws_stub");
     expect(payload.loop.projectId).toBe("proj_stub");
     expect(payload.loop.budget.maxIterations).toBe(1);
+    expect(payload.environment.liveMode).toBe("proof");
   });
 });
 
@@ -141,7 +173,7 @@ describe("MARTIN_LIVE=false — stub adapter", () => {
 
 describe("--engine flag", () => {
   it("defaults to claude when no --engine flag is given", async () => {
-    // Use stub mode — we verify no engine flag selects the claude adapter path,
+    // Use proof mode — we verify no engine flag selects the claude adapter path,
     // not that claude itself runs successfully
     const result = await withEnv("MARTIN_LIVE", "false", () =>
       executeCli([
@@ -149,6 +181,8 @@ describe("--engine flag", () => {
         "run",
         "--objective",
         "Fix the bug",
+        "--verify",
+        NOOP_VERIFIER,
         "--max-iterations",
         "1",
         "--budget-usd",
@@ -237,6 +271,8 @@ describe("--cwd flag", () => {
           "run",
           "--objective",
           "Fix the bug",
+          "--verify",
+          NOOP_VERIFIER,
           "--cwd",
           dir,
           "--max-iterations",
@@ -307,7 +343,6 @@ describe("bench command", () => {
     const result = await executeCli(["bench", "--suite", "ralphy-smoke"]);
 
     expect(result.exitCode).toBe(1);
-    expect(result.stdout).toBe("");
     expect(result.stderr).toContain("workspace-only RC surface");
     expect(result.stderr).toContain("pnpm --filter @martin/benchmarks");
   });
@@ -337,11 +372,12 @@ describe("help command", () => {
 
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toContain("martin start");
-    expect(result.stdout).toContain("martin guide");
+    expect(result.stdout).toContain("martin-loop start");
+    expect(result.stdout).toContain("martin-loop guide");
     expect(result.stdout).toContain("martin-loop run");
     expect(result.stdout).toContain("martin-loop demo");
     expect(result.stdout).toContain("martin-loop inspect");
     expect(result.stdout).toContain("martin-loop resume");
+    expect(result.stdout).toContain("--proof");
   });
 });

--- a/packages/cli/tests/cli-integration.test.ts
+++ b/packages/cli/tests/cli-integration.test.ts
@@ -89,6 +89,23 @@ async function withFakeCodexCli<T>(fn: () => Promise<T>): Promise<T> {
 // ---------------------------------------------------------------------------
 
 describe("MARTIN_LIVE=false — no-spend proof mode", () => {
+  it("preflight resolves proof mode when --proof is passed", async () => {
+    const result = await executeCli([
+      "--json",
+      "preflight",
+      "--objective",
+      "Add a greeting function",
+      "--proof",
+      "--verify",
+      NOOP_VERIFIER
+    ]);
+
+    expect(result.exitCode).toBe(0);
+    const payload = JSON.parse(result.stdout);
+    expect(payload.command).toBe("preflight");
+    expect(payload.environment.liveMode).toBe("proof");
+  });
+
   it("run command completes as a verifier-backed proof when --proof is passed", async () => {
     const result = await executeCli([
       "--json",

--- a/packages/cli/tests/cli.test.ts
+++ b/packages/cli/tests/cli.test.ts
@@ -7,6 +7,8 @@ import { describe, expect, it } from "vitest";
 import { createLoopRecord } from "../../contracts/src/index.js";
 import { executeCli, parseCliArguments } from "../src/index.js";
 
+const FAST_VERIFIER = process.platform === "win32" ? "cmd /c exit 0" : "true";
+
 describe("parseCliArguments", () => {
   it("parses a run command into a typed request", () => {
     const parsed = parseCliArguments([
@@ -77,6 +79,25 @@ describe("parseCliArguments", () => {
       host: "codex"
     });
   });
+
+  it("parses --proof as a first-class run option", () => {
+    expect(parseCliArguments([
+      "run",
+      "--objective",
+      "Check the verifier path",
+      "--proof",
+      "--verify",
+      "npm test"
+    ])).toEqual({
+      command: "run",
+      request: expect.objectContaining({
+        objective: "Check the verifier path",
+        title: "Check the verifier path",
+        proofMode: true,
+        verificationPlan: ["npm test"]
+      })
+    });
+  });
 });
 
 describe.sequential("executeCli", () => {
@@ -87,7 +108,7 @@ describe.sequential("executeCli", () => {
     expect(result.exitCode).toBe(0);
     expect(payload.command).toBe("guide");
     expect(payload.topic).toBe("start");
-    expect(payload.recommendedSequence).toContain("martin session-start");
+    expect(payload.recommendedSequence).toContain("martin-loop session-start");
     expect(payload.commandMap.some((entry: { topic: string }) => entry.topic === "mcp")).toBe(true);
   });
 
@@ -97,8 +118,10 @@ describe.sequential("executeCli", () => {
 
     expect(result.exitCode).toBe(0);
     expect(payload.command).toBe("tour");
-    expect(payload.steps[0].command).toBe("martin start");
-    expect(payload.steps.some((step: { command: string }) => step.command.includes("martin preflight"))).toBe(true);
+    expect(payload.steps[0].command).toBe("martin-loop start");
+    expect(
+      payload.steps.some((step: { command: string }) => step.command.includes("martin-loop preflight"))
+    ).toBe(true);
   });
 
   it("resolves effectivePolicy from config and applies it to the run", async () => {
@@ -119,8 +142,8 @@ describe.sequential("executeCli", () => {
           "  destructiveActionPolicy: approval",
           "  telemetryDestination: control-plane",
           "  verifierRules:",
-          "    - pnpm test",
-          "    - pnpm lint"
+          `    - ${FAST_VERIFIER}`,
+          `    - ${FAST_VERIFIER}`
         ].join("\n"),
         "utf8"
       );
@@ -157,7 +180,7 @@ describe.sequential("executeCli", () => {
           maxIterations: 6,
           maxTokens: 45000
         },
-        verifierRules: ["pnpm test", "pnpm lint"],
+        verifierRules: [FAST_VERIFIER, FAST_VERIFIER],
         maxUsd: 12,
         softLimitUsd: 7,
         maxIterations: 6,
@@ -167,10 +190,10 @@ describe.sequential("executeCli", () => {
       expect(payload.loop.budget).toEqual({
         maxUsd: 12,
         softLimitUsd: 7,
-        maxIterations: 6,
-        maxTokens: 45000
-      });
-      expect(payload.loop.task.verificationPlan).toEqual(["pnpm test", "pnpm lint"]);
+          maxIterations: 6,
+          maxTokens: 45000
+        });
+      expect(payload.loop.task.verificationPlan).toEqual([FAST_VERIFIER, FAST_VERIFIER]);
     } finally {
       await rm(directory, { force: true, recursive: true });
     }
@@ -197,7 +220,7 @@ describe.sequential("executeCli", () => {
           "  destructiveActionPolicy: approval",
           "  telemetryDestination: local-only",
           "  verifierRules:",
-          "    - pnpm verify:shared-baseline"
+          `    - ${FAST_VERIFIER}`
         ].join("\n"),
         "utf8"
       );
@@ -241,14 +264,14 @@ describe.sequential("executeCli", () => {
           maxIterations: 5,
           maxTokens: 30000
         },
-        verifierRules: ["pnpm verify:shared-baseline"],
+        verifierRules: [FAST_VERIFIER],
         maxUsd: 8,
         softLimitUsd: 5,
         maxIterations: 5,
         maxTokens: 30000,
         telemetryDestination: "control-plane"
       });
-      expect(payload.loop.task.verificationPlan).toEqual(["pnpm verify:shared-baseline"]);
+      expect(payload.loop.task.verificationPlan).toEqual([FAST_VERIFIER]);
     } finally {
       process.chdir(previousCwd);
 
@@ -319,8 +342,8 @@ describe.sequential("executeCli", () => {
           "  destructiveActionPolicy: approval",
           "  telemetryDestination: control-plane",
           "  verifierRules:",
-          "    - pnpm test",
-          "    - pnpm lint"
+          `    - ${FAST_VERIFIER}`,
+          `    - ${FAST_VERIFIER}`
         ].join("\n"),
         "utf8"
       );
@@ -344,7 +367,7 @@ describe.sequential("executeCli", () => {
 
       expect(payload.effectivePolicy.configPath).toBe(configPath);
       expect(payload.effectivePolicy.policyProfile).toBe("strict");
-      expect(payload.loop.task.verificationPlan).toEqual(["pnpm test", "pnpm lint"]);
+      expect(payload.loop.task.verificationPlan).toEqual([FAST_VERIFIER, FAST_VERIFIER]);
     } finally {
       if (previousInitCwd === undefined) {
         delete process.env.INIT_CWD;
@@ -366,7 +389,6 @@ describe.sequential("executeCli", () => {
     const result = await executeCli(["bench", "--suite", "ralphy-smoke"]);
 
     expect(result.exitCode).toBe(1);
-    expect(result.stdout).toBe("");
     expect(result.stderr).toContain("workspace-only RC surface");
     expect(result.stderr).toContain("@martin/benchmarks");
   });
@@ -384,7 +406,8 @@ describe.sequential("executeCli", () => {
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain(targetDirectory);
       expect(result.stdout).toContain("npm install");
-      expect(result.stdout).toContain("MARTIN_LIVE=false");
+      expect(result.stdout).toContain("npx martin-loop run");
+      expect(result.stdout).toContain("--proof");
       expect(await readFile(join(targetDirectory, "README.md"), "utf8")).toContain("Demo Sandbox");
     } finally {
       process.chdir(previousCwd);

--- a/packages/cli/tests/operator-commands.test.ts
+++ b/packages/cli/tests/operator-commands.test.ts
@@ -125,7 +125,7 @@ describe.sequential("operator commands", () => {
     expect(result.exitCode).toBe(0);
     expect(payload.command).toBe("start");
     expect(payload.bestNextCommand).toBeTypeOf("string");
-    expect(payload.recommendedFlow).toContain("martin doctor");
+    expect(payload.recommendedFlow).toContain("martin-loop doctor");
     expect(payload.hostBootstrap.host).toBe("codex");
     expect(payload.hostBootstrap.printConfigCommand).toContain("--host codex");
   });
@@ -136,7 +136,7 @@ describe.sequential("operator commands", () => {
 
     expect(result.exitCode).toBe(0);
     expect(payload.command).toBe("tour");
-    expect(payload.steps[0].command).toBe("martin start");
+    expect(payload.steps[0].command).toBe("martin-loop start");
     expect(payload.steps.at(-1).command).toContain("@martinloop/mcp");
   });
 

--- a/packages/cli/tests/reliability-score.test.ts
+++ b/packages/cli/tests/reliability-score.test.ts
@@ -27,7 +27,7 @@ const perfectInput: MartinReliabilityScoreInput = {
     },
     mcpDoctorPassing: {
       present: true,
-      detail: "martin doctor passed for MCP host config"
+      detail: "martin-loop doctor passed for MCP host config"
     }
   }
 };
@@ -57,7 +57,7 @@ describe("Martin Reliability Score", () => {
         runReceiptsPresent: { present: true },
         rollbackEvidencePresent: {
           present: false,
-          detail: "Missing rollback proof at C:\\Users\\Torram\\private\\rollback.md"
+          detail: "Missing rollback proof at C:\\workspace\\private\\rollback.md"
         },
         mcpDoctorPassing: { present: false, detail: "doctor exited 1" }
       }

--- a/packages/cli/tests/run-store.test.ts
+++ b/packages/cli/tests/run-store.test.ts
@@ -8,4 +8,16 @@ describe("resolveCliEnvironment", () => {
 
     expect(environment.engine).toBe("openai");
   });
+
+  it("exposes MARTIN_LIVE=false as proof mode for public surfaces", () => {
+    const environment = resolveCliEnvironment({ env: { ...process.env, MARTIN_LIVE: "false" } });
+
+    expect(environment.liveMode).toBe("proof");
+  });
+
+  it("honors explicit proof mode without requiring environment mutation", () => {
+    const environment = resolveCliEnvironment({ liveMode: "proof" });
+
+    expect(environment.liveMode).toBe("proof");
+  });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1001,6 +1001,9 @@ export async function runMartin(input: RunMartinInput): Promise<RunMartinResult>
     // a git repo) and silently return [], which would falsely trigger no_code_change.
     const changedFileEvidenceAvailable =
       result.execution?.changedFiles !== undefined || changedFiles.length > 0;
+    const isVerifierOnlyAdapter = executingAdapter.adapterId === "direct:verifier:verify-only";
+    const patchTruthCountsEdits =
+      !isVerifyOnly && !isVerifierOnlyAdapter && changedFileEvidenceAvailable;
 
     if (isVerifyOnly && changedFiles.length > 0) {
       const patchDecision = evaluatePatchDecision({
@@ -1321,10 +1324,8 @@ export async function runMartin(input: RunMartinInput): Promise<RunMartinResult>
         previousVerifierScore,
         verifierScore: result.verification.passed ? 1 : 0,
         groundingViolationCount: groundingScanResult?.violations.length ?? 0,
-        changedFileCount:
-          !isVerifyOnly && changedFileEvidenceAvailable ? changedFiles.length : undefined,
-        diffNovelty:
-          !isVerifyOnly && changedFileEvidenceAvailable ? (changedFiles.length > 0 ? 1 : 0) : undefined,
+        changedFileCount: patchTruthCountsEdits ? changedFiles.length : undefined,
+        diffNovelty: patchTruthCountsEdits ? (changedFiles.length > 0 ? 1 : 0) : undefined,
         diffStats: result.execution?.diffStats,
         costUsd: getUsageUsd(result.usage),
         summary: result.summary

--- a/packages/core/tests/runtime.test.ts
+++ b/packages/core/tests/runtime.test.ts
@@ -471,6 +471,68 @@ describe("runMartin", () => {
     expect(result.loop.attempts[0]?.failureClass).toBeUndefined();
   });
 
+  it("allows proof adapters to complete without edits when verification passes", async () => {
+    const adapter: MartinAdapter = {
+      adapterId: "direct:verifier:verify-only",
+      kind: "direct-provider",
+      label: "Verifier-only proof adapter",
+      metadata: {
+        providerId: "openai",
+        model: "gpt-5-mini"
+      },
+      async execute() {
+        return {
+          status: "completed",
+          summary: "Verified the workspace without code changes.",
+          usage: {
+            actualUsd: 0,
+            tokensIn: 0,
+            tokensOut: 0
+          },
+          verification: {
+            passed: true,
+            summary: "Verification passed without changes."
+          },
+          execution: {
+            changedFiles: []
+          }
+        };
+      }
+    };
+
+    const result = await runMartin({
+      workspaceId: "ws_ops",
+      projectId: "proj_runtime",
+      task: {
+        title: "Prove the verifier path",
+        objective: "Run the proof adapter without making edits.",
+        verificationPlan: ["pnpm --filter @martin/contracts test"],
+        allowedPaths: ["packages/contracts/**"]
+      },
+      budget: {
+        maxUsd: 10,
+        softLimitUsd: 6,
+        maxIterations: 1,
+        maxTokens: 2_000
+      },
+      adapter,
+      now: createTimestampSource([
+        "2026-05-11T12:10:00.000Z",
+        "2026-05-11T12:10:01.000Z",
+        "2026-05-11T12:10:02.000Z",
+        "2026-05-11T12:10:03.000Z",
+        "2026-05-11T12:10:04.000Z"
+      ]),
+      idFactory: createIdFactory()
+    });
+
+    expect(result.decision.lifecycleState).toBe("completed");
+    expect(result.loop.lifecycleState).toBe("completed");
+    expect(result.loop.status).toBe("completed");
+    expect(result.loop.attempts).toHaveLength(1);
+    expect(result.loop.attempts[0]?.failureClass).toBeUndefined();
+  });
+
   it("exits on budget pressure after repeated failed attempts", async () => {
     const timestamps = createTimestampSource([
       "2026-03-27T16:10:00.000Z",

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -4,7 +4,7 @@ Governed MCP server for AI coding agents with budgets, receipts, and review-read
 
 `@martinloop/mcp` is the standalone MartinLoop server for MCP hosts. It stays local-first and stdio-first, and it gives hosts one clear execution path: check readiness, plan the work, preflight the contract, run it, and inspect the result with enough evidence to decide what happens next.
 
-The root `martin-loop` package and the standalone `@martinloop/mcp` package move on separate version lines. For the current root release, see [MartinLoop 0.2.8 release notes](../../docs/release/OSS-0.2.8-RELEASE-NOTES.md).
+The root `martin-loop` package and the standalone `@martinloop/mcp` package move on separate version lines. For the current root release, see [MartinLoop 0.2.9 release notes](../../docs/release/OSS-0.2.9-RELEASE-NOTES.md).
 
 ## What is new in 0.2.7
 
@@ -152,7 +152,8 @@ Registry/server identifier: `io.github.Keesan12/martin-loop`
 - `martin_plan`, `martin_doctor`, `martin_preflight`, `martin_status`, `martin_logs`, `martin_dossier`, `martin_eval`, and the `martin_get_*` family are planning or inspection surfaces.
 - `martin_pause`, `martin_cancel`, `martin_continue`, and `martin_create_pr` are explicit follow-on control helpers and stay out of the default `minimal` profile.
 - Live runs require `claude` or `codex` on `PATH`.
-- Stub or smoke flows use `MARTIN_LIVE=false`.
+- CLI proof flows use `martin-loop run ... --proof`.
+- Host-managed smoke flows can still set `MARTIN_LIVE=false`.
 - Paths stay bounded to the configured workspace root and runs root.
 
 ## Debugging

--- a/packages/mcp/src/resources.ts
+++ b/packages/mcp/src/resources.ts
@@ -424,7 +424,7 @@ async function loadLatestRunForCompactResource(runsRoot: string): Promise<{
         empty: true,
         warnings: [
           "No Martin run records were found yet.",
-          "Run `npx martin-loop demo`, then run a governed task or set MARTIN_LIVE=false for a no-spend local proof run."
+          "Run `npx martin-loop demo`, then run `npx martin-loop run ... --proof --verify <command>` for a no-spend local proof pass."
         ]
       };
     }
@@ -669,7 +669,7 @@ function compactEmptyState(kind: string, runsRoot: string, warnings: string[]): 
     status: "empty",
     runsRoot,
     summary: "No Martin run records are available yet.",
-    nextStep: "Run `martin doctor`, create the demo workspace with `npx martin-loop demo`, then run a no-spend stub task with MARTIN_LIVE=false.",
+    nextStep: "Run `npx martin-loop doctor`, create the demo workspace with `npx martin-loop demo`, then run `npx martin-loop run ... --proof --verify <command>`.",
     warnings
   };
 }

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -400,7 +400,7 @@ const doctorOutputSchema = {
         workspaceRoot: { type: "string" },
         workingDirectory: { type: "string" },
         runsRoot: { type: "string" },
-        mode: { type: "string", enum: ["live", "stub"] },
+        mode: { type: "string", enum: ["live", "proof"] },
         liveMode: { type: "boolean" }
       },
       required: ["workspaceRoot", "workingDirectory", "runsRoot", "mode", "liveMode"]
@@ -436,7 +436,7 @@ const preflightOutputSchema = {
       type: "object",
       additionalProperties: false,
       properties: {
-        mode: { type: "string", enum: ["live", "stub"] },
+        mode: { type: "string", enum: ["live", "proof"] },
         liveMode: { type: "boolean" },
         engineReady: { type: "boolean" }
       },

--- a/packages/mcp/src/tools/doctor.ts
+++ b/packages/mcp/src/tools/doctor.ts
@@ -32,7 +32,7 @@ export interface MartinDoctorOutput {
     workspaceRoot: string;
     workingDirectory: string;
     runsRoot: string;
-    mode: "live" | "stub";
+    mode: "live" | "proof";
     liveMode: boolean;
   };
   engines: Record<MartinEngine, { available: boolean; detail: string; resolvedPath?: string }>;

--- a/packages/mcp/src/tools/preflight.ts
+++ b/packages/mcp/src/tools/preflight.ts
@@ -44,7 +44,7 @@ export interface MartinPreflightOutput {
   summary: string;
   warnings: string[];
   readiness: {
-    mode: "live" | "stub";
+    mode: "live" | "proof";
     liveMode: boolean;
     engineReady: boolean;
   };
@@ -111,7 +111,7 @@ export async function martinPreflightTool(
   };
 
   if (!executionMode.liveMode) {
-    warnings.push("Stub mode is active; preflight only proves configuration shape, not live CLI readiness.");
+    warnings.push("Proof mode is active; preflight only proves configuration shape, not live CLI readiness.");
   } else if (!engineAvailability.available) {
     warnings.push(`Requested engine '${engine}' is not available on PATH.`);
   }

--- a/packages/mcp/src/tools/run-loop.ts
+++ b/packages/mcp/src/tools/run-loop.ts
@@ -1,7 +1,7 @@
 import {
   createClaudeCliAdapter,
   createCodexCliAdapter,
-  createStubDirectProviderAdapter
+  createVerifierOnlyAdapter
 } from "@martin/adapters";
 
 import { createFileRunStore, evaluateCostGovernor, resolveRunsRoot, runMartin } from "@martin/core";
@@ -94,14 +94,17 @@ export async function runLoopTool(input: RunLoopInput): Promise<RunLoopOutput> {
   if (executionMode.liveMode && !engineAvailability.available) {
     throw new MartinToolError("engine_unavailable", `Engine '${engine}' is not available on PATH.`, {
       category: "environment",
-      suggestion: "Install the requested CLI or set MARTIN_LIVE=false for stub execution.",
+      suggestion: "Install the requested CLI or set MARTIN_LIVE=false for a no-spend proof run.",
       retryable: false
     });
   }
 
   const adapter =
     process.env.MARTIN_LIVE === "false"
-      ? createStubDirectProviderAdapter({ label: "Stub adapter (MARTIN_LIVE=false)", providerId: "stub", model: "stub" })
+      ? createVerifierOnlyAdapter({
+          workingDirectory,
+          label: "Proof mode adapter (MARTIN_LIVE=false)"
+        })
       : engine === "codex"
         ? createCodexCliAdapter({ workingDirectory, ...(model ? { model } : {}) })
         : createClaudeCliAdapter({ workingDirectory, ...(model ? { model } : {}) });

--- a/packages/mcp/src/tools/run-loop.ts
+++ b/packages/mcp/src/tools/run-loop.ts
@@ -108,6 +108,7 @@ export async function runLoopTool(input: RunLoopInput): Promise<RunLoopOutput> {
       : engine === "codex"
         ? createCodexCliAdapter({ workingDirectory, ...(model ? { model } : {}) })
         : createClaudeCliAdapter({ workingDirectory, ...(model ? { model } : {}) });
+  const mutationMode = process.env.MARTIN_LIVE === "false" ? "verify_only" : undefined;
 
   const partialBudget: Partial<LoopBudget> = {};
   if (input.maxUsd !== undefined) {
@@ -133,6 +134,7 @@ export async function runLoopTool(input: RunLoopInput): Promise<RunLoopOutput> {
       title: input.objective.slice(0, 100),
       objective: input.objective,
       verificationPlan: input.verificationPlan ?? [],
+      ...(mutationMode ? { mutationMode } : {}),
       repoRoot: workingDirectory,
       ...(allowedPaths ? { allowedPaths } : {}),
       ...(deniedPaths ? { deniedPaths } : {})

--- a/packages/mcp/src/tools/tool-errors.ts
+++ b/packages/mcp/src/tools/tool-errors.ts
@@ -141,7 +141,7 @@ export function toToolFailure(error: unknown): ToolFailure {
       code: "engine_unavailable",
       category: "environment",
       message,
-      suggestion: "Install the requested CLI or set MARTIN_LIVE=false for stub execution.",
+      suggestion: "Install the requested CLI or set MARTIN_LIVE=false for a no-spend proof run.",
       retryable: false
     };
   }

--- a/packages/mcp/src/tools/tool-support.ts
+++ b/packages/mcp/src/tools/tool-support.ts
@@ -129,7 +129,7 @@ export interface CliAvailability {
 
 export interface ExecutionMode {
   liveMode: boolean;
-  mode: "live" | "stub";
+  mode: "live" | "proof";
   detail: string;
 }
 
@@ -163,10 +163,10 @@ export function resolveExecutionMode(): ExecutionMode {
   const liveMode = process.env.MARTIN_LIVE !== "false";
   return {
     liveMode,
-    mode: liveMode ? "live" : "stub",
+    mode: liveMode ? "live" : "proof",
     detail: liveMode
       ? "Live CLI execution is enabled."
-      : "Stub mode is active because MARTIN_LIVE=false."
+      : "Proof mode is active because MARTIN_LIVE=false."
   };
 }
 

--- a/packages/mcp/tests/mcp-tools.test.ts
+++ b/packages/mcp/tests/mcp-tools.test.ts
@@ -358,7 +358,7 @@ describe("inspectLoopTool", () => {
 // ---------------------------------------------------------------------------
 
 describe("martinDoctorTool", () => {
-  it("reports run-store visibility in stub mode without requiring live CLIs", async () => {
+  it("reports run-store visibility in proof mode without requiring live CLIs", async () => {
     await withRunsRoot(async (runsRoot) => {
       const originalEnv = process.env.MARTIN_LIVE;
       process.env.MARTIN_LIVE = "false";
@@ -371,7 +371,7 @@ describe("martinDoctorTool", () => {
         const result = await martinDoctorTool({ runsDir: runsRoot, engine: "codex" });
 
         expect(result.status).toBe("ok");
-        expect(result.environment.mode).toBe("stub");
+        expect(result.environment.mode).toBe("proof");
         expect(result.runStore.exists).toBe(true);
         expect(result.runStore.loopCount).toBe(1);
         expect(result.runStore.latestRun?.loopId).toBe(loop.loopId);
@@ -457,7 +457,7 @@ describe("martinPreflightTool", () => {
       });
 
       expect(result.ok).toBe(true);
-      expect(result.readiness.mode).toBe("stub");
+      expect(result.readiness.mode).toBe("proof");
       expect(result.normalized.engine).toBe("codex");
       expect(result.normalized.budget.maxUsd).toBe(3);
       expect(result.normalized.budget.maxIterations).toBe(2);
@@ -993,8 +993,9 @@ describe("runLoopTool", () => {
 
         expect(result.loopId).toMatch(/^loop_/u);
         expect(typeof result.attempts).toBe("number");
-        expect(typeof result.costUsd).toBe("number");
-        expect(["completed", "exited", "failed"]).toContain(result.status);
+        expect(result.costUsd).toBe(0);
+        expect(result.status).toBe("completed");
+        expect(result.verificationPassed).toBe(true);
       } finally {
         if (originalEnv === undefined) {
           delete process.env.MARTIN_LIVE;

--- a/packages/mcp/tests/mcp-tools.test.ts
+++ b/packages/mcp/tests/mcp-tools.test.ts
@@ -996,6 +996,10 @@ describe("runLoopTool", () => {
         expect(result.costUsd).toBe(0);
         expect(result.status).toBe("completed");
         expect(result.verificationPassed).toBe(true);
+        const persisted = JSON.parse(
+          await readFile(result.inspection.loopRecordPath, "utf8")
+        );
+        expect(persisted.task.mutationMode).toBe("verify_only");
       } finally {
         if (originalEnv === undefined) {
           delete process.env.MARTIN_LIVE;

--- a/scripts/build-public-facade.mjs
+++ b/scripts/build-public-facade.mjs
@@ -44,6 +44,7 @@ export async function buildPublicFacade(options = {}) {
 
   for (const facade of PACKAGE_FACADES) {
     await copyFacadeDirectory({
+      packageName: facade.packageName,
       sourceDir: path.join(rootDir, ...facade.sourceDir),
       targetDir: path.join(rootDir, ...facade.targetDir),
       distDir,
@@ -65,6 +66,7 @@ export async function buildPublicFacade(options = {}) {
 
 async function copyFacadeDirectory(input) {
   await copyDirectory({
+    packageName: input.packageName,
     sourceDir: input.sourceDir,
     targetDir: input.targetDir,
     distDir: input.distDir,
@@ -73,7 +75,13 @@ async function copyFacadeDirectory(input) {
   });
 
   if (input.packageJsonSource) {
-    await copyFile(input.packageJsonSource, path.join(input.targetDir, "package.json"));
+    const rawManifest = JSON.parse(await readFile(input.packageJsonSource, "utf8"));
+    const sanitizedManifest = sanitizeVendoredPackageJson(rawManifest, input.packageName);
+    await writeFile(
+      path.join(input.targetDir, "package.json"),
+      `${JSON.stringify(sanitizedManifest, null, 2)}\n`,
+      "utf8",
+    );
   }
 }
 
@@ -88,11 +96,12 @@ async function copyDirectory(input) {
       : entry.name;
 
     if (entry.isDirectory()) {
-      if (shouldSkipDirectory(entry.name, relativePath)) {
+      if (shouldSkipDirectory(entry.name, relativePath, input.packageName)) {
         continue;
       }
 
       await copyDirectory({
+        packageName: input.packageName,
         sourceDir: path.join(input.sourceDir, entry.name),
         targetDir: path.join(input.targetDir, entry.name),
         distDir: input.distDir,
@@ -102,7 +111,7 @@ async function copyDirectory(input) {
       continue;
     }
 
-    if (shouldSkipFile(entry.name)) {
+    if (shouldSkipFile(entry.name, relativePath, input.packageName)) {
       continue;
     }
 
@@ -111,7 +120,7 @@ async function copyDirectory(input) {
 
     if (entry.name.endsWith(".js") || entry.name.endsWith(".d.ts")) {
       const contents = await readFile(sourcePath, "utf8");
-      const rewritten = rewritePackageJsonSpecifier(
+      let rewritten = rewritePackageJsonSpecifier(
         rewritePackageSpecifiers(contents, {
           targetPath,
           distDir: input.distDir,
@@ -121,6 +130,12 @@ async function copyDirectory(input) {
           packageJsonTarget: input.packageJsonTarget,
         },
       );
+      if (
+        input.packageName === "@martin/adapters" &&
+        (relativePath === "index.js" || relativePath === "index.d.ts")
+      ) {
+        rewritten = sanitizeVendoredAdaptersIndex(rewritten);
+      }
       await writeFile(targetPath, rewritten, "utf8");
       continue;
     }
@@ -129,12 +144,22 @@ async function copyDirectory(input) {
   }
 }
 
-function shouldSkipDirectory(name, relativePath) {
-  return name === "tests" || relativePath === "src";
+function shouldSkipDirectory(name, relativePath, packageName) {
+  return (
+    name === "tests" ||
+    relativePath === "src" ||
+    (packageName === "@martin/cli" && relativePath === "bin")
+  );
 }
 
-function shouldSkipFile(name) {
-  return name.endsWith(".map");
+function shouldSkipFile(name, relativePath, packageName) {
+  return (
+    name.endsWith(".map") ||
+    (
+      packageName === "@martin/adapters" &&
+      /^stub-(agent-cli|direct-provider)\.(?:js|d\.ts)$/u.test(relativePath)
+    )
+  );
 }
 
 function rewritePackageSpecifiers(contents, input) {
@@ -165,6 +190,38 @@ function rewritePackageJsonSpecifier(contents, input) {
   return contents.replace(/require\((['"])\.\.\/package\.json\1\)/gu, `require("${specifier}")`);
 }
 
+function sanitizeVendoredAdaptersIndex(contents) {
+  return contents
+    .replace(
+      /^export \{.*createStubDirectProviderAdapter.*\} from "\.\/stub-direct-provider\.js";\r?\n?/gmu,
+      "",
+    )
+    .replace(
+      /^export \{.*createStubAgentCliAdapter.*\} from "\.\/stub-agent-cli\.js";\r?\n?/gmu,
+      "",
+    );
+}
+
+function sanitizeVendoredPackageJson(manifest, packageName) {
+  const sanitized = {
+    name: manifest.name ?? packageName,
+    version: manifest.version ?? "0.0.0",
+    type: manifest.type ?? "module",
+    description: manifest.description ?? `${packageName} vendored for the martin-loop root package.`,
+    main: "./index.js",
+    types: "./index.d.ts",
+    exports: {
+      ".": {
+        types: "./index.d.ts",
+        default: "./index.js",
+      },
+      "./package.json": "./package.json",
+    },
+  };
+
+  return sanitized;
+}
+
 function toImportSpecifier(fromDir, toFile) {
   const relativePath = path.relative(fromDir, toFile).split(path.sep).join("/");
   return relativePath.startsWith(".") ? relativePath : `./${relativePath}`;
@@ -176,7 +233,7 @@ function createRootIndexSource() {
     "",
     'export { runMartin, compilePromptPacket, createFileRunStore, makeLedgerEvent, resolveRunsRoot } from "./vendor/core/index.js";',
     'export { executeCli, parseCliArguments, renderCliHelp } from "./vendor/cli/index.js";',
-    'export { createClaudeCliAdapter, createCodexCliAdapter, createDirectProviderAdapter, createStubDirectProviderAdapter, createStubAgentCliAdapter } from "./vendor/adapters/index.js";',
+    'export { createClaudeCliAdapter, createCodexCliAdapter, createDirectProviderAdapter, createOpenAiCompatibleAdapter, createVerifierOnlyAdapter } from "./vendor/adapters/index.js";',
     'export { appendLoopEvent, buildPortfolioSnapshot, createGovernanceSnapshot, createLoopRecord, createTelemetryEnvelope, DEFAULT_BUDGET, EMPTY_COST, validateTelemetryBatch, validateTelemetryEnvelope } from "./vendor/contracts/index.js";',
     "",
     "export class MartinLoop {",
@@ -213,8 +270,8 @@ function createRootTypesSource() {
     'export type { CompileResult, MartinAdapter, MartinAdapterRequest, MartinAdapterResult, PromptPacket, RunMartinInput, RunMartinResult, RunStore } from "./vendor/core/index.js";',
     'export { executeCli, parseCliArguments, renderCliHelp } from "./vendor/cli/index.js";',
     'export type { ParsedCliArguments, RunCommandRequest } from "./vendor/cli/index.js";',
-    'export { createClaudeCliAdapter, createCodexCliAdapter, createDirectProviderAdapter, createStubDirectProviderAdapter, createStubAgentCliAdapter } from "./vendor/adapters/index.js";',
-    'export type { AgentCliAdapterOptions, ClaudeCliAdapterOptions, CliArgsBuilder, CodexCliAdapterOptions, DirectProviderAdapterOptions, SpawnLike, StubAgentCliAdapterOptions, StubDirectProviderAdapterOptions, SubprocessResult, VerificationOutcome } from "./vendor/adapters/index.js";',
+    'export { createClaudeCliAdapter, createCodexCliAdapter, createDirectProviderAdapter, createOpenAiCompatibleAdapter, createVerifierOnlyAdapter } from "./vendor/adapters/index.js";',
+    'export type { AgentCliAdapterOptions, ClaudeCliAdapterOptions, CliArgsBuilder, CodexCliAdapterOptions, DirectProviderAdapterOptions, OpenAiCompatibleAdapterOptions, SpawnLike, SubprocessResult, VerificationOutcome, VerifierOnlyAdapterOptions } from "./vendor/adapters/index.js";',
     'export { appendLoopEvent, buildPortfolioSnapshot, createGovernanceSnapshot, createLoopRecord, createTelemetryEnvelope, DEFAULT_BUDGET, EMPTY_COST, validateTelemetryBatch, validateTelemetryEnvelope } from "./vendor/contracts/index.js";',
     'export type { ApprovalPolicy, ExecutionProfile, LoopBudget, LoopRecord, LoopTask } from "./vendor/contracts/index.js";',
     "",

--- a/scripts/public-facade-smoke.mjs
+++ b/scripts/public-facade-smoke.mjs
@@ -73,10 +73,16 @@ export async function runPublicFacadeSmoke(options = {}) {
     await writeFile(
       path.join(appDir, "sdk-smoke.mjs"),
       [
-        'import { MartinLoop } from "martin-loop";',
+        'import * as martinLoop from "martin-loop";',
         "",
-        'if (typeof MartinLoop !== "function") {',
+        'if (typeof martinLoop.MartinLoop !== "function") {',
         '  throw new Error("MartinLoop export missing");',
+        "}",
+        'if (typeof martinLoop.createVerifierOnlyAdapter !== "function") {',
+        '  throw new Error("createVerifierOnlyAdapter export missing");',
+        "}",
+        'if ("createStubDirectProviderAdapter" in martinLoop || "createStubAgentCliAdapter" in martinLoop) {',
+        '  throw new Error("Stub adapter exports leaked into the public root package.");',
         "}",
         "",
         'console.log("MartinLoop");',

--- a/scripts/rc-validation.mjs
+++ b/scripts/rc-validation.mjs
@@ -42,6 +42,7 @@ export function createRcValidationEnvironment(baseEnv, cleanHomeRoot) {
 
   return {
     ...baseEnv,
+    CI: "true",
     HOME: cleanHomeRoot,
     USERPROFILE: cleanHomeRoot,
     APPDATA: roamingRoot,

--- a/scripts/root-release-guard.mjs
+++ b/scripts/root-release-guard.mjs
@@ -27,6 +27,10 @@ const ALLOWED_PACKED_PREFIXES = [
   "dist/",
   "package.json",
 ];
+const FORBIDDEN_PACKED_PATH_PATTERNS = [
+  /^dist\/vendor\/cli\/bin\//u,
+  /^dist\/vendor\/adapters\/stub-(agent-cli|direct-provider)\.(?:js|d\.ts)$/u,
+];
 
 export async function runRootReleaseGuard(options = {}) {
   const rootDir = options.rootDir ?? process.cwd();
@@ -55,6 +59,7 @@ export async function runRootReleaseGuard(options = {}) {
   }
 
   await assertDistArtifactsPresent(rootDir);
+  await assertVendoredCliManifest(rootDir);
   const packedFiles = await inspectPackedFiles({ rootDir });
   assertPackedSurface(packedFiles);
 
@@ -63,6 +68,28 @@ export async function runRootReleaseGuard(options = {}) {
     packChecked: true,
     packedFiles,
   };
+}
+
+export async function assertVendoredCliManifest(rootDir) {
+  const manifestPath = path.join(rootDir, "dist", "vendor", "cli", "package.json");
+  const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+
+  if (manifest.main !== "./index.js") {
+    throw new Error(`Vendored CLI manifest must point main at ./index.js. Received ${String(manifest.main)}.`);
+  }
+
+  if (manifest.types !== "./index.d.ts") {
+    throw new Error(`Vendored CLI manifest must point types at ./index.d.ts. Received ${String(manifest.types)}.`);
+  }
+
+  if (manifest.bin !== undefined) {
+    throw new Error("Vendored CLI manifest must not publish its internal bin surface inside the root package facade.");
+  }
+
+  const manifestText = JSON.stringify(manifest);
+  if (/workspace:\*/u.test(manifestText)) {
+    throw new Error("Vendored CLI manifest must not leak workspace:* dependencies into the public root package.");
+  }
 }
 
 export function assertRootVersionPolicy(version) {
@@ -83,6 +110,10 @@ export function assertPackedSurface(packedFiles) {
   for (const packedFile of uniqueFiles) {
     if (!ALLOWED_PACKED_PREFIXES.some((prefix) => packedFile === prefix || packedFile.startsWith(prefix))) {
       throw new Error(`Packed tarball includes unexpected path ${packedFile}.`);
+    }
+
+    if (FORBIDDEN_PACKED_PATH_PATTERNS.some((pattern) => pattern.test(packedFile))) {
+      throw new Error(`Packed tarball includes forbidden vendored implementation path ${packedFile}.`);
     }
   }
 }

--- a/scripts/tests/rc-validation.test.mjs
+++ b/scripts/tests/rc-validation.test.mjs
@@ -31,6 +31,7 @@ test("createRcValidationEnvironment points HOME-style state at an isolated direc
   const cleanHomeRoot = path.join(os.tmpdir(), "martin-rc-validation-test");
   const env = createRcValidationEnvironment(
     {
+      CI: "",
       PATH: process.env.PATH ?? "",
       HOME: "C:\\Users\\ExampleUser",
       USERPROFILE: "C:\\Users\\ExampleUser",
@@ -40,6 +41,7 @@ test("createRcValidationEnvironment points HOME-style state at an isolated direc
 
   assert.equal(env.HOME, cleanHomeRoot);
   assert.equal(env.USERPROFILE, cleanHomeRoot);
+  assert.equal(env.CI, "true");
   assert.equal(env.MARTIN_RUNS_DIR, path.join(cleanHomeRoot, ".martin", "runs"));
   assert.notEqual(env.HOME, "C:\\Users\\ExampleUser");
 });

--- a/scripts/tests/readme-public-surface.test.mjs
+++ b/scripts/tests/readme-public-surface.test.mjs
@@ -49,6 +49,10 @@ async function readRepoFile(relativePath) {
   return readFile(path.join(ROOT_DIR, relativePath), "utf8");
 }
 
+async function readRootManifest() {
+  return JSON.parse(await readRepoFile("package.json"));
+}
+
 async function collectMarkdownFiles(relativePath) {
   const fullPath = path.join(ROOT_DIR, relativePath);
   const entries = await readdir(fullPath, { withFileTypes: true });
@@ -103,6 +107,7 @@ function extractLocalMarkdownLinks(contents) {
 
 test("root README is a public product entry point", async () => {
   const readme = await readRepoFile("README.md");
+  const manifest = await readRootManifest();
 
   const expectedOrder = [
     "## Why MartinLoop",
@@ -128,10 +133,11 @@ test("root README is a public product entry point", async () => {
 
   assert.match(readme, /The open-source control plane for AI coding agents/i);
   assert.match(readme, /npx martin-loop demo/);
-  assert.match(readme, /MARTIN_LIVE=false npx martin-loop run/);
+  assert.match(readme, /npx martin-loop run .* --proof --verify "npm test"/);
   assert.match(readme, /npx martin-loop dossier --latest/);
   assert.match(readme, /npx -y @martinloop\/mcp/);
   assert.match(readme, /import \{ MartinLoop, createClaudeCliAdapter \} from "martin-loop"/);
+  assert.match(readme, new RegExp(`docs/release/OSS-${manifest.version.replace(/\./g, "\\.")}-RELEASE-NOTES\\.md`));
   assert.doesNotMatch(readme, /What's New In/i);
 });
 

--- a/scripts/tests/root-release-guard.test.mjs
+++ b/scripts/tests/root-release-guard.test.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 import {
   assertPackedSurface,
   assertRootVersionPolicy,
+  assertVendoredCliManifest,
   runRootReleaseGuard,
 } from "../root-release-guard.mjs";
 
@@ -44,4 +45,24 @@ test("assertPackedSurface rejects unexpected non-OSS paths", () => {
       ]),
     /unexpected path/i,
   );
+});
+
+test("assertPackedSurface rejects forbidden vendored implementation paths", () => {
+  assert.throws(
+    () =>
+      assertPackedSurface([
+        "package.json",
+        "README.md",
+        "CODE_OF_CONDUCT.md",
+        "dist/index.js",
+        "dist/index.d.ts",
+        "dist/bin/martin-loop.js",
+        "dist/vendor/cli/bin/martin.js",
+      ]),
+    /forbidden vendored implementation path/i,
+  );
+});
+
+test("assertVendoredCliManifest accepts the sanitized vendored CLI package manifest", async () => {
+  await assertVendoredCliManifest(ROOT_DIR);
 });


### PR DESCRIPTION
## Summary
- fix the verifier-only lifecycle so successful proof runs are not discarded as `no_code_change`
- make the Windows Codex spawn path portable for `.cmd` / npm shim installs
- default `--engine openai` to the hosted OpenAI API without requiring a localhost override
- stop forcing `--dangerously-skip-permissions` on live Claude runs
- clean the public CLI/docs/release surface for `martin-loop@0.2.9`
- tighten the packed root facade so it no longer ships the extra vendored CLI bin or stub adapter files

## Verification
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm public:copy-scan`
- `pnpm public:git-surface`
- `pnpm oss:validate`
- `pnpm public:smoke`
- `pnpm release:validate-local`
- installed-tarball repro covering:
  - `--proof` governed success with zero spend
  - Claude adapter args without forced permission bypass
  - OpenAI defaulting to `https://api.openai.com`
  - Windows Codex spawn-plan execution against a real `codex` install

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--proof` for no-spend proof runs, and expanded `--engine` options to include `gemini`.
* **Bug Fixes**
  * Improved proof-mode completion checks.
  * Fixed Windows command resolution, default hosted OpenAI behavior, and live-run permission handling.
* **Documentation**
  * Standardized CLI guidance and updated quickstart, onboarding, and release notes to use `martin-loop`.
* **Chores**
  * Released version `0.2.9` and removed the exposed vendored CLI bin surface from the root package.
* **Tests**
  * Expanded coverage for proof mode, Windows shims, adapter defaults, and public package surface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->