### PR TITLE
fix: harden public mcp trust boundaries

### DIFF
--- a/docs/release/OSS-0.2.6-RELEASE-NOTES.md
+++ b/docs/release/OSS-0.2.6-RELEASE-NOTES.md
@@ -1,0 +1,21 @@
+# martin-loop 0.2.6
+
+MartinLoop `0.2.6` tightened the public root package around runtime safety and clearer developer-facing package guidance.
+
+## What changed
+
+- stronger verifier-command blocking for destructive command patterns
+- broader context-integrity scanning across task metadata and verifier output
+- safer secret redaction and path validation
+- model-aware budget pricing
+- grounding cache invalidation improvements
+- updated README, quickstart, and package metadata for the public root package
+
+## Package versions at this release point
+
+| Package | Public version |
+| --- | --- |
+| `martin-loop` | `0.2.6` |
+| `@martinloop/mcp` | `0.2.5` |
+
+`martin-loop` is the public CLI and SDK package. `@martinloop/mcp` stays on its own standalone version line.

--- a/docs/release/OSS-0.2.7-RELEASE-NOTES.md
+++ b/docs/release/OSS-0.2.7-RELEASE-NOTES.md
@@ -1,0 +1,20 @@
+# martin-loop 0.2.7
+
+MartinLoop `0.2.7` refreshed the public root package surface and tightened release hygiene for the CLI and SDK package.
+
+## What changed
+
+- the published package README, npm metadata, and GitHub-facing release docs now describe the same MartinLoop product surface
+- release validation now blocks internal-process language and stray non-doc artifacts before a public release can publish
+- the public docs tree no longer includes leftover release archives or other non-doc artifacts
+
+## Why it mattered
+
+`0.2.7` was a release-surface cleanup patch rather than a new runtime feature drop. It made the package easier to evaluate and trust because the repo, npm page, and release workflow stayed aligned on one public-facing story.
+
+## Package versions at this release point
+
+| Package | Public version |
+| --- | --- |
+| `martin-loop` | `0.2.7` |
+| `@martinloop/mcp` | `0.2.5` |

--- a/docs/release/OSS-0.2.9-RELEASE-NOTES.md
+++ b/docs/release/OSS-0.2.9-RELEASE-NOTES.md
@@ -1,6 +1,6 @@
 # martin-loop 0.2.9
 
-MartinLoop `0.2.9` is an incident-response hotfix for the public root package. It repairs the proof path, tightens Windows portability, and removes a risky default from live Claude runs.
+MartinLoop `0.2.9` is an incident-response hotfix for the public root package. It repairs the no-spend proof path, tightens Windows portability, restores the normal Claude permission model, and cleans the shipped root tarball surface.
 
 ## What changed
 
@@ -8,7 +8,8 @@ MartinLoop `0.2.9` is an incident-response hotfix for the public root package. I
 - Windows command resolution now handles npm-style `.cmd` shims correctly for real CLIs such as `codex.cmd` and wrapped verifier commands.
 - `--engine openai` now defaults to the hosted OpenAI endpoint instead of assuming a localhost-compatible server.
 - Live Claude runs no longer force `--dangerously-skip-permissions`.
-- Public CLI help, onboarding, tour output, and MCP config guidance now consistently use `martin-loop`.
+- Public CLI help, onboarding, tour output, workflow receipts, and MCP config guidance now consistently use `martin-loop`.
+- The public root tarball no longer exposes the vendored internal CLI bin surface inside `dist/vendor/cli/package.json`.
 
 ## Start here
 
@@ -16,30 +17,36 @@ MartinLoop `0.2.9` is an incident-response hotfix for the public root package. I
 npx martin-loop start
 npx martin-loop tour
 npx martin-loop doctor
+npx martin-loop session-start
 npx martin-loop preflight "Summarize the demo workspace and confirm the verifier is green" --verify "npm test"
