### PR TITLE
fix: ship 0.2.10 trust hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.2.10]
+
+### Fixed
+- **Verifier receipts now stay trustworthy** - `verification.completed` now reflects the MartinLoop-launched verifier only, with persisted step-by-step evidence for launch state, exit code, timeout state, and concise command output.
+- **Contradictions are surfaced instead of hidden** - when adapter output says a tool or verifier failed before execution but MartinLoop’s own verifier passed, the run now keeps the pass result and records a warning/contradiction receipt instead of presenting a silent clean pass.
+- **`--runs-dir` is consistent across the governed flow** - `doctor`, `start`, `preflight`, `run`, `dossier`, and `badge` now honor the same explicit runs root without relying on `MARTIN_RUNS_DIR`.
+- **Public help is honest again** - `run --help` and `preflight --help` exit cleanly before any governed-flow checks, root-version reporting now uses the published `martin-loop` version, and `bench` is not part of the public `0.2.10` CLI surface while the public harness is being prepared.
+
+### Changed
+- CLI and MCP verification views now include verifier warnings plus step-level evidence, so operators can inspect what actually launched instead of trusting a single summary line.
+- Badge generation now uses a lightweight persisted-run probe for readiness evidence, which keeps the default command responsive even when the local runs store is large.
+
 ## [0.2.9]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -35,14 +35,14 @@ npx martin-loop dossier --latest
 
 `start` and `tour` walk a new operator through the product flow. `doctor`, `session-start`, and `preflight` create the local receipts MartinLoop expects before a real governed run. If you intentionally need to bypass that local gate for a one-off run, use `--unsafe-allow-unguarded-run` explicitly.
 
-Release notes for the current root package: [MartinLoop 0.2.9](./docs/release/OSS-0.2.9-RELEASE-NOTES.md).
+Release notes for the current root package: [MartinLoop 0.2.10](./docs/release/OSS-0.2.10-RELEASE-NOTES.md).
 
 ## What It Does
 
 - Budget caps stop the next attempt before a configured USD, token, or iteration limit is exceeded.
 - Verifier gates require a real check, such as `npm test`, before a run can count as complete.
 - Policy checks block unsafe verifier commands, risky path changes, and secret-like task inputs before execution.
-- Run receipts capture stop reason, verifier evidence, budget posture, and next safe action.
+- Run receipts capture stop reason, verifier evidence, verifier-step warnings, budget posture, and next safe action.
 - Local onboarding commands (`start`, `tour`, `guide`, `session-start`) help operators adopt the governed flow without memorizing it.
 - MCP integration gives hosts one primary coding execution entrypoint plus richer planning, inspection, and review helpers.
 
@@ -73,6 +73,8 @@ martin-loop dossier (--latest | --loop-id <id> | --file <path>)
 martin-loop runs list|get|attempt|verify ...
 martin-loop mcp print-config --host <codex|claude|gemini|generic>
 martin-loop mcp install --host <codex|claude|gemini|generic>
+martin-loop challenge [--loop-id <id> | --file <path> | --latest]
+martin-loop badge [--format svg|json] [--runs-dir <path>]
 ```
 
 The local-first onboarding flow is:
@@ -112,7 +114,7 @@ npx martin-loop mcp print-config --host gemini --transport stdio --profile full-
 npx martin-loop mcp print-config --host generic --transport stdio --profile github-review
 ```
 
-The root `martin-loop` package and the standalone `@martinloop/mcp` package move on separate version lines. The root package is `0.2.9`; the current standalone MCP package is `0.2.7`.
+The root `martin-loop` package and the standalone `@martinloop/mcp` package move on separate version lines. The root package is `0.2.10`; the current standalone MCP package is `0.2.7`.
 
 More detail: [MCP setup](./docs/getting-started/mcp.md), [MCP tool reference](./docs/reference/mcp-tools.md), and [MCP compatibility](./docs/reference/mcp-compatibility.md).
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -18,6 +18,8 @@ martin-loop triage
 martin-loop dossier (--latest | --loop-id <id> | --file <path>)
 martin-loop inspect --file <path>
 martin-loop resume <loopId>
+martin-loop challenge [--loop-id <id> | --file <path> | --latest] [--format markdown|svg]
+martin-loop badge [--format svg|json] [--runs-dir <path>]
 martin-loop runs list|get|attempt|verify ...
 martin-loop mcp print-config --host <codex|claude|gemini|generic>
 martin-loop mcp install --host <codex|claude|gemini|generic>
@@ -45,6 +47,7 @@ npx martin-loop run "Summarize the workspace and prove tests still pass" --proof
 --soft-limit-usd <n>    Soft budget threshold in USD
 --verify <cmd>          Verifier command after each attempt
 --proof                 Use the no-spend proof adapter instead of a live coding CLI
+--verify-only           Skip the coding adapter and run the verifier only
 --unsafe-allow-unguarded-run
                         Bypass the local governance gate for this one run
 --max-iterations <n>    Maximum number of attempts
@@ -59,6 +62,12 @@ npx martin-loop run "Summarize the workspace and prove tests still pass" --proof
 --workspace <id>        Workspace ID for the run record
 --project <id>          Project ID for the run record
 --metadata <key=value>  Attach metadata to the run record; repeatable
+```
+
+## Shared persisted-run options
+
+```text
+--runs-dir <path>       Override the Martin runs root for guided flow receipts, persisted evidence views, and badge generation
 ```
 
 ## Evidence Commands
@@ -80,6 +89,8 @@ Compatibility views remain available:
 ```sh
 npx martin-loop inspect --file ~/.martin/runs/<workspaceId>.jsonl
 npx martin-loop resume <loopId>
