### PR TITLE
fix: align runs verify latest with public release surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.2.11]
+
+### Fixed
+- **`runs verify --latest` now works on the public CLI** - the persisted verification view now honors `--latest` the same way `dossier` and `runs get` already do, including when `--runs-dir` points at an explicit store.
+- **Post-release selector parity is now aligned** - public phase guidance, release notes, and the shipped root package no longer disagree about the supported verification selector path.
+
 ## [0.2.10]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ npx martin-loop dossier --latest
 
 `start` and `tour` walk a new operator through the product flow. `doctor`, `session-start`, and `preflight` create the local receipts MartinLoop expects before a real governed run. If you intentionally need to bypass that local gate for a one-off run, use `--unsafe-allow-unguarded-run` explicitly.
 
-Release notes for the current root package: [MartinLoop 0.2.10](./docs/release/OSS-0.2.10-RELEASE-NOTES.md).
+Release notes for the current root package: [MartinLoop 0.2.11](./docs/release/OSS-0.2.11-RELEASE-NOTES.md).
 
 ## What It Does
 
@@ -114,7 +114,7 @@ npx martin-loop mcp print-config --host gemini --transport stdio --profile full-
 npx martin-loop mcp print-config --host generic --transport stdio --profile github-review
 ```
 
-The root `martin-loop` package and the standalone `@martinloop/mcp` package move on separate version lines. The root package is `0.2.10`; the current standalone MCP package is `0.2.7`.
+The root `martin-loop` package and the standalone `@martinloop/mcp` package move on separate version lines. The root package is `0.2.11`; the current standalone MCP package is `0.2.7`.
 
 More detail: [MCP setup](./docs/getting-started/mcp.md), [MCP tool reference](./docs/reference/mcp-tools.md), and [MCP compatibility](./docs/reference/mcp-compatibility.md).
 

--- a/docs/release/OSS-0.2.11-RELEASE-NOTES.md
+++ b/docs/release/OSS-0.2.11-RELEASE-NOTES.md
@@ -1,0 +1,28 @@
+## MartinLoop OSS `0.2.11`
+
+MartinLoop `0.2.11` is a narrow root-package follow-up to `0.2.10`. It closes the remaining public selector mismatch that was still visible after the trust hotfix shipped.
+
+### Fixed
+
+- **`runs verify --latest` now works on the packaged public CLI** - the verification view now accepts `--latest` and resolves it against the same persisted runs root used by `dossier` and `runs get`.
+- **Public guidance and shipped behavior are aligned again** - phase-command-center hints, CLI help, and public release guidance no longer point at a selector path the packaged CLI rejects.
+
+### Why this patch exists
+
+`0.2.10` fixed verifier trust and explicit runs-root handling, but a post-publish packaged-artifact repro still found one remaining selector mismatch: `martin-loop runs verify --latest` returned `invalid_input` even though public guidance already referenced it. `0.2.11` fixes that last public parity issue without widening scope.
+
+### Public smoke path
+
+```bash
+npx martin-loop doctor --runs-dir ~/.martin/runs
+npx martin-loop session-start --runs-dir ~/.martin/runs
+npx martin-loop preflight "Summarize the workspace and confirm the verifier is green" --verify "npm test" --runs-dir ~/.martin/runs
+npx martin-loop run "Summarize the workspace and confirm the verifier is green" --proof --verify "npm test" --runs-dir ~/.martin/runs
+npx martin-loop runs verify --latest --runs-dir ~/.martin/runs
+npx martin-loop dossier --latest --runs-dir ~/.martin/runs
+```
+
+### Notes
+
+- This is still a **root-package-only** patch release.
+- The standalone `@martinloop/mcp` package line remains separate.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "martin-loop",
   "private": false,
-  "version": "0.2.10",
+  "version": "0.2.11",
   "type": "module",
   "description": "Open-source command center for governed AI coding agents with built-in onboarding, hard gates, CLI, MCP, and run receipts.",
   "packageManager": "pnpm@10.33.0",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -551,7 +551,7 @@ export function parseCliArguments(args: string[]): ParsedCliArguments {
     if (subcommand === "verify") {
       return {
         command: "runs_verify",
-        selector: parseRunSelector(subcommandArgs, { allowLatest: false })
+        selector: parseRunSelector(subcommandArgs, { allowLatest: true })
       };
     }
     return { command: "help" };
@@ -654,7 +654,7 @@ export function renderCliHelp(): string {
     "  martin-loop runs list [options]",
     "  martin-loop runs get (--loop-id <id> | --file <path> | --latest) [options]",
     "  martin-loop runs attempt (--loop-id <id> | --file <path>) [--attempt-index <n>] [options]",
-    "  martin-loop runs verify (--loop-id <id> | --file <path>) [options]",
+    "  martin-loop runs verify (--loop-id <id> | --file <path> | --latest) [options]",
     "  martin-loop mcp print-config --host <codex|claude|gemini|generic> [--scope <user|project|local>] [options]",
     "  martin-loop mcp install --host <codex|claude|gemini|generic> [--scope <user|project|local>] [--dry-run] [options]",
     "  martin-loop demo [--dir <path>] [--force]",

--- a/packages/cli/tests/cli.test.ts
+++ b/packages/cli/tests/cli.test.ts
@@ -158,11 +158,12 @@ describe.sequential("executeCli", () => {
     }
   });
 
-  it("keeps the public help surface honest for 0.2.10", () => {
+  it("keeps the public help surface honest for 0.2.11", () => {
     const help = renderCliHelp();
 
     expect(help).not.toContain("martin-loop bench");
     expect(help).toContain("martin-loop badge [--format svg|json] [--runs-dir <path>]");
+    expect(help).toContain("martin-loop runs verify (--loop-id <id> | --file <path> | --latest) [options]");
   });
 
   it("renders the built-in command guide", async () => {

--- a/packages/cli/tests/operator-commands.test.ts
+++ b/packages/cli/tests/operator-commands.test.ts
@@ -385,6 +385,9 @@ describe.sequential("operator commands", () => {
       const verify = JSON.parse(
         (await executeCli(["--json", "runs", "verify", "--loop-id", loop.loopId])).stdout
       );
+      const verifyLatest = JSON.parse(
+        (await executeCli(["--json", "runs", "verify", "--latest", "--runs-dir", runsRoot])).stdout
+      );
       const triage = JSON.parse((await executeCli(["--json", "triage"])).stdout);
 
       expect(dossier.command).toBe("dossier");
@@ -395,7 +398,10 @@ describe.sequential("operator commands", () => {
       expect(attempt.command).toBe("runs_attempt");
       expect(attempt.attempt.index).toBe(1);
       expect(verify.command).toBe("runs_verify");
+      expect(verifyLatest.command).toBe("runs_verify");
+      expect(verifyLatest.loopId).toBe(loop.loopId);
       expect(verify.verification.summary).toContain("verification lane");
+      expect(verifyLatest.verification.summary).toContain("verification lane");
       expect(triage.command).toBe("triage");
       expect(triage.findings[0].loopId).toBe(loop.loopId);
       expect(triage.findings[0].reasons).toContain("verification_failed");

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -4,7 +4,7 @@ Governed MCP server for AI coding agents with budgets, receipts, and review-read
 
 `@martinloop/mcp` is the standalone MartinLoop server for MCP hosts. It stays local-first and stdio-first, and it gives hosts one clear execution path: check readiness, plan the work, preflight the contract, run it, and inspect the result with enough evidence to decide what happens next.
 
-The root `martin-loop` package and the standalone `@martinloop/mcp` package move on separate version lines. For the current root release, see [MartinLoop 0.2.10 release notes](../../docs/release/OSS-0.2.10-RELEASE-NOTES.md).
+The root `martin-loop` package and the standalone `@martinloop/mcp` package move on separate version lines. For the current root release, see [MartinLoop 0.2.11 release notes](../../docs/release/OSS-0.2.11-RELEASE-NOTES.md).
 
 ## What is new in 0.2.7
 

--- a/scripts/tests/mcp-release-docs.test.mjs
+++ b/scripts/tests/mcp-release-docs.test.mjs
@@ -242,17 +242,16 @@ test("CLI package readme links stay inside the cleaned docs tree", async () => {
   }
 });
 
-test("root release note captures onboarding and governance changes", async () => {
+test("root release note stays public-facing and runnable", async () => {
   const releaseNotes = await readRepoFile(path.join("docs", "release", `OSS-${rootPackageJson.version}-RELEASE-NOTES.md`));
 
-  assert.match(releaseNotes, /martin-loop start/);
-  assert.match(releaseNotes, /martin-loop tour/);
+  assert.match(releaseNotes, new RegExp(`0\\.${rootPackageJson.version.split(".").slice(1).join("\\.")}`));
+  assert.match(releaseNotes, /root-package-only|root package/i);
+  assert.match(releaseNotes, /runs verify --latest/i);
+  assert.match(releaseNotes, /dossier --latest/i);
   assert.match(releaseNotes, /doctor/i);
   assert.match(releaseNotes, /session-start/i);
   assert.match(releaseNotes, /preflight/i);
-  assert.match(releaseNotes, /--unsafe-allow-unguarded-run/);
-  assert.match(releaseNotes, /vendored internal CLI bin surface/i);
-  assert.match(releaseNotes, /root-release-guard/i);
 });
 
 test("MCP release note matches the current package line and the governed flow", async () => {


### PR DESCRIPTION
## Summary
- allow `martin-loop runs verify --latest` on the public CLI so it matches the shipped command guidance
- align the root README, MCP README, changelog, and root release notes with the current `0.2.11` root package line
- tighten the docs test harness so narrow patch releases stay public-facing and runnable without dragging old/internal-ish release-note expectations forward

## Verification
- `pnpm --filter @martin/cli exec vitest run tests/operator-commands.test.ts tests/cli.test.ts`
- `node --test scripts/tests/mcp-release-docs.test.mjs scripts/tests/readme-public-surface.test.mjs`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm public:copy-scan`
- `pnpm public:git-surface`
- `pnpm oss:validate`
- `pnpm public:smoke`
- `pnpm release:validate-local`
- `pnpm release:validate-local:install`
- `pnpm release:validate:platforms`
- `pnpm audit --prod --json`

## Evidence
- full RC gate logs: `C:\Users\Torram\AppData\Local\Temp\martin-0.2.11-rc-gate-20260606-203748`
- packaged selector-parity repro: `C:\Users\Torram\AppData\Local\Temp\martin-0.2.11-selector-repro-1f97b0096d054faba00ad5b5e1a2b031\app\evidence\selector-parity-summary.json`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `runs verify --latest` now works on the public CLI, including with explicit `--runs-dir` argument.
  * Corrected misalignment between public guidance, help text, and actual selector-path behavior.

* **Documentation**
  * Updated release notes, README, and package documentation for version 0.2.11 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->