+npx martin-loop run "Summarize the demo workspace and confirm the verifier is green" --proof --verify "npm test"
+npx martin-loop dossier --latest
 ```
 
 ## Upgrade notes
 
-- The recommended no-spend flow is:
-
-```sh
-npx martin-loop run "Summarize the demo workspace and confirm the verifier is green" --proof --verify "npm test"
-```
-
+- The recommended no-spend path is the same local-first guarded flow the root README documents: `start` -> `tour` -> `doctor` -> `session-start` -> `preflight` -> `run`.
+- `--proof` is the public no-spend entrypoint. Host-managed smoke flows can still use environment-owned proof lanes when the launcher controls the process, but normal operator guidance should stay on `--proof`.
 - Live Claude users should expect the normal Claude permission model to apply again.
 - Windows users can keep using real CLI shims on PATH instead of rewriting commands to machine-specific executables.
-- `--unsafe-allow-unguarded-run` still exists for advanced local operators, but the normal public path remains `start` -> `doctor` -> `preflight` -> `run`.
+- `--unsafe-allow-unguarded-run` still exists for advanced local operators, but it remains an explicit bypass rather than the default path.
 
 ## Validation
 
-`0.2.9` is intended to pass the same public release gate as the normal root release line:
+`0.2.9` ships through the same public root release gate the GitHub Actions release workflow runs:
 
+- `pnpm install --frozen-lockfile`
 - `pnpm lint`
-- `pnpm test`
-- `pnpm build`
 - `pnpm public:copy-scan`
 - `pnpm public:git-surface`
+- `pnpm test`
+- `pnpm build`
 - `pnpm oss:validate`
 - `pnpm public:smoke`
-- `pnpm release:validate-local`
+- `pnpm --filter @martinloop/mcp lint`
+- `pnpm --filter @martinloop/mcp test`
+- `pnpm --filter @martinloop/mcp build`
+- `pnpm --filter @martinloop/mcp smoke:pack`
+- `pnpm --filter @martinloop/mcp smoke:published:pack`
+- `pnpm --filter @martinloop/mcp verify:release`
+- `node ./scripts/root-release-guard.mjs --tag v0.2.9 --pack`

--- a/packages/mcp/src/server-validation.ts
+++ b/packages/mcp/src/server-validation.ts
@@ -109,6 +109,20 @@ export function resolveSafeRepoRoot(
   return candidate;
 }
 
+export function resolveTrustedLoopRepoRoot(
+  repoRoot?: string,
+  workspaceRoot: string = process.env.MARTIN_MCP_WORKSPACE_ROOT ?? process.cwd()
+): string {
+  try {
+    return resolveSafeRepoRoot(repoRoot, workspaceRoot);
+  } catch {
+    throw invalidPathError(
+      "Run record points outside the trusted workspace.",
+      "Inspect or promote only loop records that were created under the current workspace root."
+    );
+  }
+}
+
 export function resolveSafeRunsJsonPath(
   file: string,
   runsRoot: string = resolveRunsRoot(process.env)

--- a/packages/mcp/src/tools/eval.ts
+++ b/packages/mcp/src/tools/eval.ts
@@ -1,4 +1,5 @@
 import { loadDetailedLoopRecord, readLedgerEvents } from "./run-store.js";
+import { resolveTrustedLoopRepoRoot } from "../server-validation.js";
 import { buildVerificationSummary } from "./tool-support.js";
 import { assessRunRisk, inspectRepoSignals } from "./workflow-governance.js";
 
@@ -36,8 +37,8 @@ export async function martinEvalTool(input: MartinEvalInput): Promise<MartinEval
   const detail = await loadDetailedLoopRecord(input);
   const ledgerEvents = await readLedgerEvents(detail);
   const verification = buildVerificationSummary(detail.loop, ledgerEvents);
-  const repoRoot = detail.loop.task?.repoRoot;
-  const signals = inspectRepoSignals(repoRoot ?? process.cwd());
+  const repoRoot = resolveTrustedLoopRepoRoot(detail.loop.task?.repoRoot);
+  const signals = inspectRepoSignals(repoRoot);
   const risk = assessRunRisk({
     objective: detail.loop.task?.objective ?? detail.loop.loopId,
     allowedPaths: detail.loop.task?.allowedPaths ?? [],

--- a/packages/mcp/src/tools/pr-tools.ts
+++ b/packages/mcp/src/tools/pr-tools.ts
@@ -3,6 +3,7 @@ import { spawnSync } from "node:child_process";
 import { loadDetailedLoopRecord } from "./run-store.js";
 import { martinRunDossierTool, type MartinRunDossierInput } from "./run-dossier.js";
 import { martinEvalTool } from "./eval.js";
+import { resolveTrustedLoopRepoRoot } from "../server-validation.js";
 import { detectCliAvailability } from "./tool-support.js";
 import { MartinToolError } from "./tool-errors.js";
 
@@ -60,7 +61,7 @@ export async function martinCreatePrTool(
 ): Promise<MartinCreatePrOutput> {
   const summary = await martinPrSummaryTool(input);
   const detail = await loadDetailedLoopRecord(input);
-  const repoRoot = detail.loop.task?.repoRoot ?? process.cwd();
+  const repoRoot = resolveTrustedLoopRepoRoot(detail.loop.task?.repoRoot);
   const branch = readGitValue(repoRoot, ["branch", "--show-current"]);
   const title = input.title?.trim() || summary.title;
 

--- a/packages/mcp/src/tools/run-dossier.ts
+++ b/packages/mcp/src/tools/run-dossier.ts
@@ -13,6 +13,7 @@ import {
   readAttemptArtifactFiles,
   readLedgerEvents
 } from "./run-store.js";
+import { resolveTrustedLoopRepoRoot } from "../server-validation.js";
 import { readRunControlState } from "./run-controls.js";
 import { martinEvalTool } from "./eval.js";
 import { assessRunRisk, inspectRepoSignals } from "./workflow-governance.js";
@@ -77,7 +78,7 @@ export async function martinRunDossierTool(
   const verification = buildVerificationSummary(detail.loop, ledgerEvents);
   const control = await readRunControlState(detail);
   const evaluation = await martinEvalTool(input);
-  const repoRoot = detail.loop.task?.repoRoot ?? process.cwd();
+  const repoRoot = resolveTrustedLoopRepoRoot(detail.loop.task?.repoRoot);
   const risk = assessRunRisk({
     objective: detail.loop.task?.objective ?? detail.loop.loopId,
     allowedPaths: detail.loop.task?.allowedPaths ?? [],

--- a/packages/mcp/tests/mcp-tools.test.ts
+++ b/packages/mcp/tests/mcp-tools.test.ts
@@ -8,10 +8,13 @@ import { describe, expect, it, vi } from "vitest";
 import { getStatusTool } from "../src/tools/get-status.js";
 import { inspectLoopTool } from "../src/tools/inspect-loop.js";
 import { martinDoctorTool } from "../src/tools/doctor.js";
+import { martinEvalTool } from "../src/tools/eval.js";
 import { martinGetVerificationResultsTool } from "../src/tools/get-verification-results.js";
 import { martinListRunsTool } from "../src/tools/list-runs.js";
 import { martinPreflightTool } from "../src/tools/preflight.js";
+import { martinCreatePrTool } from "../src/tools/pr-tools.js";
 import { runLoopTool } from "../src/tools/run-loop.js";
+import { martinRunDossierTool } from "../src/tools/run-dossier.js";
 import { martinTriageRunsTool } from "../src/tools/triage-runs.js";
 import { recordMcpWorkflowStep } from "../src/workflow-state.js";
 
@@ -60,6 +63,28 @@ async function withRunsRoot<T>(fn: (runsRoot: string) => Promise<T>): Promise<T>
 
     await rm(runsRoot, { recursive: true, force: true }).catch(() => {});
   }
+}
+
+async function withWorkspaceRoot<T>(fn: (workspaceRoot: string) => Promise<T>): Promise<T> {
+  const previousWorkspaceRoot = process.env.MARTIN_MCP_WORKSPACE_ROOT;
+  const workspaceRoot = await mkdtemp(join(tmpdir(), "martin-mcp-workspace-"));
+  process.env.MARTIN_MCP_WORKSPACE_ROOT = workspaceRoot;
+  try {
+    return await fn(workspaceRoot);
+  } finally {
+    if (previousWorkspaceRoot === undefined) {
+      delete process.env.MARTIN_MCP_WORKSPACE_ROOT;
+    } else {
+      process.env.MARTIN_MCP_WORKSPACE_ROOT = previousWorkspaceRoot;
+    }
+
+    await rm(workspaceRoot, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+async function writeLoopRecord(runsRoot: string, loop: ReturnType<typeof makeLoopRecord>): Promise<void> {
+  await mkdir(join(runsRoot, loop.loopId), { recursive: true });
+  await writeFile(join(runsRoot, loop.loopId, "loop-record.json"), JSON.stringify(loop), "utf8");
 }
 
 async function primeRunGate(
@@ -1114,6 +1139,61 @@ describe("runLoopTool", () => {
           process.env.MARTIN_LIVE = originalEnv;
         }
       }
+    });
+  });
+
+  it("uses a persisted repoRoot when it remains inside the trusted workspace", async () => {
+    await withWorkspaceRoot(async (workspaceRoot) => {
+      await withRunsRoot(async (runsRoot) => {
+        const loop = makeLoopRecord();
+        loop.task = {
+          ...loop.task,
+          repoRoot: workspaceRoot
+        };
+
+        await writeLoopRecord(runsRoot, loop);
+
+        await expect(martinEvalTool({ loopId: loop.loopId })).resolves.toMatchObject({
+          loopId: loop.loopId
+        });
+        await expect(martinRunDossierTool({ loopId: loop.loopId })).resolves.toMatchObject({
+          loop: { loopId: loop.loopId }
+        });
+        await expect(martinCreatePrTool({ loopId: loop.loopId, execute: false })).resolves.toMatchObject({
+          loopId: loop.loopId,
+          created: false,
+          execute: false
+        });
+      });
+    });
+  });
+
+  it("rejects eval, dossier, and PR preview when a persisted repoRoot escapes the trusted workspace", async () => {
+    await withWorkspaceRoot(async () => {
+      await withRunsRoot(async (runsRoot) => {
+        const outsideRepoRoot = await mkdtemp(join(tmpdir(), "martin-mcp-outside-repo-"));
+        try {
+          const loop = makeLoopRecord();
+          loop.task = {
+            ...loop.task,
+            repoRoot: outsideRepoRoot
+          };
+
+          await writeLoopRecord(runsRoot, loop);
+
+          await expect(martinEvalTool({ loopId: loop.loopId })).rejects.toThrow(
+            "Run record points outside the trusted workspace."
+          );
+          await expect(martinRunDossierTool({ loopId: loop.loopId })).rejects.toThrow(
+            "Run record points outside the trusted workspace."
+          );
+          await expect(martinCreatePrTool({ loopId: loop.loopId, execute: false })).rejects.toThrow(
+            "Run record points outside the trusted workspace."
+          );
+        } finally {
+          await rm(outsideRepoRoot, { recursive: true, force: true }).catch(() => {});
+        }
+      });
     });
   });
 });

--- a/scripts/tests/mcp-release-docs.test.mjs
+++ b/scripts/tests/mcp-release-docs.test.mjs
@@ -128,6 +128,12 @@ test("root release note exists for the current root package version", async () =
   await access(path.join(ROOT_DIR, "docs", "release", `OSS-${rootPackageJson.version}-RELEASE-NOTES.md`));
 });
 
+test("historical root release notes keep canonical OSS filenames for the 0.2.x line", async () => {
+  for (const version of ["0.2.6", "0.2.7", "0.2.8", rootPackageJson.version]) {
+    await access(path.join(ROOT_DIR, "docs", "release", `OSS-${version}-RELEASE-NOTES.md`));
+  }
+});
+
 test("MCP public docs exist in the cleaned docs tree", async () => {
   for (const relativePath of [
     "docs/getting-started/mcp.md",
@@ -242,8 +248,11 @@ test("root release note captures onboarding and governance changes", async () =>
   assert.match(releaseNotes, /martin-loop start/);
   assert.match(releaseNotes, /martin-loop tour/);
   assert.match(releaseNotes, /doctor/i);
+  assert.match(releaseNotes, /session-start/i);
   assert.match(releaseNotes, /preflight/i);
   assert.match(releaseNotes, /--unsafe-allow-unguarded-run/);
+  assert.match(releaseNotes, /vendored internal CLI bin surface/i);
+  assert.match(releaseNotes, /root-release-guard/i);
 });
 
 test("MCP release note matches the current package line and the governed flow", async () => {


### PR DESCRIPTION
## Summary
- harden public MCP review helpers so persisted loop metadata cannot steer eval, dossier, or PR preview into an untrusted repo root
- align the 0.2.9 root release note with the shipped fix list and the actual public release gate
- restore canonical OSS release-note filenames for the root 0.2.x history

## Verification
- pnpm lint
- pnpm test
- pnpm build
- pnpm public:copy-scan
- pnpm public:git-surface
- pnpm oss:validate
- pnpm public:smoke
- pnpm release:validate-local
- pnpm audit --prod --json


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Repaired no-spend proof path handling
  * Enhanced Windows CLI portability and npm shim compatibility
  * Restored standard Claude permission model
  * Improved repository path validation across tools

* **Documentation**
  * Updated release notes (versions 0.2.6-0.2.9) with expanded onboarding and upgrade workflow guidance
  * Clarified operational best practices and safety-first setup steps

<!-- end of auto-generated comment: release notes by coderabbit.ai -->