### PR TITLE
test: make release guard runner-clean

### DIFF
--- a/scripts/tests/root-release-guard.test.mjs
+++ b/scripts/tests/root-release-guard.test.mjs
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -64,5 +65,38 @@ test("assertPackedSurface rejects forbidden vendored implementation paths", () =
 });
 
 test("assertVendoredCliManifest accepts the sanitized vendored CLI package manifest", async () => {
-  await assertVendoredCliManifest(ROOT_DIR);
+  await withTempRoot(async (tempRoot) => {
+    const manifestDir = path.join(tempRoot, "dist", "vendor", "cli");
+    await mkdir(manifestDir, { recursive: true });
+    await writeFile(
+      path.join(manifestDir, "package.json"),
+      `${JSON.stringify({
+        name: "@martin/cli",
+        version: "0.1.0",
+        type: "module",
+        description: "@martin/cli vendored for the martin-loop root package.",
+        main: "./index.js",
+        types: "./index.d.ts",
+        exports: {
+          ".": {
+            types: "./index.d.ts",
+            default: "./index.js",
+          },
+          "./package.json": "./package.json",
+        },
+      }, null, 2)}\n`,
+      "utf8",
+    );
+
+    await assertVendoredCliManifest(tempRoot);
+  });
 });
+
+async function withTempRoot(run) {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "martin-root-release-guard-"));
+  try {
+    await run(tempRoot);
+  } finally {
+    await rm(tempRoot, { force: true, recursive: true });
+  }
+}


### PR DESCRIPTION
## Summary
- decouple the vendored CLI manifest test from leftover local dist artifacts
- generate the manifest fixture in a temp root so the release guard is verified in a clean-runner shape
- prove the formerly failing release gate passes from a clean local state before we repoint the v0.2.9 tag

## Verification
- 
ode --test scripts/tests/root-release-guard.test.mjs
- removed local root dist/ and reran 
ode --test scripts/tests/root-release-guard.test.mjs
- pnpm lint && pnpm public:copy-scan && pnpm public:git-surface && pnpm test && pnpm build && pnpm oss:validate && pnpm public:smoke && pnpm release:validate-local && pnpm release:validate-local:install


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure with improved temporary directory handling for better test isolation and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->