+npx martin-loop challenge --latest
+npx martin-loop badge --format json --runs-dir ~/.martin/runs
 ```
 
 ## Phase Commands

--- a/docs/release/OSS-0.2.10-RELEASE-NOTES.md
+++ b/docs/release/OSS-0.2.10-RELEASE-NOTES.md
@@ -1,0 +1,49 @@
+# martin-loop 0.2.10
+
+MartinLoop `0.2.10` is the public trust hotfix for the root package. It closes the two audit findings that made receipts and operator guidance look dishonest: verifier receipt integrity and `--runs-dir` drift across the guarded flow.
+
+## What changed
+
+- `verification.completed` now reflects the MartinLoop-launched verifier only.
+- Verification evidence now persists per-step launch state, exit code, timeout state, and concise command detail.
+- If adapter output says a tool or verifier failed before execution but MartinLoop’s own verifier passed, MartinLoop now records that contradiction as a warning instead of presenting a silent clean pass.
+- `doctor`, `start`, `preflight`, `run`, `dossier`, and `badge` now honor the same explicit `--runs-dir` target.
+- `run --help` and `preflight --help` now exit cleanly before governed-flow checks.
+- Public help/version output now reports the published root `martin-loop` version, and `bench` is not part of the public `0.2.10` CLI surface while the portable harness is being prepared.
+- `--unsafe-allow-unguarded-run` remains available as an explicit local override when an operator intentionally needs to bypass the guarded flow for one run.
+- The public root tarball still excludes the vendored internal CLI bin surface, and the same `root-release-guard` remains in the release gate.
+
+## Operator impact
+
+- Use `runs verify`, `dossier`, or the MCP verification views when you need the full verifier story. They now show warnings plus step-level evidence instead of a single pass/fail sentence.
+- Use `--runs-dir <path>` when you want one explicit Martin store across the guided flow, persisted evidence views, and badge generation.
+- The public no-spend path is still `npx martin-loop run ... --proof`.
+
+## Start here
+
+```sh
+npx martin-loop start
+npx martin-loop tour
+npx martin-loop doctor --runs-dir ~/.martin/runs
+npx martin-loop session-start
+npx martin-loop preflight "Summarize the demo workspace and confirm the verifier is green" --verify "npm test" --runs-dir ~/.martin/runs
+npx martin-loop run "Summarize the demo workspace and confirm the verifier is green" --proof --verify "npm test" --runs-dir ~/.martin/runs
+npx martin-loop runs verify --latest --runs-dir ~/.martin/runs
+npx martin-loop dossier --latest --runs-dir ~/.martin/runs
+```
+
+## Validation
+
+`0.2.10` is intended to ship through the same public root release gate the GitHub Actions release workflow runs:
+
+- `pnpm lint`
+- `pnpm test`
+- `pnpm build`
+- `pnpm public:copy-scan`
+- `pnpm public:git-surface`
+- `pnpm oss:validate`
+- `pnpm public:smoke`
+- `pnpm release:validate-local`
+- `pnpm release:validate-local:install`
+- `pnpm release:validate:platforms`
+- `pnpm audit --prod --json`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "martin-loop",
   "private": false,
-  "version": "0.2.9",
+  "version": "0.2.10",
   "type": "module",
   "description": "Open-source command center for governed AI coding agents with built-in onboarding, hard gates, CLI, MCP, and run receipts.",
   "packageManager": "pnpm@10.33.0",

--- a/packages/adapters/src/claude-cli.ts
+++ b/packages/adapters/src/claude-cli.ts
@@ -399,7 +399,7 @@ export function createAgentCliAdapter(options: AgentCliAdapterOptions): MartinAd
           status: "completed",
           summary,
           usage,
-          verification: { passed: true, summary: verification.summary },
+          verification,
           ...(executionArtifacts
             ? {
                 execution: {
@@ -459,7 +459,7 @@ export function createAgentCliAdapter(options: AgentCliAdapterOptions): MartinAd
           ? `${summary}${errorBlock}${scopeViolations.length > 0 ? `\nScope violations: ${scopeViolations.join(", ")}` : ""}`
           : summary,
         usage,
-        verification: { passed: false, summary: verification.summary },
+        verification,
         ...(executionArtifacts
           ? {
               execution: {

--- a/packages/adapters/src/cli-bridge.ts
+++ b/packages/adapters/src/cli-bridge.ts
@@ -15,11 +15,23 @@ export interface SubprocessResult {
   stdout: string;
   stderr: string;
   timedOut: boolean;
+  launched: boolean;
+}
+
+export interface VerificationStepOutcome {
+  command: string;
+  launched: boolean;
+  exitCode?: number;
+  timedOut: boolean;
+  fastFail: boolean;
+  detail?: string;
 }
 
 export interface VerificationOutcome {
   passed: boolean;
   summary: string;
+  steps: VerificationStepOutcome[];
+  warnings?: string[];
 }
 
 export async function runSubprocess(
@@ -57,7 +69,8 @@ export async function runSubprocess(
         exitCode: 1,
         stdout: "",
         stderr: message,
-        timedOut: false
+        timedOut: false,
+        launched: false
       });
       return;
     }
@@ -90,7 +103,8 @@ export async function runSubprocess(
         exitCode: 1,
         stdout: "",
         stderr: error.message,
-        timedOut: false
+        timedOut: false,
+        launched: false
       });
     });
 
@@ -100,7 +114,8 @@ export async function runSubprocess(
         exitCode: code ?? 1,
         stdout: Buffer.concat(stdoutChunks).toString("utf8"),
         stderr: Buffer.concat(stderrChunks).toString("utf8"),
-        timedOut
+        timedOut,
+        launched: true
       });
     });
 
@@ -115,7 +130,8 @@ export async function runSubprocess(
             exitCode: 1,
             stdout: Buffer.concat(stdoutChunks).toString("utf8"),
             stderr: stdinError.message,
-            timedOut: false
+            timedOut: false,
+            launched: false
           });
         }
       }
@@ -138,10 +154,11 @@ export async function runVerification(
     : commands.map((command) => ({ command, fastFail: true }));
 
   if (steps.length === 0) {
-    return { passed: true, summary: "No verification commands specified." };
+    return { passed: true, summary: "No verification commands specified.", steps: [] };
   }
 
   const failedSteps: string[] = [];
+  const stepOutcomes: VerificationStepOutcome[] = [];
 
   for (const step of steps) {
     const parts = splitCommand(step.command);
@@ -152,26 +169,55 @@ export async function runVerification(
     }
 
     const result = await runSubprocess(bin, args, { cwd, timeoutMs, spawnImpl });
+    const detail = truncate(result.stderr.trim() || result.stdout.trim(), 500);
+    stepOutcomes.push({
+      command: step.command,
+      launched: result.launched,
+      ...(result.launched ? { exitCode: result.exitCode } : {}),
+      timedOut: result.timedOut,
+      fastFail: step.fastFail,
+      ...(detail ? { detail } : {})
+    });
+
+    if (!result.launched) {
+      const summary = `Verification could not launch: ${step.command}\n${detail || "Launch failed."}`;
+      if (step.fastFail) {
+        return { passed: false, summary, steps: stepOutcomes };
+      }
+      failedSteps.push(step.command);
+      continue;
+    }
 
     if (result.timedOut) {
-      return { passed: false, summary: `Verification timed out: ${step.command}` };
+      return {
+        passed: false,
+        summary: `Verification timed out: ${step.command}`,
+        steps: stepOutcomes
+      };
     }
 
     if (result.exitCode !== 0) {
-      const detail = truncate(result.stderr.trim() || result.stdout.trim(), 500);
       const summary = `Verification failed: ${step.command}\n${detail}`;
       if (step.fastFail) {
-        return { passed: false, summary };
+        return { passed: false, summary, steps: stepOutcomes };
       }
       failedSteps.push(step.command);
     }
   }
 
   if (failedSteps.length > 0) {
-    return { passed: false, summary: `Failed steps: ${failedSteps.join(", ")}` };
+    return {
+      passed: false,
+      summary: `Failed steps: ${failedSteps.join(", ")}`,
+      steps: stepOutcomes
+    };
   }
 
-  return { passed: true, summary: `All ${String(steps.length)} verification step(s) passed.` };
+  return {
+    passed: true,
+    summary: `All ${String(steps.length)} verification step(s) passed.`,
+    steps: stepOutcomes
+  };
 }
 
 export async function readGitExecutionArtifacts(

--- a/packages/adapters/tests/claude-cli.test.ts
+++ b/packages/adapters/tests/claude-cli.test.ts
@@ -19,7 +19,7 @@ import {
   readGitChangedFiles,
   type SpawnLike
 } from "../src/index.js";
-import { runSubprocess, splitCommand } from "../src/cli-bridge.js";
+import { runSubprocess, runVerification, splitCommand } from "../src/cli-bridge.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -534,6 +534,30 @@ describe("runSubprocess", () => {
   });
 });
 
+describe("runVerification", () => {
+  it("fails closed and records launched=false when a verifier step cannot start", async () => {
+    const spawnImpl: SpawnLike = () => {
+      const error = new Error("CreateProcessAsUserW failed: 5");
+      Object.assign(error, { code: "EPERM" });
+      throw error;
+    };
+
+    const result = await runVerification(["npm test"], process.cwd(), 1_000, undefined, spawnImpl);
+
+    expect(result.passed).toBe(false);
+    expect(result.summary).toContain("Verification could not launch: npm test");
+    expect(result.steps).toEqual([
+      expect.objectContaining({
+        command: "npm test",
+        launched: false,
+        timedOut: false,
+        fastFail: true,
+        detail: "CreateProcessAsUserW failed: 5"
+      })
+    ]);
+  });
+});
+
 describe("readGitChangedFiles", () => {
   it("parses NUL-delimited rename entries and keeps the destination path", async () => {
     const calls: SpawnCall[] = [];
@@ -855,6 +879,15 @@ describe("createCodexCliAdapter", () => {
 
     expect(result.status).toBe("completed");
     expect(result.verification.passed).toBe(true);
+    expect(result.verification.steps).toEqual([
+      expect.objectContaining({
+        command: process.platform === "win32" ? "cmd /c exit 0" : "true",
+        launched: true,
+        exitCode: 0,
+        timedOut: false,
+        fastFail: true
+      })
+    ]);
     expect(calls[0]?.command).toBe("codex");
     expect(calls[1]?.command).toBe(process.platform === "win32" ? "cmd" : "true");
   });

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -22,6 +22,8 @@ The CLI groups onboarding, readiness checks, governed execution, evidence review
 - `martin-loop runs list|get|attempt|verify`
 - `martin-loop mcp print-config`
 - `martin-loop mcp install`
+- `martin-loop challenge`
+- `martin-loop badge`
 
 ## Output Modes
 
@@ -57,6 +59,8 @@ Built-in onboarding:
 - `guide` explains what each command does and when to use it.
 
 Governed runs are hard-blocked by default until `doctor`, a local session step, and `preflight` receipts exist for the same repo and task. Use `--unsafe-allow-unguarded-run` only when you intentionally need to bypass that local gate.
+
+`run --help` and `preflight --help` stay ungated so operators can inspect the public surface without generating local receipts first.
 
 ## MCP Config
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -10,7 +10,7 @@ import {
   createOpenAiCompatibleAdapter,
   createVerifierOnlyAdapter
 } from "@martin/adapters";
-import { runMartin, type MartinAdapter } from "@martin/core";
+import { createFileRunStore, runMartin, type MartinAdapter } from "@martin/core";
 import {
   buildPortfolioSnapshot,
   createLoopRecord,
@@ -61,6 +61,7 @@ import {
   buildRunDossier,
   buildVerificationSummary,
   computeScopeFingerprint,
+  findPersistedLoopEvidence,
   listPersistedLoops,
   loadPersistedAttempt,
   loadPersistedLoop,
@@ -77,7 +78,8 @@ import {
 } from "./workflow-state.js";
 
 const require = createRequire(import.meta.url);
-const packageJson = require("../package.json") as { version: string };
+const rootPackageJson = require("../../../package.json") as { version: string };
+const CLI_VERSION = rootPackageJson.version;
 
 export type RunCommandRequest = {
   workspaceId: string;
@@ -89,6 +91,7 @@ export type RunCommandRequest = {
   budget: LoopBudget;
   configPath?: string;
   cwd?: string;
+  runsDir?: string;
   model?: string;
   engine?: string;
   mutationMode?: MutationMode;
@@ -167,11 +170,15 @@ type GuideCommand = {
   command: "guide";
   topic?: GuideTopic;
   host?: MartinMcpHost;
+  cwd?: string;
+  runsDir?: string;
 };
 
 type TourCommand = {
   command: "tour";
   host?: MartinMcpHost;
+  cwd?: string;
+  runsDir?: string;
 };
 
 type NativePhaseCommand = {
@@ -253,6 +260,7 @@ type ChallengeCommand = {
 type BadgeCommand = {
   command: "badge";
   format: "svg" | "json";
+  runsDir?: string;
 };
 
 export type ParsedCliArguments =
@@ -262,10 +270,6 @@ export type ParsedCliArguments =
   | {
       command: "run";
       request: RunCommandRequest;
-    }
-  | {
-      command: "bench";
-      suiteId: string;
     }
   | {
       command: "demo";
@@ -317,14 +321,6 @@ export async function executeCli(args: string[]): Promise<{
           exitCode: 0,
           stdout: renderCliHelp(),
           stderr: ""
-        };
-        break;
-      case "bench":
-        result = {
-          exitCode: 1,
-          stdout: "",
-          stderr:
-            "The benchmark harness remains a workspace-only RC surface and is not part of the publishable @martin/cli boundary yet. Use pnpm --filter @martin/benchmarks test or pnpm --filter @martin/benchmarks eval:phase12 from the repo root instead."
         };
         break;
       case "demo": {
@@ -419,18 +415,15 @@ export function parseCliArguments(args: string[]): ParsedCliArguments {
     return { command: "help" };
   }
 
+  if (hasFlag(rest, "--help") || hasFlag(rest, "-h")) {
+    return { command: "help" };
+  }
+
   if (command === "run" || command === "preflight") {
     const request = parseRunRequest(rest);
     return command === "run"
       ? { command: "run", request }
       : { command: "preflight", request };
-  }
-
-  if (command === "bench") {
-    return {
-      command: "bench",
-      suiteId: readOption(rest, "--suite") ?? "ralphy-smoke"
-    };
   }
 
   if (command === "demo") {
@@ -487,6 +480,8 @@ export function parseCliArguments(args: string[]): ParsedCliArguments {
     const topic = parseGuideTopic(rest);
     return {
       command: "guide",
+      ...(readOption(rest, "--cwd") ? { cwd: readOption(rest, "--cwd") } : {}),
+      ...(readOption(rest, "--runs-dir") ? { runsDir: readOption(rest, "--runs-dir") } : {}),
       ...(host ? { host } : {}),
       ...(topic ? { topic } : {})
     };
@@ -496,6 +491,8 @@ export function parseCliArguments(args: string[]): ParsedCliArguments {
     const host = parseOptionalMcpHost(rest);
     return {
       command: "tour",
+      ...(readOption(rest, "--cwd") ? { cwd: readOption(rest, "--cwd") } : {}),
+      ...(readOption(rest, "--runs-dir") ? { runsDir: readOption(rest, "--runs-dir") } : {}),
       ...(host ? { host } : {})
     };
   }
@@ -629,11 +626,14 @@ export function parseCliArguments(args: string[]): ParsedCliArguments {
   if (command === "badge") {
     return {
       command: "badge",
-      format: parseBadgeFormat(rest)
+      format: parseBadgeFormat(rest),
+      ...(readOption(rest, "--runs-dir") ? { runsDir: readOption(rest, "--runs-dir") } : {})
     };
   }
 
-  return { command: "help" };
+  throw new CliCommandError("invalid_input", `Unknown command '${command}'.`, {
+    suggestion: "Run 'martin-loop --help' to see the supported public CLI commands."
+  });
 }
 
 export function renderCliHelp(): string {
@@ -660,9 +660,8 @@ export function renderCliHelp(): string {
     "  martin-loop demo [--dir <path>] [--force]",
     "  martin-loop inspect --file <path>",
     "  martin-loop resume <loopId>",
-    "  martin-loop bench --suite <suiteId>",
     "  martin-loop challenge [--loop-id <id> | --file <path> | --latest] [--format markdown|svg]",
-    "  martin-loop badge [--format svg|json]",
+    "  martin-loop badge [--format svg|json] [--runs-dir <path>]",
     "",
     "Operator commands:",
     "  start        Guided onboarding for humans and MCP hosts; picks the safest next command.",
@@ -772,9 +771,11 @@ async function executeRunCommand(
   };
   const cliEnvironment = resolveCliEnvironment({
     cwd: resolvedRequest.cwd,
+    runsDir: resolvedRequest.runsDir,
     engine: resolvedRequest.engine,
     ...(resolvedRequest.proofMode ? { liveMode: "proof" as const } : {})
   });
+  const store = createFileRunStore({ runsRoot: cliEnvironment.runsRoot });
   const allowUngovernedRun = resolvedRequest.allowUngovernedRun === true;
   if (!allowUngovernedRun) {
     const gate = await evaluateCliRunGate({
@@ -824,7 +825,8 @@ async function executeRunCommand(
       },
       budget: resolvedRequest.budget,
       metadata: resolvedRequest.metadata,
-      adapter
+      adapter,
+      store
     });
   } catch (error) {
     const fallbackLoop = createLoopRecord({
@@ -1012,7 +1014,7 @@ async function executeDoctorCommand(
 
   const data = {
     command: "doctor",
-    cliVersion: packageJson.version,
+    cliVersion: CLI_VERSION,
     environment,
     config: {
       path: configPath,
@@ -1070,7 +1072,7 @@ async function executeStartCommand(
   command: StartCommand,
   outputMode: MartinOutputMode
 ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
-  const environment = resolveCliEnvironment({ cwd: command.cwd });
+  const environment = resolveCliEnvironment({ cwd: command.cwd, runsDir: command.runsDir });
   const codexAvailable = isCommandAvailable("codex");
   const claudeAvailable = isCommandAvailable("claude");
   const geminiAvailable = isCommandAvailable("gemini");
@@ -1103,7 +1105,7 @@ async function executeStartCommand(
   return renderCliSuccess(outputMode, {
     data: {
       command: "start",
-      cliVersion: packageJson.version,
+      cliVersion: CLI_VERSION,
       workingDirectory: environment.workingDirectory,
       runsRoot: environment.runsRoot,
       liveMode: environment.liveMode,
@@ -1142,7 +1144,7 @@ async function executeGuideCommand(
   command: GuideCommand,
   outputMode: MartinOutputMode
 ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
-  const environment = resolveCliEnvironment({});
+  const environment = resolveCliEnvironment({ cwd: command.cwd, runsDir: command.runsDir });
   const commandMap = buildGuideCommandMap(command.host);
   const selected = command.topic
     ? commandMap.find((entry) => entry.topic === command.topic)
@@ -1179,7 +1181,7 @@ async function executeTourCommand(
   command: TourCommand,
   outputMode: MartinOutputMode
 ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
-  const environment = resolveCliEnvironment({});
+  const environment = resolveCliEnvironment({ cwd: command.cwd, runsDir: command.runsDir });
   const hostBootstrap = buildHostBootstrapPlan({
     preferredHost: command.host,
     codexAvailable: true,
@@ -1292,6 +1294,7 @@ async function executePreflightCommand(
   const resolvedGuardrails = await resolveGuardrails(request);
   const environment = resolveCliEnvironment({
     cwd: request.cwd,
+    runsDir: request.runsDir,
     engine: request.engine,
     ...(request.proofMode ? { liveMode: "proof" as const } : {})
   });
@@ -1451,7 +1454,7 @@ async function executeDossierCommand(
       `Source: ${detail.source}`
     ],
     quiet: detail.loop.loopId,
-    warnings: detail.warnings
+    warnings: [...detail.warnings, ...verification.warnings]
   });
 }
 
@@ -1503,7 +1506,7 @@ async function executeRunsGetCommand(
       `Source: ${detail.source}`
     ],
     quiet: detail.loop.loopId,
-    warnings: detail.warnings
+    warnings: [...detail.warnings, ...verification.warnings]
   });
 }
 
@@ -1529,7 +1532,7 @@ async function executeRunsAttemptCommand(
       loaded.attempt.summary ?? "No attempt summary was recorded."
     ],
     quiet: `${loaded.detail.loop.loopId}:${loaded.attempt.index}`,
-    warnings: loaded.detail.warnings
+    warnings: [...loaded.detail.warnings, ...loaded.verification.warnings]
   });
 }
 
@@ -1789,6 +1792,10 @@ function parseRunRequest(rest: string[]): RunCommandRequest {
         request.cwd = next;
         index += 1;
         break;
+      case "--runs-dir":
+        request.runsDir = next;
+        index += 1;
+        break;
       case "--verify-only":
         request.mutationMode = "verify_only";
         break;
@@ -1836,6 +1843,7 @@ function parseRunRequest(rest: string[]): RunCommandRequest {
     budget: request.budget as LoopBudget,
     ...(request.configPath ? { configPath: request.configPath } : {}),
     ...(request.cwd ? { cwd: request.cwd } : {}),
+    ...(request.runsDir ? { runsDir: request.runsDir } : {}),
     ...(request.model ? { model: request.model } : {}),
     ...(request.engine ? { engine: request.engine } : {}),
     ...(request.mutationMode ? { mutationMode: request.mutationMode } : {}),
@@ -2149,7 +2157,7 @@ function renderDoctorHuman(input: {
   });
 
   return [
-    `Martin CLI doctor (${packageJson.version})`,
+    `Martin CLI doctor (${CLI_VERSION})`,
     `Working directory: ${input.environment.workingDirectory} (${input.workingDirectoryReady ? "ready" : "missing"})`,
     `Runs root: ${input.environment.runsRoot} (${input.runsRootReady ? "ready" : "not created yet"})`,
     `Live mode: ${input.environment.liveMode}`,
@@ -2186,7 +2194,7 @@ function buildStartHuman(input: {
   });
 
   return [
-    `Martin Loop start (${packageJson.version})`,
+    `Martin Loop start (${CLI_VERSION})`,
     input.workingDirectoryReady
       ? "Current working directory looks ready for local MartinLoop commands."
       : "No ready working directory detected yet. Use the demo path first or point Martin at a repo with --cwd.",
@@ -2481,6 +2489,7 @@ async function resolveFirstRunBanner(
   commandArgs: string[]
 ): Promise<string | undefined> {
   if (
+    parsed.command === "help" ||
     parsed.command === "tour" ||
     parsed.command === "mcp_print_config" ||
     parsed.command === "mcp_install"
@@ -2973,7 +2982,7 @@ async function executeBadgeCommand(
   command: BadgeCommand,
   outputMode: MartinOutputMode
 ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
-  const input = await buildLocalReliabilityScoreInput();
+  const input = await buildLocalReliabilityScoreInput(command.runsDir);
   const score = computeMartinReliabilityScore(input);
   const svg = renderMartinReliabilityBadgeSvg(score);
   const json = renderMartinReliabilityBadgeJson(score);
@@ -2997,13 +3006,12 @@ async function executeBadgeCommand(
   });
 }
 
-async function buildLocalReliabilityScoreInput(): Promise<MartinReliabilityScoreInput> {
-  const environment = resolveCliEnvironment();
-  const shouldInspectRunStore = process.env["MARTIN_RUNS_DIR"] !== undefined;
-  const loops = shouldInspectRunStore
-    ? await listPersistedLoops({ limit: 20 }).catch(() => ({ loops: [] as LoopRecord[] }))
-    : { loops: [] as LoopRecord[] };
-  const latestLoop = loops.loops[0];
+async function buildLocalReliabilityScoreInput(runsDir?: string): Promise<MartinReliabilityScoreInput> {
+  const environment = resolveCliEnvironment({ ...(runsDir ? { runsDir } : {}) });
+  const persistedEvidence = await findPersistedLoopEvidence(runsDir).catch(() => ({
+    loop: undefined as LoopRecord | undefined
+  }));
+  const latestLoop = persistedEvidence.loop;
   const configPath = join(environment.invocationRoot, "martin.config.yaml");
   const configExists = await stat(configPath).then((entry) => entry.isFile()).catch(() => false);
   const budgetConfigured =
@@ -3011,7 +3019,7 @@ async function buildLocalReliabilityScoreInput(): Promise<MartinReliabilityScore
     (latestLoop !== undefined && latestLoop.budget.maxUsd > 0 && latestLoop.budget.maxIterations > 0);
   const verifierConfigured =
     latestLoop?.task.verificationPlan.some((cmd) => cmd.trim().length > 0) ?? configExists;
-  const runReceiptsPresent = loops.loops.length > 0;
+  const runReceiptsPresent = latestLoop !== undefined;
   const rollbackEvidencePresent =
     latestLoop?.artifacts.some((artifact) => artifact.kind.toLowerCase().includes("rollback")) ?? false;
   const mcpDoctorPassing = isCommandAvailable("node");

--- a/packages/cli/src/persistence.ts
+++ b/packages/cli/src/persistence.ts
@@ -36,7 +36,7 @@ export function resolveRunsRoot(env: NodeJS.ProcessEnv = process.env): string {
  * Uses the Phase 3 flat path: ~/.martin/runs/<loopId>/
  *   - contract.json   (task + budget, immutable)
  *   - state.json      (status, cost, metrics summary)
- *   - ledger.jsonl    (all events, one JSON per line)
+ *   - events.jsonl    (loop events, one JSON per line; the core ledger stays authoritative)
  *   - attempts/       (per-attempt JSON files)
  */
 export async function persistLoopArtifacts(
@@ -65,7 +65,7 @@ export async function persistLoopArtifacts(
     writeJsonFile(join(loopRoot, "state.json"), state),
     writeJsonFile(join(loopRoot, "loop-record.json"), loop),
     writeJsonFile(join(loopRoot, "loop.json"), loop),
-    writeEvents(join(loopRoot, "ledger.jsonl"), loop.events),
+    writeEvents(join(loopRoot, "events.jsonl"), loop.events),
     ...loop.attempts.map((attempt) =>
       writeJsonFile(
         join(attemptsRoot, `${String(attempt.index).padStart(3, "0")}-${attempt.attemptId}.json`),

--- a/packages/cli/src/run-store.ts
+++ b/packages/cli/src/run-store.ts
@@ -39,6 +39,12 @@ interface CorpusRecord {
   failureClass?: string | null;
 }
 
+type RunsDirEntry = {
+  name: string | { toString(): string };
+  isFile(): boolean;
+  isDirectory(): boolean;
+};
+
 function resolveLocalCorpusPath(): string {
   if (process.env["MARTIN_LEARNING_CORPUS_PATH"]) {
     return process.env["MARTIN_LEARNING_CORPUS_PATH"];
@@ -130,7 +136,17 @@ export interface VerificationSummary {
   eventCount: number;
   latestAttemptIndex?: number;
   completedAt?: string;
+  steps: VerificationStepSummary[];
   warnings: string[];
+}
+
+export interface VerificationStepSummary {
+  command: string;
+  launched: boolean;
+  exitCode?: number;
+  timedOut: boolean;
+  fastFail: boolean;
+  detail?: string;
 }
 
 export interface ArtifactSummary {
@@ -356,28 +372,33 @@ export function buildVerificationSummary(loop: LoopRecord): VerificationSummary 
       status: "unavailable",
       summary: "No persisted verification evidence was found for this loop.",
       eventCount: 0,
+      steps: [],
       warnings: ["Verification evidence is unavailable for this persisted loop."]
     };
   }
 
+  const payload = isRecord(latestEvent.payload) ? latestEvent.payload : undefined;
   const passed = latestEvent.payload["passed"] === true;
   const latestAttemptIndex =
-    typeof latestEvent.payload["attemptIndex"] === "number"
-      ? (latestEvent.payload["attemptIndex"] as number)
+    typeof payload?.["attemptIndex"] === "number"
+      ? (payload["attemptIndex"] as number)
       : loop.attempts.at(-1)?.index;
+  const warnings = readVerificationWarnings(payload);
+  const steps = readVerificationSteps(payload);
 
   return {
     status: passed ? "passed" : "failed",
     summary:
-      typeof latestEvent.payload["summary"] === "string"
-        ? (latestEvent.payload["summary"] as string)
+      typeof payload?.["summary"] === "string"
+        ? (payload["summary"] as string)
         : passed
           ? "Verification passed."
           : "Verification failed.",
     eventCount: verificationEvents.length,
     ...(latestAttemptIndex !== undefined ? { latestAttemptIndex } : {}),
     completedAt: latestEvent.timestamp,
-    warnings: []
+    steps,
+    warnings
   };
 }
 
@@ -423,6 +444,7 @@ export function buildRunReceipt(loop: LoopRecord, verification = buildVerificati
       status: verification.status,
       summary: verification.summary,
       eventCount: verification.eventCount,
+      steps: verification.steps,
       warnings: verification.warnings
     },
     rollbackEvidence: {
@@ -468,6 +490,116 @@ export async function triagePersistedLoops(
     findings,
     warnings: listed.warnings
   };
+}
+
+export async function findPersistedLoopEvidence(
+  runsDir: string | undefined,
+  options: { invocationRoot?: string } = {}
+): Promise<{ runsRoot: string; loop?: LoopRecord; warnings: string[] }> {
+  const runsRoot = resolveRunsRootPath(runsDir, options.invocationRoot);
+  const entries = await readdir(runsRoot, { withFileTypes: true }).catch((error: unknown) => {
+    if (isMissing(error)) {
+      return [] as Awaited<ReturnType<typeof readdir>>;
+    }
+
+    throw new CliCommandError("store_unreadable", "Unable to read the Martin runs directory.", {
+      suggestion: "Check MARTIN_RUNS_DIR or pass --runs-dir with a readable path."
+    });
+  });
+
+  entries.sort((left, right) => String(left.name).localeCompare(String(right.name)));
+  const warnings: string[] = [];
+  const indexedLoop = await loadLatestLoopFromWorkspaceIndexes(runsRoot, entries, warnings);
+  if (indexedLoop) {
+    return {
+      runsRoot,
+      loop: indexedLoop,
+      warnings
+    };
+  }
+
+  let latestLoop: LoopRecord | undefined;
+  for (const entry of entries) {
+    try {
+      const entryName = String(entry.name);
+      if (entry.isDirectory()) {
+        const canonical = await findCanonicalLoopRecordPath(path.join(runsRoot, entryName));
+        if (!canonical) {
+          continue;
+        }
+
+        const loop = await readLoopRecordFile(canonical);
+        if (!latestLoop || loopTimestamp(loop) >= loopTimestamp(latestLoop)) {
+          latestLoop = loop;
+        }
+        continue;
+      }
+
+      if (!entry.isFile() || (!entryName.endsWith(".json") && !entryName.endsWith(".jsonl"))) {
+        continue;
+      }
+
+      const loop = (await readLoopsFromFile(path.join(runsRoot, entryName), runsRoot)).sort(
+        (left, right) => loopTimestamp(right) - loopTimestamp(left)
+      )[0];
+      if (loop && (!latestLoop || loopTimestamp(loop) >= loopTimestamp(latestLoop))) {
+        latestLoop = loop;
+      }
+    } catch (error) {
+      warnings.push(
+        `Skipped unreadable persisted loop entry '${String(entry.name)}': ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+
+  return {
+    runsRoot,
+    ...(latestLoop ? { loop: latestLoop } : {}),
+    warnings
+  };
+}
+
+async function loadLatestLoopFromWorkspaceIndexes(
+  runsRoot: string,
+  entries: ReadonlyArray<RunsDirEntry>,
+  warnings: string[]
+): Promise<LoopRecord | undefined> {
+  let latestSummary: { loopId: string; updatedAt: string } | undefined;
+
+  for (const entry of entries) {
+    const entryName = String(entry.name);
+    if (!entry.isFile() || !entryName.endsWith(".jsonl")) {
+      continue;
+    }
+
+    try {
+      const candidate = await readLatestWorkspaceIndexSummary(path.join(runsRoot, entryName));
+      if (!candidate) {
+        continue;
+      }
+
+      if (!latestSummary || Date.parse(candidate.updatedAt) >= Date.parse(latestSummary.updatedAt)) {
+        latestSummary = candidate;
+      }
+    } catch (error) {
+      warnings.push(
+        `Skipped unreadable workspace index '${entryName}': ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+
+  if (!latestSummary) {
+    return undefined;
+  }
+
+  try {
+    return (await loadLoopById(latestSummary.loopId, runsRoot)).loop;
+  } catch (error) {
+    warnings.push(
+      `Workspace index pointed at unreadable loop '${latestSummary.loopId}': ${error instanceof Error ? error.message : String(error)}`
+    );
+    return undefined;
+  }
 }
 
 function buildPreventionSummary(
@@ -683,6 +815,30 @@ async function readLoopRecordFile(file: string): Promise<LoopRecord> {
   return parsed;
 }
 
+async function readLatestWorkspaceIndexSummary(
+  file: string
+): Promise<{ loopId: string; updatedAt: string } | undefined> {
+  const contents = await readFile(file, "utf8");
+  const lines = contents
+    .split(/\r?\n/gu)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  const latestLine = lines.at(-1);
+  if (!latestLine) {
+    return undefined;
+  }
+
+  const parsed = JSON.parse(latestLine) as unknown;
+  if (!isWorkspaceIndexSummary(parsed)) {
+    return undefined;
+  }
+
+  return {
+    loopId: parsed.loopId,
+    updatedAt: parsed.updatedAt
+  };
+}
+
 function parseUnknownLoopValues(contents: string, file: string): unknown[] {
   if (file.endsWith(".jsonl")) {
     return contents
@@ -724,6 +880,61 @@ function isLoopSummary(value: unknown): value is { loopId: string } {
     value !== null &&
     typeof (value as { loopId?: unknown }).loopId === "string"
   );
+}
+
+function isWorkspaceIndexSummary(
+  candidate: unknown
+): candidate is {
+  loopId: string;
+  updatedAt: string;
+} {
+  return (
+    typeof candidate === "object" &&
+    candidate !== null &&
+    typeof (candidate as { loopId?: unknown }).loopId === "string" &&
+    typeof (candidate as { updatedAt?: unknown }).updatedAt === "string"
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function readVerificationWarnings(payload: Record<string, unknown> | undefined): string[] {
+  if (!Array.isArray(payload?.["warnings"])) {
+    return [];
+  }
+
+  return payload["warnings"].filter((warning): warning is string => typeof warning === "string");
+}
+
+function readVerificationSteps(payload: Record<string, unknown> | undefined): VerificationStepSummary[] {
+  if (!Array.isArray(payload?.["steps"])) {
+    return [];
+  }
+
+  return payload["steps"]
+    .map((candidate) => normalizeVerificationStep(candidate))
+    .filter((candidate): candidate is VerificationStepSummary => candidate !== undefined);
+}
+
+function normalizeVerificationStep(candidate: unknown): VerificationStepSummary | undefined {
+  if (!isRecord(candidate)) {
+    return undefined;
+  }
+
+  if (typeof candidate["command"] !== "string" || typeof candidate["launched"] !== "boolean") {
+    return undefined;
+  }
+
+  return {
+    command: candidate["command"],
+    launched: candidate["launched"],
+    ...(typeof candidate["exitCode"] === "number" ? { exitCode: candidate["exitCode"] } : {}),
+    timedOut: candidate["timedOut"] === true,
+    fastFail: candidate["fastFail"] !== false,
+    ...(typeof candidate["detail"] === "string" ? { detail: candidate["detail"] } : {})
+  };
 }
 
 function dedupeLoops(loops: LoopRecord[]): LoopRecord[] {

--- a/packages/cli/src/run-store.ts
+++ b/packages/cli/src/run-store.ts
@@ -144,8 +144,8 @@ export interface VerificationStepSummary {
   command: string;
   launched: boolean;
   exitCode?: number;
-  timedOut: boolean;
-  fastFail: boolean;
+  timedOut?: boolean;
+  fastFail?: boolean;
   detail?: string;
 }
 
@@ -378,7 +378,7 @@ export function buildVerificationSummary(loop: LoopRecord): VerificationSummary 
   }
 
   const payload = isRecord(latestEvent.payload) ? latestEvent.payload : undefined;
-  const passed = latestEvent.payload["passed"] === true;
+  const passed = payload?.["passed"] === true;
   const latestAttemptIndex =
     typeof payload?.["attemptIndex"] === "number"
       ? (payload["attemptIndex"] as number)
@@ -529,7 +529,9 @@ export async function findPersistedLoopEvidence(
         }
 
         const loop = await readLoopRecordFile(canonical);
-        if (!latestLoop || loopTimestamp(loop) >= loopTimestamp(latestLoop)) {
+        const candidateTimestamp = loopTimestamp(loop);
+        const latestTimestamp = latestLoop ? loopTimestamp(latestLoop) : Number.NEGATIVE_INFINITY;
+        if (candidateTimestamp > latestTimestamp) {
           latestLoop = loop;
         }
         continue;
@@ -542,7 +544,9 @@ export async function findPersistedLoopEvidence(
       const loop = (await readLoopsFromFile(path.join(runsRoot, entryName), runsRoot)).sort(
         (left, right) => loopTimestamp(right) - loopTimestamp(left)
       )[0];
-      if (loop && (!latestLoop || loopTimestamp(loop) >= loopTimestamp(latestLoop))) {
+      const candidateTimestamp = loop ? loopTimestamp(loop) : Number.NEGATIVE_INFINITY;
+      const latestTimestamp = latestLoop ? loopTimestamp(latestLoop) : Number.NEGATIVE_INFINITY;
+      if (loop && candidateTimestamp > latestTimestamp) {
         latestLoop = loop;
       }
     } catch (error) {
@@ -578,7 +582,11 @@ async function loadLatestLoopFromWorkspaceIndexes(
         continue;
       }
 
-      if (!latestSummary || Date.parse(candidate.updatedAt) >= Date.parse(latestSummary.updatedAt)) {
+      const candidateTimestamp = parseTimestamp(candidate.updatedAt);
+      const latestTimestamp = latestSummary
+        ? parseTimestamp(latestSummary.updatedAt)
+        : Number.NEGATIVE_INFINITY;
+      if (candidateTimestamp > latestTimestamp) {
         latestSummary = candidate;
       }
     } catch (error) {
@@ -931,8 +939,8 @@ function normalizeVerificationStep(candidate: unknown): VerificationStepSummary 
     command: candidate["command"],
     launched: candidate["launched"],
     ...(typeof candidate["exitCode"] === "number" ? { exitCode: candidate["exitCode"] } : {}),
-    timedOut: candidate["timedOut"] === true,
-    fastFail: candidate["fastFail"] !== false,
+    ...(typeof candidate["timedOut"] === "boolean" ? { timedOut: candidate["timedOut"] } : {}),
+    ...(typeof candidate["fastFail"] === "boolean" ? { fastFail: candidate["fastFail"] } : {}),
     ...(typeof candidate["detail"] === "string" ? { detail: candidate["detail"] } : {})
   };
 }
@@ -953,7 +961,16 @@ function upsertLoop(target: Map<string, LoopRecord>, loop: LoopRecord): void {
 }
 
 function loopTimestamp(loop: LoopRecord): number {
-  return Date.parse(loop.updatedAt || loop.createdAt || "");
+  return parseTimestamp(loop.updatedAt || loop.createdAt || "");
+}
+
+function parseTimestamp(timestamp: string | undefined): number {
+  if (typeof timestamp !== "string") {
+    return Number.NEGATIVE_INFINITY;
+  }
+
+  const parsed = Date.parse(timestamp);
+  return Number.isFinite(parsed) ? parsed : Number.NEGATIVE_INFINITY;
 }
 
 function isMissing(error: unknown): boolean {

--- a/packages/cli/tests/cli-integration.test.ts
+++ b/packages/cli/tests/cli-integration.test.ts
@@ -356,12 +356,12 @@ describe.sequential("inspect command", () => {
 // ---------------------------------------------------------------------------
 
 describe("bench command", () => {
-  it("guides operators to the workspace benchmark harness instead of shipping bench in the public CLI", async () => {
+  it("treats bench as an unsupported public command", async () => {
     const result = await executeCli(["bench", "--suite", "ralphy-smoke"]);
 
-    expect(result.exitCode).toBe(1);
-    expect(result.stderr).toContain("workspace-only RC surface");
-    expect(result.stderr).toContain("pnpm --filter @martin/benchmarks");
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain("Unknown command 'bench'.");
+    expect(result.stderr).toContain("martin-loop --help");
   });
 });
 

--- a/packages/cli/tests/cli.test.ts
+++ b/packages/cli/tests/cli.test.ts
@@ -1,11 +1,11 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
 import { createLoopRecord } from "../../contracts/src/index.js";
-import { executeCli, parseCliArguments } from "../src/index.js";
+import { executeCli, parseCliArguments, renderCliHelp } from "../src/index.js";
 
 const FAST_VERIFIER = process.platform === "win32" ? "cmd /c exit 0" : "true";
 
@@ -98,9 +98,73 @@ describe("parseCliArguments", () => {
       })
     });
   });
+
+  it("treats subcommand help as an ungated help request", () => {
+    expect(parseCliArguments(["run", "--help"])).toEqual({ command: "help" });
+    expect(parseCliArguments(["preflight", "-h"])).toEqual({ command: "help" });
+  });
 });
 
 describe.sequential("executeCli", () => {
+  it("renders help for run --help and preflight --help without entering the governed flow", async () => {
+    const runHelp = await executeCli(["run", "--help"]);
+    const preflightHelp = await executeCli(["preflight", "--help"]);
+
+    expect(runHelp.exitCode).toBe(0);
+    expect(preflightHelp.exitCode).toBe(0);
+    expect(runHelp.stdout).toContain("Martin Loop CLI");
+    expect(preflightHelp.stdout).toContain("Martin Loop CLI");
+  });
+
+  it("does not persist first-run workflow state when rendering help", async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), "martin-cli-help-home-"));
+    const previousEnv = {
+      HOME: process.env.HOME,
+      USERPROFILE: process.env.USERPROFILE,
+      HOMEDRIVE: process.env.HOMEDRIVE,
+      HOMEPATH: process.env.HOMEPATH,
+      LOCALAPPDATA: process.env.LOCALAPPDATA,
+      APPDATA: process.env.APPDATA,
+      INIT_CWD: process.env.INIT_CWD
+    };
+    const previousCwd = process.cwd();
+
+    try {
+      process.env.HOME = homeDir;
+      process.env.USERPROFILE = homeDir;
+      process.env.HOMEDRIVE = homeDir.slice(0, 2);
+      process.env.HOMEPATH = homeDir.slice(2);
+      process.env.LOCALAPPDATA = join(homeDir, "AppData", "Local");
+      process.env.APPDATA = join(homeDir, "AppData", "Roaming");
+      process.env.INIT_CWD = homeDir;
+      process.chdir(homeDir);
+      await mkdir(process.env.LOCALAPPDATA, { recursive: true });
+      await mkdir(process.env.APPDATA, { recursive: true });
+
+      const result = await executeCli(["run", "--help"]);
+
+      expect(result.exitCode).toBe(0);
+      await expect(access(join(homeDir, ".martin", "runs", "_martin", "workflow-state.json"))).rejects.toThrow();
+    } finally {
+      process.chdir(previousCwd);
+      for (const [key, value] of Object.entries(previousEnv)) {
+        if (value === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = value;
+        }
+      }
+      await rm(homeDir, { force: true, recursive: true });
+    }
+  });
+
+  it("keeps the public help surface honest for 0.2.10", () => {
+    const help = renderCliHelp();
+
+    expect(help).not.toContain("martin-loop bench");
+    expect(help).toContain("martin-loop badge [--format svg|json] [--runs-dir <path>]");
+  });
+
   it("renders the built-in command guide", async () => {
     const result = await executeCli(["--json", "guide", "start"]);
     const payload = JSON.parse(result.stdout);
@@ -385,12 +449,12 @@ describe.sequential("executeCli", () => {
     }
   });
 
-  it("surfaces bench as an RC-only workspace command instead of a publishable CLI feature", async () => {
+  it("rejects unsupported bench invocations from the public CLI surface", async () => {
     const result = await executeCli(["bench", "--suite", "ralphy-smoke"]);
 
-    expect(result.exitCode).toBe(1);
-    expect(result.stderr).toContain("workspace-only RC surface");
-    expect(result.stderr).toContain("@martin/benchmarks");
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain("Unknown command 'bench'.");
+    expect(result.stderr).toContain("martin-loop --help");
   });
 
   it("copies the seeded demo workspace into the default target directory", async () => {

--- a/packages/cli/tests/operator-commands.test.ts
+++ b/packages/cli/tests/operator-commands.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -104,14 +104,22 @@ async function withRunsRoot<T>(fn: (runsRoot: string) => Promise<T>): Promise<T>
   }
 }
 
+async function readRootPackageVersion(): Promise<string> {
+  const packageJson = JSON.parse(
+    await readFile(new URL("../../../package.json", import.meta.url), "utf8")
+  ) as { version: string };
+  return packageJson.version;
+}
+
 describe.sequential("operator commands", () => {
   it("doctor reports environment readiness and starter MCP tools", async () => {
+    const rootVersion = await readRootPackageVersion();
     const result = await executeCli(["--json", "doctor"]);
     const payload = JSON.parse(result.stdout);
 
     expect(result.exitCode).toBe(0);
     expect(payload.command).toBe("doctor");
-    expect(payload.cliVersion).toBeTypeOf("string");
+    expect(payload.cliVersion).toBe(rootVersion);
     expect(payload.profiles.minimal).toContain("martin_list_runs");
     expect(payload.starterTools).toContain("martin_doctor");
     expect(payload.environment.runsRoot).toBeTypeOf("string");
@@ -119,11 +127,13 @@ describe.sequential("operator commands", () => {
   });
 
   it("start returns an onboarding plan with host bootstrap guidance", async () => {
+    const rootVersion = await readRootPackageVersion();
     const result = await executeCli(["--json", "start", "--host", "codex"]);
     const payload = JSON.parse(result.stdout);
 
     expect(result.exitCode).toBe(0);
     expect(payload.command).toBe("start");
+    expect(payload.cliVersion).toBe(rootVersion);
     expect(payload.bestNextCommand).toBeTypeOf("string");
     expect(payload.recommendedFlow).toContain("martin-loop doctor");
     expect(payload.hostBootstrap.host).toBe("codex");
@@ -202,6 +212,142 @@ describe.sequential("operator commands", () => {
     });
   });
 
+  it("keeps --runs-dir consistent across doctor, start, preflight, run, and dossier", async () => {
+    const workspace = await mkdtemp(join(tmpdir(), "martin-cli-explicit-runs-dir-"));
+    const runsRoot = await mkdtemp(join(tmpdir(), "martin-cli-explicit-runs-root-"));
+    const previousLive = process.env.MARTIN_LIVE;
+    const previousRunsRoot = process.env.MARTIN_RUNS_DIR;
+    delete process.env.MARTIN_RUNS_DIR;
+    process.env.MARTIN_LIVE = "false";
+
+    try {
+      const doctor = JSON.parse(
+        (await executeCli(["--json", "doctor", "--cwd", workspace, "--runs-dir", runsRoot])).stdout
+      );
+      const start = JSON.parse(
+        (await executeCli(["--json", "start", "--cwd", workspace, "--runs-dir", runsRoot])).stdout
+      );
+      const preflight = JSON.parse(
+        (
+          await executeCli([
+            "--json",
+            "preflight",
+            "--objective",
+            "Repair the failing MCP lane",
+            "--cwd",
+            workspace,
+            "--runs-dir",
+            runsRoot,
+            "--verify",
+            `"${process.execPath}" -e "process.exit(0)"`
+          ])
+        ).stdout
+      );
+      const run = JSON.parse(
+        (
+          await executeCli([
+            "--json",
+            "run",
+            "--objective",
+            "Repair the failing MCP lane",
+            "--cwd",
+            workspace,
+            "--runs-dir",
+            runsRoot,
+            "--verify",
+            `"${process.execPath}" -e "process.exit(0)"`
+          ])
+        ).stdout
+      );
+      const dossier = JSON.parse(
+        (await executeCli(["--json", "dossier", "--latest", "--runs-dir", runsRoot])).stdout
+      );
+
+      expect(doctor.environment.runsRoot).toBe(runsRoot);
+      expect(start.runsRoot).toBe(runsRoot);
+      expect(preflight.environment.runsRoot).toBe(runsRoot);
+      expect(run.environment.runsRoot).toBe(runsRoot);
+      expect(dossier.paths.runsRoot).toBe(runsRoot);
+      expect(dossier.loop.loopId).toBe(run.loop.loopId);
+    } finally {
+      if (previousLive === undefined) {
+        delete process.env.MARTIN_LIVE;
+      } else {
+        process.env.MARTIN_LIVE = previousLive;
+      }
+      if (previousRunsRoot === undefined) {
+        delete process.env.MARTIN_RUNS_DIR;
+      } else {
+        process.env.MARTIN_RUNS_DIR = previousRunsRoot;
+      }
+      await rm(workspace, { force: true, recursive: true }).catch(() => {});
+      await rm(runsRoot, { force: true, recursive: true }).catch(() => {});
+    }
+  });
+
+  it("uses the latest persisted run when badge reads an explicit runs directory", async () => {
+    await withRunsRoot(async (defaultRunsRoot) => {
+      const runsRoot = await mkdtemp(join(tmpdir(), "martin-cli-badge-runs-root-"));
+
+      try {
+        const oldBaseLoop = makeLoopRecord();
+        const latestBaseLoop = makeLoopRecord();
+        const oldLoop = {
+          ...oldBaseLoop,
+          loopId: "aaa_old",
+          updatedAt: "2026-05-16T12:00:00.000Z",
+          task: {
+            ...oldBaseLoop.task,
+            verificationPlan: []
+          },
+          artifacts: []
+        };
+        const latestLoop = {
+          ...latestBaseLoop,
+          loopId: "zzz_new",
+          updatedAt: "2026-05-17T12:00:00.000Z",
+          task: {
+            ...latestBaseLoop.task,
+            verificationPlan: ["pnpm --filter @martinloop/mcp test"]
+          },
+          artifacts: [
+            {
+              artifactId: "artifact_rollback",
+              kind: "rollback_plan" as const,
+              label: "Rollback plan",
+              uri: "file:///tmp/rollback.patch"
+            }
+          ]
+        };
+
+        for (const loop of [oldLoop, latestLoop]) {
+          const loopDir = join(runsRoot, loop.loopId);
+          await mkdir(loopDir, { recursive: true });
+          await writeFile(join(loopDir, "loop-record.json"), JSON.stringify(loop, null, 2), "utf8");
+        }
+
+        const result = await executeCli(["--json", "badge", "--runs-dir", runsRoot]);
+        const payload = JSON.parse(result.stdout);
+
+        expect(result.exitCode).toBe(0);
+        expect(payload.score.points).toBe(100);
+        expect(payload.score.grade).toBe("ready");
+        expect(
+          payload.score.signals.find((signal: { id: string; passed: boolean }) => signal.id === "verifierConfigured")
+            ?.passed
+        ).toBe(true);
+        expect(
+          payload.score.signals.find(
+            (signal: { id: string; passed: boolean }) => signal.id === "rollbackEvidencePresent"
+          )?.passed
+        ).toBe(true);
+        expect(defaultRunsRoot).not.toBe(runsRoot);
+      } finally {
+        await rm(runsRoot, { force: true, recursive: true }).catch(() => {});
+      }
+    });
+  });
+
   it("preflight reports blocked state when the working directory is missing", async () => {
     const missingDirectory = join(tmpdir(), "martin-cli-missing", "repo");
     const result = await executeCli([
@@ -253,6 +399,63 @@ describe.sequential("operator commands", () => {
       expect(triage.command).toBe("triage");
       expect(triage.findings[0].loopId).toBe(loop.loopId);
       expect(triage.findings[0].reasons).toContain("verification_failed");
+    });
+  });
+
+  it("surfaces verification contradictions and step evidence in dossier, attempt, and verify views", async () => {
+    await withRunsRoot(async (runsRoot) => {
+      const loop = makeLoopRecord();
+      const loopDir = join(runsRoot, loop.loopId);
+      await mkdir(loopDir, { recursive: true });
+      const loopWithVerificationEvidence = {
+        ...loop,
+        events: loop.events.map((event) =>
+          event.type === "verification.completed"
+            ? {
+                ...event,
+                payload: {
+                  ...event.payload,
+                  warnings: [
+                    "Adapter output reported a tool-launch problem before MartinLoop ran its own verifier: CreateProcessAsUserW failed: 5"
+                  ],
+                  steps: [
+                    {
+                      command: "npm test",
+                      launched: true,
+                      exitCode: 0,
+                      timedOut: false,
+                      fastFail: true,
+                      detail: "tests passed"
+                    }
+                  ]
+                }
+              }
+            : event
+        )
+      };
+      await writeFile(join(loopDir, "loop-record.json"), JSON.stringify(loopWithVerificationEvidence, null, 2), "utf8");
+      await writeFile(
+        join(runsRoot, `${loop.workspaceId}.jsonl`),
+        `${JSON.stringify({ loopId: loop.loopId, status: loop.status, updatedAt: loop.updatedAt })}\n`,
+        "utf8"
+      );
+
+      const dossier = JSON.parse((await executeCli(["--json", "dossier", "--loop-id", loop.loopId])).stdout);
+      const attempt = JSON.parse(
+        (await executeCli(["--json", "runs", "attempt", "--loop-id", loop.loopId])).stdout
+      );
+      const verify = JSON.parse(
+        (await executeCli(["--json", "runs", "verify", "--loop-id", loop.loopId])).stdout
+      );
+
+      expect(dossier.verification.warnings).toContain("Adapter output reported a tool-launch problem before MartinLoop ran its own verifier: CreateProcessAsUserW failed: 5");
+      expect(dossier.verification.steps[0].command).toBe("npm test");
+      expect(dossier.receipt.verifier.warnings).toContain("Adapter output reported a tool-launch problem before MartinLoop ran its own verifier: CreateProcessAsUserW failed: 5");
+      expect(dossier.receipt.verifier.steps[0].command).toBe("npm test");
+      expect(attempt.verification.warnings).toContain("Adapter output reported a tool-launch problem before MartinLoop ran its own verifier: CreateProcessAsUserW failed: 5");
+      expect(attempt.verification.steps[0].command).toBe("npm test");
+      expect(verify.verification.warnings).toContain("Adapter output reported a tool-launch problem before MartinLoop ran its own verifier: CreateProcessAsUserW failed: 5");
+      expect(verify.verification.steps[0].command).toBe("npm test");
     });
   });
 
@@ -419,5 +622,34 @@ describe("badge command", () => {
     expect(result.stdout).not.toContain("full autonomy");
     expect(result.stdout).not.toContain("self-learning");
     expect(result.stdout).not.toMatch(/[A-Z]:\\/);
+  });
+
+  it("reads run receipts from an explicit --runs-dir without requiring MARTIN_RUNS_DIR", async () => {
+    const runsRoot = await mkdtemp(join(tmpdir(), "martin-badge-runs-root-"));
+    const previousRunsRoot = process.env.MARTIN_RUNS_DIR;
+    delete process.env.MARTIN_RUNS_DIR;
+
+    try {
+      const loop = makeLoopRecord();
+      const loopDir = join(runsRoot, loop.loopId);
+      await mkdir(loopDir, { recursive: true });
+      await writeFile(join(loopDir, "loop-record.json"), JSON.stringify(loop, null, 2), "utf8");
+
+      const result = await executeCli(["--json", "badge", "--format", "json", "--runs-dir", runsRoot]);
+      const payload = JSON.parse(result.stdout);
+      const runReceiptsSignal = payload.score.signals.find(
+        (signal: { id: string; passed: boolean }) => signal.id === "runReceiptsPresent"
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(runReceiptsSignal?.passed).toBe(true);
+    } finally {
+      if (previousRunsRoot === undefined) {
+        delete process.env.MARTIN_RUNS_DIR;
+      } else {
+        process.env.MARTIN_RUNS_DIR = previousRunsRoot;
+      }
+      await rm(runsRoot, { force: true, recursive: true }).catch(() => {});
+    }
   });
 });

--- a/packages/cli/tests/persistence.test.ts
+++ b/packages/cli/tests/persistence.test.ts
@@ -9,7 +9,7 @@ import { createLoopRecord } from "@martin/contracts";
 import { persistLoopArtifacts } from "../src/persistence.js";
 
 describe("persistLoopArtifacts", () => {
-  it("writes contract, state, ledger, and attempt artifacts to <runsRoot>/<loopId>/", async () => {
+  it("writes contract, state, events, and attempt artifacts to <runsRoot>/<loopId>/ without shadowing the core ledger", async () => {
     const runsRoot = await mkdtemp(join(tmpdir(), "martin-runs-"));
     const loop = createLoopRecord({
       workspaceId: "ws_alpha",
@@ -52,12 +52,13 @@ describe("persistLoopArtifacts", () => {
     const attempt = JSON.parse(
       await readFile(join(base, "attempts", "001-att_1.json"), "utf8")
     );
-    const ledger = await readFile(join(base, "ledger.jsonl"), "utf8");
+    const events = await readFile(join(base, "events.jsonl"), "utf8");
 
     expect(contract.task.title).toBe("Repair runtime");
     expect(state.metrics.attemptCount).toBe(1);
     expect(attempt.failureClass).toBe("test_regression");
-    expect(ledger).toContain('"type":"run.started"');
+    expect(events).toContain('"type":"run.started"');
+    await expect(readFile(join(base, "ledger.jsonl"), "utf8")).rejects.toThrow();
   });
 
   it("uses flat <runId> path — NOT nested <workspaceId>/<loopId>", async () => {

--- a/packages/cli/tests/run-store.test.ts
+++ b/packages/cli/tests/run-store.test.ts
@@ -1,6 +1,48 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { createLoopRecord, type LoopRecord } from "@martin/contracts";
 import { describe, expect, it } from "vitest";
 
-import { resolveCliEnvironment } from "../src/run-store.js";
+import {
+  buildVerificationSummary,
+  findPersistedLoopEvidence,
+  resolveCliEnvironment,
+} from "../src/run-store.js";
+
+function makeLoopRecord(overrides: Partial<LoopRecord> = {}): LoopRecord {
+  const loop = createLoopRecord({
+    workspaceId: "ws_run_store",
+    projectId: "proj_run_store",
+    task: {
+      title: "Repair verifier evidence handling",
+      objective: "Repair verifier evidence handling",
+      verificationPlan: ["npm test"],
+    },
+    budget: {
+      maxUsd: 10,
+      softLimitUsd: 6,
+      maxIterations: 3,
+      maxTokens: 10000,
+    },
+    cost: {
+      actualUsd: 1,
+      avoidedUsd: 0,
+      tokensIn: 100,
+      tokensOut: 50,
+    },
+  });
+
+  return {
+    ...loop,
+    status: "completed" as const,
+    lifecycleState: "completed" as const,
+    attempts: [],
+    events: [],
+    ...overrides,
+  };
+}
 
 describe("resolveCliEnvironment", () => {
   it("preserves the openai engine selection", () => {
@@ -19,5 +61,118 @@ describe("resolveCliEnvironment", () => {
     const environment = resolveCliEnvironment({ liveMode: "proof" });
 
     expect(environment.liveMode).toBe("proof");
+  });
+});
+
+describe("buildVerificationSummary", () => {
+  it("treats malformed verification payloads as failed evidence instead of throwing", () => {
+    const loop = makeLoopRecord({
+      events: [
+        {
+          eventId: "evt_malformed",
+          timestamp: "2026-06-06T20:00:00.000Z",
+          type: "verification.completed",
+          lifecycleState: "verifying",
+          payload: null as unknown as Record<string, unknown>,
+        },
+      ],
+    });
+
+    expect(() => buildVerificationSummary(loop)).not.toThrow();
+    expect(buildVerificationSummary(loop)).toMatchObject({
+      status: "failed",
+      eventCount: 1,
+      steps: [],
+      warnings: [],
+    });
+  });
+
+  it("does not invent timedOut or fastFail fields when persisted evidence omits them", () => {
+    const loop = makeLoopRecord({
+      events: [
+        {
+          eventId: "evt_sparse_step",
+          timestamp: "2026-06-06T20:05:00.000Z",
+          type: "verification.completed",
+          lifecycleState: "verifying",
+          payload: {
+            passed: true,
+            steps: [{ command: "npm test", launched: true }],
+          },
+        },
+      ],
+    });
+
+    expect(buildVerificationSummary(loop).steps).toEqual([{ command: "npm test", launched: true }]);
+  });
+});
+
+describe("findPersistedLoopEvidence", () => {
+  async function withRunsRoot<T>(fn: (runsRoot: string) => Promise<T>): Promise<T> {
+    const runsRoot = await mkdtemp(join(tmpdir(), "martin-run-store-"));
+    try {
+      return await fn(runsRoot);
+    } finally {
+      await rm(runsRoot, { force: true, recursive: true }).catch(() => {});
+    }
+  }
+
+  it("ignores invalid timestamps in workspace indexes when choosing the latest run", async () => {
+    await withRunsRoot(async (runsRoot) => {
+      const invalidLoop = makeLoopRecord({
+        loopId: "aaa_invalid",
+        updatedAt: "not-a-date",
+      });
+      const validLoop = makeLoopRecord({
+        loopId: "zzz_valid",
+        updatedAt: "2026-06-06T20:10:00.000Z",
+      });
+
+      for (const loop of [invalidLoop, validLoop]) {
+        const loopDir = join(runsRoot, loop.loopId);
+        await mkdir(loopDir, { recursive: true });
+        await writeFile(join(loopDir, "loop-record.json"), JSON.stringify(loop), "utf8");
+      }
+
+      await writeFile(
+        join(runsRoot, "workspace-a.jsonl"),
+        `${JSON.stringify({ loopId: invalidLoop.loopId, updatedAt: "not-a-date" })}\n`,
+        "utf8",
+      );
+      await writeFile(
+        join(runsRoot, "workspace-b.jsonl"),
+        `${JSON.stringify({ loopId: validLoop.loopId, updatedAt: validLoop.updatedAt })}\n`,
+        "utf8",
+      );
+
+      await expect(findPersistedLoopEvidence(runsRoot)).resolves.toMatchObject({
+        runsRoot,
+        loop: expect.objectContaining({ loopId: validLoop.loopId }),
+      });
+    });
+  });
+
+  it("ignores invalid loop timestamps during directory fallback scanning", async () => {
+    await withRunsRoot(async (runsRoot) => {
+      const invalidLoop = makeLoopRecord({
+        loopId: "aaa_invalid",
+        updatedAt: "not-a-date",
+      });
+      const validLoop = makeLoopRecord({
+        loopId: "zzz_valid",
+        updatedAt: "2026-06-06T20:15:00.000Z",
+      });
+
+      for (const loop of [invalidLoop, validLoop]) {
+        const loopDir = join(runsRoot, loop.loopId);
+        await mkdir(loopDir, { recursive: true });
+        await writeFile(join(loopDir, "loop-record.json"), JSON.stringify(loop), "utf8");
+      }
+
+      await expect(findPersistedLoopEvidence(runsRoot)).resolves.toMatchObject({
+        runsRoot,
+        loop: expect.objectContaining({ loopId: validLoop.loopId }),
+      });
+    });
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -197,6 +197,22 @@ export interface MartinAdapterRequest {
   previousAttempts: LoopAttempt[];
 }
 
+export interface MartinVerificationStep {
+  command: string;
+  launched: boolean;
+  exitCode?: number;
+  timedOut: boolean;
+  fastFail?: boolean;
+  detail?: string;
+}
+
+export interface MartinVerificationOutcome {
+  passed: boolean;
+  summary: string;
+  steps?: MartinVerificationStep[];
+  warnings?: string[];
+}
+
 export interface MartinAdapterResult {
   status: "completed" | "failed";
   summary: string;
@@ -207,10 +223,7 @@ export interface MartinAdapterResult {
     tokensOut: number;
     provenance?: CostProvenance;
   };
-  verification: {
-    passed: boolean;
-    summary: string;
-  };
+  verification: MartinVerificationOutcome;
   execution?: {
     changedFiles?: string[];
     diffStats?: {
@@ -619,7 +632,7 @@ export async function runMartin(input: RunMartinInput): Promise<RunMartinResult>
     const contextPrecheck = await runContextIntegrityPrecheck(
       loop.loopId,
       loop.attempts.length + 1,
-      runDir(resolveRunsRoot(), loop.loopId),
+      runDir(resolveActiveRunsRoot(input.store), loop.loopId),
       {
         userPrompt: distilled.focus,
         history: loop.attempts.map(a => a.summary).join("\n")
@@ -794,6 +807,7 @@ export async function runMartin(input: RunMartinInput): Promise<RunMartinResult>
     const result = await executingAdapter.execute(request);
     const attemptCompletedAt = now();
     const compiledContext = compilePromptPacket(request);
+    const verification = normalizeVerificationOutcome(result);
 
     // PATCH → VERIFY
     currentPhase = "VERIFY";
@@ -911,11 +925,14 @@ export async function runMartin(input: RunMartinInput): Promise<RunMartinResult>
       loop,
       {
         type: "verification.completed",
-        lifecycleState: result.verification.passed ? "completed" : "verifying",
+        lifecycleState: verification.passed ? "completed" : "verifying",
         payload: {
           attemptId,
-          passed: result.verification.passed,
-          summary: result.verification.summary
+          attemptIndex: currentAttemptIndex,
+          passed: verification.passed,
+          summary: verification.summary,
+          ...(verification.steps?.length ? { steps: verification.steps } : {}),
+          ...(verification.warnings?.length ? { warnings: verification.warnings } : {})
         }
       },
       { now: attemptCompletedAt, idFactory }
@@ -951,6 +968,7 @@ export async function runMartin(input: RunMartinInput): Promise<RunMartinResult>
       });
       await input.store.writeAttemptArtifacts(loop.loopId, currentAttemptIndex, {
         compiledContext,
+        verification,
         ...(rollbackBoundary ? { rollbackBoundary } : {})
       });
       await input.store.appendLedger(
@@ -968,7 +986,13 @@ export async function runMartin(input: RunMartinInput): Promise<RunMartinResult>
           kind: "verification.completed",
           runId: loop.loopId,
           attemptIndex: currentAttemptIndex,
-          payload: { passed: result.verification.passed, summary: result.verification.summary }
+          payload: {
+            attemptId,
+            passed: verification.passed,
+            summary: verification.summary,
+            ...(verification.steps?.length ? { steps: verification.steps } : {}),
+            ...(verification.warnings?.length ? { warnings: verification.warnings } : {})
+          }
         })
       );
       await input.store.appendLedger(
@@ -1007,9 +1031,9 @@ export async function runMartin(input: RunMartinInput): Promise<RunMartinResult>
 
     if (isVerifyOnly && changedFiles.length > 0) {
       const patchDecision = evaluatePatchDecision({
-        verificationPassed: result.verification.passed,
+        verificationPassed: verification.passed,
         previousVerifierScore,
-        verifierScore: result.verification.passed ? 1 : 0,
+        verifierScore: verification.passed ? 1 : 0,
         scopeViolationCount: changedFiles.length,
         changedFileCount: changedFiles.length,
         diffNovelty: 1,
@@ -1115,9 +1139,9 @@ export async function runMartin(input: RunMartinInput): Promise<RunMartinResult>
 
     if (!filesystemDecision.allowed) {
       const patchDecision = evaluatePatchDecision({
-        verificationPassed: result.verification.passed,
+        verificationPassed: verification.passed,
         previousVerifierScore,
-        verifierScore: result.verification.passed ? 1 : 0,
+        verifierScore: verification.passed ? 1 : 0,
         scopeViolationCount: filesystemDecision.violations.length,
         changedFileCount: changedFiles.length,
         diffNovelty: changedFiles.length > 0 ? 1 : 0,
@@ -1202,9 +1226,9 @@ export async function runMartin(input: RunMartinInput): Promise<RunMartinResult>
 
     if (!changeApprovalDecision.allowed) {
       const patchDecision = evaluatePatchDecision({
-        verificationPassed: result.verification.passed,
+        verificationPassed: verification.passed,
         previousVerifierScore,
-        verifierScore: result.verification.passed ? 1 : 0,
+        verifierScore: verification.passed ? 1 : 0,
         safetyViolationCount: changeApprovalDecision.violations.length,
         changedFileCount: changedFiles.length,
         diffNovelty: changedFiles.length > 0 ? 1 : 0,
@@ -1320,9 +1344,9 @@ export async function runMartin(input: RunMartinInput): Promise<RunMartinResult>
     let patchDecision: EvaluatedPatchDecision | undefined;
     if (result.status === "completed") {
       patchDecision = evaluatePatchDecision({
-        verificationPassed: result.verification.passed,
+        verificationPassed: verification.passed,
         previousVerifierScore,
-        verifierScore: result.verification.passed ? 1 : 0,
+        verifierScore: verification.passed ? 1 : 0,
         groundingViolationCount: groundingScanResult?.violations.length ?? 0,
         changedFileCount: patchTruthCountsEdits ? changedFiles.length : undefined,
         diffNovelty: patchTruthCountsEdits ? (changedFiles.length > 0 ? 1 : 0) : undefined,
@@ -1381,10 +1405,10 @@ export async function runMartin(input: RunMartinInput): Promise<RunMartinResult>
         await input.store.appendLedger(
           loop.loopId,
           makeLedgerEvent({
-            kind: result.verification.passed ? "attempt.kept" : "attempt.discarded",
+            kind: verification.passed ? "attempt.kept" : "attempt.discarded",
             runId: loop.loopId,
             attemptIndex: currentAttemptIndex,
-            payload: { reason: result.verification.summary }
+            payload: { reason: verification.summary }
           })
         );
       }
@@ -1618,6 +1642,11 @@ async function persistLoopRecordIfSupported(
   await store?.writeLoopRecord?.(loop.loopId, loop);
 }
 
+function resolveActiveRunsRoot(store: RunStore | undefined): string {
+  const configuredRunsRoot = store?.runsRoot?.trim();
+  return configuredRunsRoot && configuredRunsRoot.length > 0 ? configuredRunsRoot : resolveRunsRoot();
+}
+
 function getAdapterTransport(adapter: MartinAdapter): "cli" | "http" | "routed_http" {
   return adapter.metadata.transport ?? (adapter.kind === "agent-cli" ? "cli" : "http");
 }
@@ -1762,6 +1791,55 @@ function getLastVerifierScore(loop: LoopRecord): number {
   }
 
   return 0;
+}
+
+function truncateVerificationDetail(text: string, maxLength: number): string {
+  return text.length <= maxLength ? text : `${text.slice(0, maxLength - 1)}…`;
+}
+
+function normalizeVerificationOutcome(result: MartinAdapterResult): MartinVerificationOutcome {
+  const warnings = [...(result.verification.warnings ?? [])];
+  const contradiction = detectVerificationContradiction(result);
+  if (contradiction && !warnings.includes(contradiction)) {
+    warnings.push(contradiction);
+  }
+
+  return {
+    passed: result.verification.passed,
+    summary: result.verification.summary,
+    ...(result.verification.steps?.length ? { steps: result.verification.steps } : {}),
+    ...(warnings.length ? { warnings } : {})
+  };
+}
+
+function detectVerificationContradiction(result: MartinAdapterResult): string | undefined {
+  if (!result.verification.passed) {
+    return undefined;
+  }
+
+  const sources = [result.summary, result.failure?.message]
+    .filter((value): value is string => typeof value === "string" && value.trim().length > 0);
+
+  const contradictionPatterns = [
+    /createprocessasuserw failed:\s*\d+/iu,
+    /\bverifier not run\b/iu,
+    /\bfailed before verifier\b/iu,
+    /\bnever launched\b/iu,
+    /\bfailed to launch\b/iu,
+    /\bcould not launch\b/iu
+  ];
+
+  for (const source of sources) {
+    const match = contradictionPatterns.find((pattern) => pattern.test(source));
+    if (!match) {
+      continue;
+    }
+
+    const excerpt = truncateVerificationDetail(source.trim().replace(/\s+/gu, " "), 220);
+    return `Adapter output reported a tool-launch problem before MartinLoop ran its own verifier: ${excerpt}`;
+  }
+
+  return undefined;
 }
 
 function toPatchDecisionArtifact(decision: EvaluatedPatchDecision): PatchDecisionArtifact {

--- a/packages/core/src/persistence/store.ts
+++ b/packages/core/src/persistence/store.ts
@@ -24,6 +24,8 @@ export interface RunContract {
 export interface AttemptArtifacts {
   /** Compiled PromptPacket written as compiled-context.json */
   compiledContext: unknown;
+  /** Structured verification evidence captured from the authoritative MartinLoop verifier (optional) */
+  verification?: unknown;
   /** Unified diff string from the patch (optional) */
   diff?: string;
   /** Raw verifier command output (optional) */
@@ -50,6 +52,12 @@ export interface AttemptArtifacts {
  * is durably written before the run proceeds to the next step.
  */
 export interface RunStore {
+  /**
+   * Optional runs root hint for filesystem-backed stores.
+   * Orchestration should prefer this over recomputing the default home store.
+   */
+  runsRoot?: string;
+
   /**
    * Write contract.json for a new run. Called once at run start.
    * The contract is immutable after this point.
@@ -104,6 +112,7 @@ export function artifactDir(runsRoot: string, runId: string, attemptIndex: numbe
  *   <runsRoot>/<runId>/state.json
  *   <runsRoot>/<runId>/ledger.jsonl
  *   <runsRoot>/<runId>/artifacts/attempt-<n>/compiled-context.json
+ *   <runsRoot>/<runId>/artifacts/attempt-<n>/verification.json (if verification provided)
  *   <runsRoot>/<runId>/artifacts/attempt-<n>/diff.patch (if diff provided)
  *   <runsRoot>/<runId>/artifacts/attempt-<n>/verifier-output.txt (if provided)
  *   <runsRoot>/<runId>/artifacts/attempt-<n>/grounding-scan.json (if provided)
@@ -117,6 +126,8 @@ export function createFileRunStore(options: { runsRoot?: string } = {}): RunStor
   const runsRoot = options.runsRoot ?? resolveRunsRoot();
 
   return {
+    runsRoot,
+
     async initRun(contract: RunContract): Promise<void> {
       const dir = runDir(runsRoot, contract.runId);
       await mkdir(dir, { recursive: true });
@@ -148,6 +159,9 @@ export function createFileRunStore(options: { runsRoot?: string } = {}): RunStor
       await mkdir(dir, { recursive: true });
 
       await writeJsonFile(join(dir, "compiled-context.json"), artifacts.compiledContext);
+      if (artifacts.verification !== undefined) {
+        await writeJsonFile(join(dir, "verification.json"), artifacts.verification);
+      }
 
       if (artifacts.diff !== undefined) {
         await writeFile(join(dir, "diff.patch"), artifacts.diff, "utf8");

--- a/packages/core/src/policy.ts
+++ b/packages/core/src/policy.ts
@@ -58,6 +58,15 @@ export interface MartinAdapterResultLike {
   verification: {
     passed: boolean;
     summary: string;
+    steps?: Array<{
+      command: string;
+      launched: boolean;
+      exitCode?: number;
+      timedOut: boolean;
+      fastFail?: boolean;
+      detail?: string;
+    }>;
+    warnings?: string[];
   };
   failure?: {
     message: string;

--- a/packages/core/tests/runtime.test.ts
+++ b/packages/core/tests/runtime.test.ts
@@ -409,6 +409,175 @@ describe("runMartin", () => {
     expect(result.decision.lifecycleState).toBe("completed");
   });
 
+  it("persists authoritative verification steps and contradiction warnings for successful runs", async () => {
+    const runsRoot = await mkdtemp(join(tmpdir(), "martin-verification-evidence-"));
+    const store = createFileRunStore({ runsRoot });
+
+    const adapter: MartinAdapter = {
+      adapterId: "agent-cli:codex",
+      kind: "agent-cli",
+      label: "Codex CLI adapter",
+      metadata: {
+        providerId: "codex",
+        model: "codex",
+        transport: "cli"
+      },
+      async execute() {
+        return {
+          status: "completed",
+          summary: "CreateProcessAsUserW failed: 5 before verifier execution in the adapter transcript.",
+          usage: {
+            actualUsd: 0.02,
+            tokensIn: 12,
+            tokensOut: 6
+          },
+          verification: {
+            passed: true,
+            summary: "All 1 verification step(s) passed.",
+            steps: [
+              {
+                command: "npm test",
+                launched: true,
+                exitCode: 0,
+                timedOut: false,
+                fastFail: true,
+                detail: "tests passed"
+              }
+            ]
+          }
+        };
+      }
+    };
+
+    const result = await runMartin({
+      workspaceId: "ws_ops",
+      projectId: "proj_runtime",
+      task: {
+        title: "Repair the Windows Codex verifier path",
+        objective: "Persist contradiction warnings instead of silently claiming a clean verification pass.",
+        verificationPlan: ["npm test"]
+      },
+      budget: {
+        maxUsd: 10,
+        softLimitUsd: 6,
+        maxIterations: 1,
+        maxTokens: 2_000
+      },
+      adapter,
+      store,
+      now: createTimestampSource([
+        "2026-06-06T10:00:00.000Z",
+        "2026-06-06T10:00:01.000Z",
+        "2026-06-06T10:00:02.000Z",
+        "2026-06-06T10:00:03.000Z",
+        "2026-06-06T10:00:04.000Z",
+        "2026-06-06T10:00:05.000Z",
+        "2026-06-06T10:00:06.000Z"
+      ]),
+      idFactory: createIdFactory()
+    });
+
+    const verificationEvent = result.loop.events.find((event) => event.type === "verification.completed");
+    const verificationArtifact = JSON.parse(
+      await readFile(join(runsRoot, result.loop.loopId, "artifacts", "attempt-001", "verification.json"), "utf8")
+    );
+    const ledger = await readLedger(runsRoot, result.loop.loopId);
+    const verificationLedger = ledger.find((entry) => entry.kind === "verification.completed");
+
+    expect(verificationEvent?.payload["passed"]).toBe(true);
+    expect(verificationEvent?.payload["warnings"]).toContain(
+      "Adapter output reported a tool-launch problem before MartinLoop ran its own verifier: CreateProcessAsUserW failed: 5 before verifier execution in the adapter transcript."
+    );
+    expect(verificationEvent?.payload["steps"]).toEqual([
+      expect.objectContaining({
+        command: "npm test",
+        launched: true,
+        exitCode: 0
+      })
+    ]);
+    expect(verificationArtifact.warnings).toContain(
+      "Adapter output reported a tool-launch problem before MartinLoop ran its own verifier: CreateProcessAsUserW failed: 5 before verifier execution in the adapter transcript."
+    );
+    expect(verificationArtifact.steps[0].command).toBe("npm test");
+    expect(verificationLedger?.payload["warnings"]).toContain(
+      "Adapter output reported a tool-launch problem before MartinLoop ran its own verifier: CreateProcessAsUserW failed: 5 before verifier execution in the adapter transcript."
+    );
+    expect(verificationLedger?.payload["steps"]).toEqual([
+      expect.objectContaining({
+        command: "npm test",
+        launched: true,
+        exitCode: 0
+      })
+    ]);
+  });
+
+  it("writes context integrity precheck artifacts into the active runs root", async () => {
+    const runsRoot = await mkdtemp(join(tmpdir(), "martin-context-precheck-"));
+    const store = createFileRunStore({ runsRoot });
+
+    const adapter: MartinAdapter = {
+      adapterId: "direct:proof",
+      kind: "direct-provider",
+      label: "Proof adapter",
+      metadata: {
+        providerId: "openai",
+        model: "gpt-5-mini"
+      },
+      async execute() {
+        return {
+          status: "completed",
+          summary: "Verified the workspace without code changes.",
+          usage: {
+            actualUsd: 0,
+            tokensIn: 0,
+            tokensOut: 0
+          },
+          verification: {
+            passed: true,
+            summary: "All 1 verification step(s) passed."
+          },
+          execution: {
+            changedFiles: []
+          }
+        };
+      }
+    };
+
+    const result = await runMartin({
+      workspaceId: "ws_ops",
+      projectId: "proj_runtime",
+      task: {
+        title: "Verify context integrity persistence",
+        objective: "Keep context integrity artifacts inside the active runs root.",
+        verificationPlan: ["pnpm test"]
+      },
+      budget: {
+        maxUsd: 10,
+        softLimitUsd: 6,
+        maxIterations: 1,
+        maxTokens: 2_000
+      },
+      adapter,
+      store,
+      now: createTimestampSource([
+        "2026-06-06T10:10:00.000Z",
+        "2026-06-06T10:10:01.000Z",
+        "2026-06-06T10:10:02.000Z",
+        "2026-06-06T10:10:03.000Z",
+        "2026-06-06T10:10:04.000Z"
+      ]),
+      idFactory: createIdFactory()
+    });
+
+    const artifact = JSON.parse(
+      await readFile(join(runsRoot, result.loop.loopId, "context-integrity-precheck.json"), "utf8")
+    );
+
+    expect(artifact.runId).toBe(result.loop.loopId);
+    expect(artifact.attemptIndex).toBe(1);
+    expect(artifact.verdict).toBe("clean");
+  });
+
   it("allows verifier-only runs to complete without code changes when verification passes", async () => {
     const adapter: MartinAdapter = {
       adapterId: "direct:verify-only",

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -4,7 +4,7 @@ Governed MCP server for AI coding agents with budgets, receipts, and review-read
 
 `@martinloop/mcp` is the standalone MartinLoop server for MCP hosts. It stays local-first and stdio-first, and it gives hosts one clear execution path: check readiness, plan the work, preflight the contract, run it, and inspect the result with enough evidence to decide what happens next.
 
-The root `martin-loop` package and the standalone `@martinloop/mcp` package move on separate version lines. For the current root release, see [MartinLoop 0.2.9 release notes](../../docs/release/OSS-0.2.9-RELEASE-NOTES.md).
+The root `martin-loop` package and the standalone `@martinloop/mcp` package move on separate version lines. For the current root release, see [MartinLoop 0.2.10 release notes](../../docs/release/OSS-0.2.10-RELEASE-NOTES.md).
 
 ## What is new in 0.2.7
 

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -156,7 +156,7 @@ const verificationSchema = {
           fastFail: { type: "boolean" },
           detail: { type: "string" }
         },
-        required: ["command", "launched", "timedOut", "fastFail"]
+        required: ["command", "launched"]
       }
     },
     warnings: stringArraySchema

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -143,6 +143,22 @@ const verificationSchema = {
     latestAttemptIndex: { type: "integer" },
     completedAt: { type: "string" },
     summary: { type: "string" },
+    steps: {
+      type: "array",
+      items: {
+        type: "object",
+        additionalProperties: true,
+        properties: {
+          command: { type: "string" },
+          launched: { type: "boolean" },
+          exitCode: { type: "integer" },
+          timedOut: { type: "boolean" },
+          fastFail: { type: "boolean" },
+          detail: { type: "string" }
+        },
+        required: ["command", "launched", "timedOut", "fastFail"]
+      }
+    },
     warnings: stringArraySchema
   },
   required: ["status", "eventCount", "ledgerEventCount", "warnings"]

--- a/packages/mcp/src/tools/tool-support.ts
+++ b/packages/mcp/src/tools/tool-support.ts
@@ -90,7 +90,17 @@ export interface VerificationSummary {
   latestAttemptIndex?: number;
   completedAt?: string;
   summary?: string;
+  steps: VerificationStepSummary[];
   warnings: string[];
+}
+
+export interface VerificationStepSummary {
+  command: string;
+  launched: boolean;
+  exitCode?: number;
+  timedOut: boolean;
+  fastFail: boolean;
+  detail?: string;
 }
 
 interface NormalizedVerificationEvidence {
@@ -99,6 +109,8 @@ interface NormalizedVerificationEvidence {
   summary?: string;
   attemptId?: string;
   attemptIndex?: number;
+  warnings?: string[];
+  steps?: VerificationStepSummary[];
 }
 
 export interface RunWarningEnvelope {
@@ -329,9 +341,12 @@ export function buildVerificationSummary(
       status: "unavailable",
       eventCount: verificationEvents.length,
       ledgerEventCount: verificationLedgerEvents.length,
+      steps: [],
       warnings
     };
   }
+
+  warnings.push(...(latestEvidence.warnings ?? []));
 
   return {
     status:
@@ -347,6 +362,7 @@ export function buildVerificationSummary(
     ...(typeof latestEvidence.summary === "string" && latestEvidence.summary.trim().length > 0
       ? { summary: latestEvidence.summary.trim() }
       : {}),
+    steps: latestEvidence.steps ?? [],
     warnings
   };
 }
@@ -643,7 +659,9 @@ function normalizeLoopVerificationEvidence(
     ...(matchedAttempt.attemptId ? { attemptId: matchedAttempt.attemptId } : {}),
     attemptIndex: matchedAttempt.index,
     ...(typeof payload?.["passed"] === "boolean" ? { passed: payload["passed"] } : {}),
-    ...(typeof payload?.["summary"] === "string" ? { summary: payload["summary"] } : {})
+    ...(typeof payload?.["summary"] === "string" ? { summary: payload["summary"] } : {}),
+    ...(readVerificationWarnings(payload).length ? { warnings: readVerificationWarnings(payload) } : {}),
+    ...(readVerificationSteps(payload).length ? { steps: readVerificationSteps(payload) } : {})
   };
 }
 
@@ -671,7 +689,9 @@ function normalizeLedgerVerificationEvidence(
     ...(matchedAttempt?.attemptId ? { attemptId: matchedAttempt.attemptId } : {}),
     attemptIndex: event.attemptIndex,
     ...(typeof payload?.["passed"] === "boolean" ? { passed: payload["passed"] } : {}),
-    ...(typeof payload?.["summary"] === "string" ? { summary: payload["summary"] } : {})
+    ...(typeof payload?.["summary"] === "string" ? { summary: payload["summary"] } : {}),
+    ...(readVerificationWarnings(payload).length ? { warnings: readVerificationWarnings(payload) } : {}),
+    ...(readVerificationSteps(payload).length ? { steps: readVerificationSteps(payload) } : {})
   };
 }
 
@@ -702,4 +722,41 @@ function getLedgerWarnings(ledgerEvents: LedgerEvent[]): string[] {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
+}
+
+function readVerificationWarnings(payload: Record<string, unknown> | undefined): string[] {
+  if (!Array.isArray(payload?.["warnings"])) {
+    return [];
+  }
+
+  return payload["warnings"].filter((warning): warning is string => typeof warning === "string");
+}
+
+function readVerificationSteps(payload: Record<string, unknown> | undefined): VerificationStepSummary[] {
+  if (!Array.isArray(payload?.["steps"])) {
+    return [];
+  }
+
+  return payload["steps"]
+    .map((candidate) => normalizeVerificationStep(candidate))
+    .filter((candidate): candidate is VerificationStepSummary => candidate !== undefined);
+}
+
+function normalizeVerificationStep(candidate: unknown): VerificationStepSummary | undefined {
+  if (!isRecord(candidate)) {
+    return undefined;
+  }
+
+  if (typeof candidate["command"] !== "string" || typeof candidate["launched"] !== "boolean") {
+    return undefined;
+  }
+
+  return {
+    command: candidate["command"],
+    launched: candidate["launched"],
+    ...(typeof candidate["exitCode"] === "number" ? { exitCode: candidate["exitCode"] } : {}),
+    timedOut: candidate["timedOut"] === true,
+    fastFail: candidate["fastFail"] !== false,
+    ...(typeof candidate["detail"] === "string" ? { detail: candidate["detail"] } : {})
+  };
 }

--- a/packages/mcp/src/tools/tool-support.ts
+++ b/packages/mcp/src/tools/tool-support.ts
@@ -98,8 +98,8 @@ export interface VerificationStepSummary {
   command: string;
   launched: boolean;
   exitCode?: number;
-  timedOut: boolean;
-  fastFail: boolean;
+  timedOut?: boolean;
+  fastFail?: boolean;
   detail?: string;
 }
 
@@ -755,8 +755,8 @@ function normalizeVerificationStep(candidate: unknown): VerificationStepSummary 
     command: candidate["command"],
     launched: candidate["launched"],
     ...(typeof candidate["exitCode"] === "number" ? { exitCode: candidate["exitCode"] } : {}),
-    timedOut: candidate["timedOut"] === true,
-    fastFail: candidate["fastFail"] !== false,
+    ...(typeof candidate["timedOut"] === "boolean" ? { timedOut: candidate["timedOut"] } : {}),
+    ...(typeof candidate["fastFail"] === "boolean" ? { fastFail: candidate["fastFail"] } : {}),
     ...(typeof candidate["detail"] === "string" ? { detail: candidate["detail"] } : {})
   };
 }

--- a/packages/mcp/tests/mcp-tools.test.ts
+++ b/packages/mcp/tests/mcp-tools.test.ts
@@ -674,6 +674,81 @@ describe("martinTriageRunsTool", () => {
     });
   });
 
+  it("surfaces verification warnings and step evidence from the authoritative MartinLoop verifier", async () => {
+    await withRunsRoot(async (runsRoot) => {
+      const loop = {
+        ...makeLoopRecord({ costUsd: 2 }),
+        loopId: "loop_verification_warning_steps",
+        status: "completed",
+        lifecycleState: "completed",
+        attempts: [
+          {
+            attemptId: "att_warning_steps",
+            index: 1,
+            adapterId: "codex-cli",
+            model: "gpt-5-codex",
+            summary: "Verification passed with contradiction warnings."
+          }
+        ],
+        events: [
+          {
+            eventId: "evt_1",
+            timestamp: "2026-06-06T04:00:00.000Z",
+            type: "verification.completed",
+            lifecycleState: "verifying",
+            payload: {
+              attemptId: "att_warning_steps",
+              attemptIndex: 1,
+              passed: true,
+              summary: "All 1 verification step(s) passed.",
+              warnings: [
+                "Adapter output reported a tool-launch problem before MartinLoop ran its own verifier: CreateProcessAsUserW failed: 5"
+              ],
+              steps: [
+                {
+                  command: "npm test",
+                  launched: true,
+                  exitCode: 0,
+                  timedOut: false,
+                  fastFail: true,
+                  detail: "tests passed"
+                }
+              ]
+            }
+          }
+        ]
+      };
+
+      await mkdir(join(runsRoot, loop.loopId), { recursive: true });
+      await writeFile(join(runsRoot, loop.loopId, "loop-record.json"), JSON.stringify(loop), "utf8");
+
+      const verification = await martinGetVerificationResultsTool({ loopId: loop.loopId });
+      const dossier = await martinRunDossierTool({ loopId: loop.loopId });
+
+      expect(verification.verification.status).toBe("passed");
+      expect(verification.verification.warnings).toContain(
+        "Adapter output reported a tool-launch problem before MartinLoop ran its own verifier: CreateProcessAsUserW failed: 5"
+      );
+      expect(verification.verification.steps).toEqual([
+        expect.objectContaining({
+          command: "npm test",
+          launched: true,
+          exitCode: 0
+        })
+      ]);
+      expect(dossier.verification.warnings).toContain(
+        "Adapter output reported a tool-launch problem before MartinLoop ran its own verifier: CreateProcessAsUserW failed: 5"
+      );
+      expect(dossier.verification.steps).toEqual([
+        expect.objectContaining({
+          command: "npm test",
+          launched: true,
+          exitCode: 0
+        })
+      ]);
+    });
+  });
+
   it("distinguishes unreadable ledger evidence from absent ledger verification evidence", async () => {
     await withRunsRoot(async (runsRoot) => {
       const loop = {

--- a/packages/mcp/tests/mcp-tools.test.ts
+++ b/packages/mcp/tests/mcp-tools.test.ts
@@ -749,6 +749,55 @@ describe("martinTriageRunsTool", () => {
     });
   });
 
+  it("does not fabricate missing timedOut or fastFail fields in verification step summaries", async () => {
+    await withRunsRoot(async (runsRoot) => {
+      const loop = {
+        ...makeLoopRecord({ costUsd: 2 }),
+        loopId: "loop_sparse_verification_steps",
+        status: "completed",
+        lifecycleState: "completed",
+        attempts: [
+          {
+            attemptId: "att_sparse_steps",
+            index: 1,
+            adapterId: "codex-cli",
+            model: "gpt-5-codex",
+            summary: "Verification passed with sparse step metadata."
+          }
+        ],
+        events: [
+          {
+            eventId: "evt_sparse_steps",
+            timestamp: "2026-06-06T04:05:00.000Z",
+            type: "verification.completed",
+            lifecycleState: "verifying",
+            payload: {
+              attemptId: "att_sparse_steps",
+              attemptIndex: 1,
+              passed: true,
+              summary: "All 1 verification step(s) passed.",
+              steps: [
+                {
+                  command: "npm test",
+                  launched: true
+                }
+              ]
+            }
+          }
+        ]
+      };
+
+      await mkdir(join(runsRoot, loop.loopId), { recursive: true });
+      await writeFile(join(runsRoot, loop.loopId, "loop-record.json"), JSON.stringify(loop), "utf8");
+
+      const verification = await martinGetVerificationResultsTool({ loopId: loop.loopId });
+      const dossier = await martinRunDossierTool({ loopId: loop.loopId });
+
+      expect(verification.verification.steps).toEqual([{ command: "npm test", launched: true }]);
+      expect(dossier.verification.steps).toEqual([{ command: "npm test", launched: true }]);
+    });
+  });
+
   it("distinguishes unreadable ledger evidence from absent ledger verification evidence", async () => {
     await withRunsRoot(async (runsRoot) => {
       const loop = {

--- a/scripts/release-matrix.mjs
+++ b/scripts/release-matrix.mjs
@@ -171,14 +171,30 @@ async function runCommand(step, options) {
 }
 
 export function createReleaseMatrixEnvironment(baseEnv = process.env) {
+  const ci = readEnvValueCaseInsensitive(baseEnv, "CI");
+  const confirmModulesPurge = readEnvValueCaseInsensitive(baseEnv, "npm_config_confirm_modules_purge");
+
   return {
     ...baseEnv,
-    CI: baseEnv.CI && baseEnv.CI.trim().length > 0 ? baseEnv.CI : "true",
+    CI: ci && ci.trim().length > 0 ? ci : "true",
     npm_config_confirm_modules_purge:
-      baseEnv.npm_config_confirm_modules_purge && baseEnv.npm_config_confirm_modules_purge.trim().length > 0
-        ? baseEnv.npm_config_confirm_modules_purge
-        : "false",
+      confirmModulesPurge && confirmModulesPurge.trim().length > 0 ? confirmModulesPurge : "false",
   };
+}
+
+function readEnvValueCaseInsensitive(baseEnv, key) {
+  const direct = baseEnv[key];
+  if (typeof direct === "string") {
+    return direct;
+  }
+
+  const matchedKey = Object.keys(baseEnv).find((candidate) => candidate.toLowerCase() === key.toLowerCase());
+  if (!matchedKey) {
+    return undefined;
+  }
+
+  const matchedValue = baseEnv[matchedKey];
+  return typeof matchedValue === "string" ? matchedValue : undefined;
 }
 
 function logDirFor(options) {

--- a/scripts/release-matrix.mjs
+++ b/scripts/release-matrix.mjs
@@ -128,11 +128,12 @@ async function resolveReleaseMatrixOutputRoot(configuredOutputRoot) {
 async function runCommand(step, options) {
   const execution = resolveRcCommandExecution(step.command, process.platform);
   const stepLogPath = path.join(logDirFor(options), `${String(options.index).padStart(2, "0")}-${slugify(step.label)}.log`);
+  const env = createReleaseMatrixEnvironment(process.env);
 
   return new Promise((resolve, reject) => {
     const child = spawn(execution.command, execution.args, {
       cwd: options.cwd,
-      env: process.env,
+      env,
       stdio: ["ignore", "pipe", "pipe"],
       shell: execution.shell,
     });
@@ -167,6 +168,17 @@ async function runCommand(step, options) {
       reject(new Error(`Command failed (${code ?? "unknown"}): ${step.label}`));
     });
   });
+}
+
+export function createReleaseMatrixEnvironment(baseEnv = process.env) {
+  return {
+    ...baseEnv,
+    CI: baseEnv.CI && baseEnv.CI.trim().length > 0 ? baseEnv.CI : "true",
+    npm_config_confirm_modules_purge:
+      baseEnv.npm_config_confirm_modules_purge && baseEnv.npm_config_confirm_modules_purge.trim().length > 0
+        ? baseEnv.npm_config_confirm_modules_purge
+        : "false",
+  };
 }
 
 function logDirFor(options) {

--- a/scripts/tests/release-matrix.test.mjs
+++ b/scripts/tests/release-matrix.test.mjs
@@ -1,0 +1,37 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  createReleaseMatrixEnvironment,
+  createReleaseMatrixPlan,
+  resolveReleaseMatrixLane,
+} from "../release-matrix.mjs";
+
+test("createReleaseMatrixPlan keeps install first in every platform lane", () => {
+  const plan = createReleaseMatrixPlan({ rootDir: "C:/repo" });
+
+  assert.equal(plan.rootDir, "C:/repo");
+  assert.equal(plan.lanes.length, 3);
+  for (const lane of plan.lanes) {
+    assert.equal(lane.steps[0]?.command.join(" "), "pnpm install --frozen-lockfile");
+  }
+});
+
+test("resolveReleaseMatrixLane selects the correct local platform lane", () => {
+  const plan = createReleaseMatrixPlan({ rootDir: "C:/repo" });
+
+  assert.equal(resolveReleaseMatrixLane(plan, "win32").id, "windows");
+  assert.equal(resolveReleaseMatrixLane(plan, "darwin").id, "macos");
+  assert.equal(resolveReleaseMatrixLane(plan, "linux").id, "linux");
+});
+
+test("createReleaseMatrixEnvironment forces non-interactive install defaults", () => {
+  const env = createReleaseMatrixEnvironment({
+    PATH: process.env.PATH ?? "",
+    CI: "",
+    npm_config_confirm_modules_purge: "",
+  });
+
+  assert.equal(env.CI, "true");
+  assert.equal(env.npm_config_confirm_modules_purge, "false");
+});

--- a/scripts/tests/release-matrix.test.mjs
+++ b/scripts/tests/release-matrix.test.mjs
@@ -35,3 +35,23 @@ test("createReleaseMatrixEnvironment forces non-interactive install defaults", (
   assert.equal(env.CI, "true");
   assert.equal(env.npm_config_confirm_modules_purge, "false");
 });
+
+test("createReleaseMatrixEnvironment preserves explicit non-empty values", () => {
+  const env = createReleaseMatrixEnvironment({
+    PATH: process.env.PATH ?? "",
+    CI: "already-set",
+    npm_config_confirm_modules_purge: "preserve-me",
+  });
+
+  assert.equal(env.CI, "already-set");
+  assert.equal(env.npm_config_confirm_modules_purge, "preserve-me");
+});
+
+test("createReleaseMatrixEnvironment honors mixed-case install env keys", () => {
+  const env = createReleaseMatrixEnvironment({
+    PATH: process.env.PATH ?? "",
+    NPM_CONFIG_CONFIRM_MODULES_PURGE: "mixed-case-value",
+  });
+
+  assert.equal(env.npm_config_confirm_modules_purge, "mixed-case-value");
+});


### PR DESCRIPTION
## Summary
- harden verifier receipt truth so MartinLoop fails closed when Codex exits before the verifier runs
- keep context-integrity artifacts inside the active runs root instead of falling back to the default home store
- make `run --help` and `preflight --help` read-only so help output does not stamp workflow state
- preserve the existing 0.2.10 public copy, release notes, and verification updates for runs-root, help, and verifier evidence

## Verification
- pnpm lint
- pnpm test
- pnpm build
- pnpm public:copy-scan
- pnpm public:git-surface
- pnpm oss:validate
- pnpm public:smoke
- pnpm release:validate-local
- pnpm release:validate-local:install
- pnpm release:validate:platforms
- pnpm audit --prod --json
- live installed-tarball Windows Codex repro using explicit `--runs-dir`, `doctor`, `start`, `session-start`, `preflight`, `run`, `dossier`, and `runs verify`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `challenge` and `badge` CLI commands.
  * Added `--runs-dir` flag across multiple commands and a `--verify-only` option.
  * Help (`--help`/`-h`) now renders without entering governed-flow checks.
  * Badge generation uses a lightweight persisted-run probe for readiness while keeping defaults responsive.

* **Bug Fixes**
  * Contradictions between adapter and verifier are recorded as warnings.
  * Verification step evidence now surfaces launch state, exit/timed-out info, and step-level details.

* **Changed**
  * `bench` removed from the public CLI surface.
  * Help/version output reports the published root package version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->