### PR TITLE
Surface tampered receipt state across CLI and MCP

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -72,6 +72,7 @@ import {
   readLocalCorpusRisk,
   resolveCliEnvironment,
   resolveInvocationRoot,
+  resolveReceiptScope,
   triagePersistedLoops
 } from "./run-store.js";
 import { CliCommandError, renderCliError, renderCliSuccess } from "./ux.js";
@@ -1349,7 +1350,7 @@ async function executeDossierCommand(
       `Source: ${detail.source}`
     ],
     quiet: detail.loop.loopId,
-    warnings: detail.warnings
+    warnings: [...detail.warnings, ...verification.warnings]
   });
 }
 
@@ -1384,12 +1385,15 @@ async function executeRunsGetCommand(
   const detail = await loadPersistedLoop(selector);
   const verification = buildVerificationSummary(detail.loop);
   const artifacts = buildArtifactSummary(detail.loop);
+  const receiptScope = resolveReceiptScope(detail.loop, detail.runsRoot);
 
   return renderCliSuccess(outputMode, {
     data: {
       command: "runs_get",
       source: detail.source,
       loop: detail.loop,
+      receiptIntegrity: detail.integrity,
+      ...(receiptScope ? { receiptScope } : {}),
       verification,
       artifacts
     },
@@ -1401,7 +1405,7 @@ async function executeRunsGetCommand(
       `Source: ${detail.source}`
     ],
     quiet: detail.loop.loopId,
-    warnings: detail.warnings
+    warnings: [...detail.warnings, ...verification.warnings]
   });
 }
 
@@ -1437,12 +1441,15 @@ async function executeRunsVerifyCommand(
 ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
   const detail = await loadPersistedLoop(selector);
   const verification = buildVerificationSummary(detail.loop);
+  const receiptScope = resolveReceiptScope(detail.loop, detail.runsRoot);
 
   return renderCliSuccess(outputMode, {
     data: {
       command: "runs_verify",
       loopId: detail.loop.loopId,
       source: detail.source,
+      receiptIntegrity: detail.integrity,
+      ...(receiptScope ? { receiptScope } : {}),
       verification
     },
     human: [

--- a/packages/cli/src/run-store.ts
+++ b/packages/cli/src/run-store.ts
@@ -735,13 +735,13 @@ export function resolveReceiptScope(loop: LoopRecord, runsRoot?: string): Receip
     return loop.receiptScope;
   }
 
-  if (!loop.task.repoRoot && !runsRoot) {
+  if (!loop.task?.repoRoot && !runsRoot) {
     return undefined;
   }
 
   return {
-    ...(loop.task.repoRoot ? { repoRoot: loop.task.repoRoot } : {}),
-    ...(loop.task.repoRoot ? { workingDirectory: loop.task.repoRoot } : {}),
+    ...(loop.task?.repoRoot ? { repoRoot: loop.task.repoRoot } : {}),
+    ...(loop.task?.repoRoot ? { workingDirectory: loop.task.repoRoot } : {}),
     ...(runsRoot ? { runsRoot } : {})
   };
 }

--- a/packages/cli/src/run-store.ts
+++ b/packages/cli/src/run-store.ts
@@ -10,7 +10,8 @@ import type {
   LoopRecord,
   MartinRunListFilters,
   MartinRunSelector,
-  ReceiptIntegritySummary
+  ReceiptIntegritySummary,
+  ReceiptScope
 } from "@martin/contracts";
 
 import { CliCommandError } from "./ux.js";
@@ -450,7 +451,11 @@ export function buildArtifactSummary(loop: LoopRecord): ArtifactSummary {
   };
 }
 
-export function buildRunReceipt(loop: LoopRecord, verification = buildVerificationSummary(loop)): Record<string, unknown> {
+export function buildRunReceipt(
+  loop: LoopRecord,
+  verification = buildVerificationSummary(loop),
+  receiptScope = resolveReceiptScope(loop)
+): Record<string, unknown> {
   const latestAttempt = loop.attempts.at(-1);
   const integrity = resolveReceiptIntegrity(loop);
   const trustworthy = integrity.state === "verified";
@@ -469,6 +474,7 @@ export function buildRunReceipt(loop: LoopRecord, verification = buildVerificati
   return {
     trustworthy,
     receiptIntegrity: integrity,
+    ...(receiptScope ? { receiptScope } : {}),
     whatHappened: latestAttempt?.summary ?? verification.summary ?? loop.task.objective,
     whatMartinPrevented: prevented,
     tokenWasteReceipt: {
@@ -506,7 +512,8 @@ export function buildRunReceipt(loop: LoopRecord, verification = buildVerificati
 export function buildRunDossier(detail: PersistedLoopDetail): Record<string, unknown> {
   const verification = buildVerificationSummary(detail.loop);
   const artifactSummary = buildArtifactSummary(detail.loop);
-  const receipt = buildRunReceipt(detail.loop, verification);
+  const receiptScope = resolveReceiptScope(detail.loop, detail.runsRoot);
+  const receipt = buildRunReceipt(detail.loop, verification, receiptScope);
 
   return {
     source: detail.source,
@@ -517,6 +524,7 @@ export function buildRunDossier(detail: PersistedLoopDetail): Record<string, unk
     },
     loop: detail.loop,
     receiptIntegrity: detail.integrity,
+    ...(receiptScope ? { receiptScope } : {}),
     verification,
     receipt,
     artifacts: artifactSummary,
@@ -720,6 +728,22 @@ function resolveReceiptIntegrity(loop: LoopRecord): ReceiptIntegritySummary {
       reason: "Receipt integrity metadata was not available on the loop record."
     }
   );
+}
+
+export function resolveReceiptScope(loop: LoopRecord, runsRoot?: string): ReceiptScope | undefined {
+  if (loop.receiptScope) {
+    return loop.receiptScope;
+  }
+
+  if (!loop.task.repoRoot && !runsRoot) {
+    return undefined;
+  }
+
+  return {
+    ...(loop.task.repoRoot ? { repoRoot: loop.task.repoRoot } : {}),
+    ...(loop.task.repoRoot ? { workingDirectory: loop.task.repoRoot } : {}),
+    ...(runsRoot ? { runsRoot } : {})
+  };
 }
 
 async function resolveReceiptEvidencePath(runDirectory: string): Promise<string> {

--- a/packages/cli/tests/operator-commands.test.ts
+++ b/packages/cli/tests/operator-commands.test.ts
@@ -2,12 +2,13 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { createLoopRecord, type LoopEventDraft } from "@martin/contracts";
+import { writeReceiptIntegrityMaterial } from "@martin/core";
+import { createLoopRecord, type LoopEventDraft, type LoopRecord } from "@martin/contracts";
 import { describe, expect, it } from "vitest";
 
 import { executeCli } from "../src/index.js";
 
-function makeLoopRecord() {
+function makeLoopRecord(): LoopRecord {
   const loop = createLoopRecord({
     workspaceId: "ws_ops",
     projectId: "proj_runtime",
@@ -31,7 +32,7 @@ function makeLoopRecord() {
   });
 
   const attemptId = "att_001";
-  const events: LoopEventDraft[] = [
+  const events: Array<LoopEventDraft & { lifecycleState: LoopRecord["lifecycleState"] }> = [
     {
       type: "run.started",
       lifecycleState: "running",
@@ -188,6 +189,90 @@ describe("operator commands", () => {
       expect(triage.command).toBe("triage");
       expect(triage.findings[0].loopId).toBe(loop.loopId);
       expect(triage.findings[0].reasons).toContain("verification_failed");
+    });
+  });
+
+  it("fails closed on tampered canonical receipts and surfaces receipt scope on persisted-run commands", async () => {
+    await withRunsRoot(async (runsRoot) => {
+      const repoRoot = join(runsRoot, "workspace");
+      const workingDirectory = join(repoRoot, "packages", "cli");
+      const baseLoop = makeLoopRecord();
+      const loop = {
+        ...baseLoop,
+        task: {
+          ...baseLoop.task,
+          repoRoot
+        },
+        receiptScope: {
+          repoRoot,
+          workingDirectory,
+          invocationRoot: repoRoot,
+          runsRoot
+        }
+      };
+      const loopDir = join(runsRoot, loop.loopId);
+      const loopRecordPath = join(loopDir, "loop-record.json");
+      const ledgerPath = join(loopDir, "ledger.jsonl");
+      const ledgerEntries = loop.events;
+
+      await mkdir(loopDir, { recursive: true });
+      await writeFile(loopRecordPath, JSON.stringify(loop, null, 2), "utf8");
+      await writeFile(
+        ledgerPath,
+        ledgerEntries.map((entry) => JSON.stringify(entry)).join("\n").concat("\n"),
+        "utf8"
+      );
+      await writeReceiptIntegrityMaterial({
+        runId: loop.loopId,
+        runsRoot,
+        loopRecord: loop,
+        ledgerEntries,
+        scope: loop.receiptScope,
+        signedAt: loop.updatedAt
+      });
+
+      const tamperedLoop = {
+        ...loop,
+        status: "completed" as const,
+        updatedAt: "2026-05-16T12:05:00.000Z"
+      };
+      await writeFile(loopRecordPath, JSON.stringify(tamperedLoop, null, 2), "utf8");
+
+      const dossier = JSON.parse((await executeCli(["--json", "dossier", "--loop-id", loop.loopId])).stdout);
+      const getRun = JSON.parse((await executeCli(["--json", "runs", "get", "--loop-id", loop.loopId])).stdout);
+      const verify = JSON.parse(
+        (await executeCli(["--json", "runs", "verify", "--loop-id", loop.loopId])).stdout
+      );
+
+      for (const payload of [dossier, getRun, verify]) {
+        expect(payload.receiptIntegrity.state).toBe("tamper_detected");
+        expect(payload.receiptScope).toMatchObject({
+          repoRoot,
+          workingDirectory,
+          invocationRoot: repoRoot,
+          runsRoot
+        });
+      }
+
+      expect(dossier.receipt.receiptScope).toMatchObject({
+        repoRoot,
+        workingDirectory,
+        invocationRoot: repoRoot,
+        runsRoot
+      });
+      expect(dossier.receipt.trustworthy).toBe(false);
+      expect(dossier.verification.warnings).toContain(
+        "Receipt integrity is tamper_detected; persisted verifier evidence is not trustworthy yet."
+      );
+      expect(dossier.warnings).toContain(
+        "Receipt integrity is tamper_detected; persisted verifier evidence is not trustworthy yet."
+      );
+      expect(getRun.warnings).toContain(
+        "Receipt integrity is tamper_detected; persisted verifier evidence is not trustworthy yet."
+      );
+      expect(verify.warnings).toContain(
+        "Receipt integrity is tamper_detected; persisted verifier evidence is not trustworthy yet."
+      );
     });
   });
 

--- a/packages/mcp/src/tools/get-run.ts
+++ b/packages/mcp/src/tools/get-run.ts
@@ -7,7 +7,7 @@ import {
   buildVerificationSummary
 } from "./tool-support.js";
 import { loadDetailedLoopRecord, readLedgerEvents } from "./run-store.js";
-import type { ReceiptIntegritySummary } from "@martin/contracts";
+import type { ReceiptIntegritySummary, ReceiptScope } from "@martin/contracts";
 
 export interface MartinGetRunInput {
   file?: string;
@@ -24,6 +24,7 @@ export interface MartinGetRunOutput {
   cost: ReturnType<typeof buildCostSnapshot>;
   verification: ReturnType<typeof buildVerificationSummary>;
   receiptIntegrity: ReceiptIntegritySummary;
+  receiptScope?: ReceiptScope;
   artifacts: ReturnType<typeof buildArtifactSummary>;
   inspection: {
     runsRoot: string;
@@ -49,6 +50,7 @@ export async function martinGetRunTool(
     cost: buildCostSnapshot(detail.loop.cost),
     verification,
     receiptIntegrity: resolveReceiptIntegrity(detail.loop),
+    ...(detail.loop.receiptScope ? { receiptScope: detail.loop.receiptScope } : {}),
     artifacts: buildArtifactSummary(detail.loop),
     inspection: {
       runsRoot: detail.runsRoot,

--- a/packages/mcp/src/tools/get-verification-results.ts
+++ b/packages/mcp/src/tools/get-verification-results.ts
@@ -1,6 +1,6 @@
 import { buildLoopPreview, buildVerificationSummary, resolveReceiptIntegrity } from "./tool-support.js";
 import { loadDetailedLoopRecord, readLedgerEvents } from "./run-store.js";
-import type { ReceiptIntegritySummary } from "@martin/contracts";
+import type { ReceiptIntegritySummary, ReceiptScope } from "@martin/contracts";
 
 export interface MartinGetVerificationResultsInput {
   file?: string;
@@ -14,6 +14,7 @@ export interface MartinGetVerificationResultsOutput {
   loop: ReturnType<typeof buildLoopPreview>;
   verification: ReturnType<typeof buildVerificationSummary>;
   receiptIntegrity: ReceiptIntegritySummary;
+  receiptScope?: ReceiptScope;
   warnings: string[];
 }
 
@@ -30,6 +31,7 @@ export async function martinGetVerificationResultsTool(
     loop: buildLoopPreview(detail.loop),
     verification,
     receiptIntegrity: resolveReceiptIntegrity(detail.loop),
+    ...(detail.loop.receiptScope ? { receiptScope: detail.loop.receiptScope } : {}),
     warnings: [...detail.warnings, ...verification.warnings]
   };
 }

--- a/packages/mcp/src/tools/run-dossier.ts
+++ b/packages/mcp/src/tools/run-dossier.ts
@@ -18,7 +18,7 @@ import {
 import { readRunControlState } from "./run-controls.js";
 import { martinEvalTool } from "./eval.js";
 import { assessRunRisk, inspectRepoSignals } from "./workflow-governance.js";
-import type { ReceiptIntegritySummary } from "@martin/contracts";
+import type { ReceiptIntegritySummary, ReceiptScope } from "@martin/contracts";
 
 export interface MartinRunDossierInput {
   file?: string;
@@ -35,6 +35,7 @@ export interface MartinRunDossierOutput {
   budget: ReturnType<typeof buildBudgetSnapshot>;
   cost: ReturnType<typeof buildCostSnapshot>;
   receiptIntegrity: ReceiptIntegritySummary;
+  receiptScope?: ReceiptScope;
   attempts: Array<{
     index: number;
     attemptId?: string;
@@ -131,6 +132,7 @@ export async function martinRunDossierTool(
     budget: buildBudgetSnapshot(detail.loop.budget),
     cost: buildCostSnapshot(detail.loop.cost),
     receiptIntegrity: resolveReceiptIntegrity(detail.loop),
+    ...(detail.loop.receiptScope ? { receiptScope: detail.loop.receiptScope } : {}),
     attempts,
     verification,
     artifacts: buildArtifactSummary(detail.loop),

--- a/packages/mcp/src/tools/run-store.ts
+++ b/packages/mcp/src/tools/run-store.ts
@@ -5,6 +5,7 @@ import {
   readLatestLoopRecordFromFile,
   readLoopRecordsFromFile,
   resolveRunsRoot,
+  verifyReceiptIntegrityFromFiles,
   type LedgerEvent
 } from "@martin/core";
 
@@ -42,6 +43,32 @@ export interface DetailedLoopSource {
   canonicalRunDirectory?: string;
   canonicalLoopRecordPath?: string;
   ledgerPath?: string;
+}
+
+async function attachReceiptIntegrity(detail: DetailedLoopSource): Promise<DetailedLoopSource> {
+  const integrity =
+    detail.canonicalLoopRecordPath && detail.canonicalRunDirectory
+      ? await verifyReceiptIntegrityFromFiles({
+          runId: detail.loop.loopId,
+          runsRoot: detail.runsRoot,
+          loopRecordPath: detail.canonicalLoopRecordPath,
+          ledgerPath: path.join(detail.canonicalRunDirectory, "ledger.jsonl")
+        }).catch(() => ({
+          state: "unsigned" as const,
+          reason: "Receipt integrity verification could not be completed."
+        }))
+      : ({
+          state: "unsigned" as const,
+          reason: "Receipt integrity is only available for canonical run directories."
+        });
+
+  return {
+    ...detail,
+    loop: {
+      ...detail.loop,
+      receiptIntegrity: integrity
+    }
+  };
 }
 
 export interface LoopListInput {
@@ -220,14 +247,14 @@ export async function loadDetailedLoopRecord(input: {
         const canonicalStats = await safeStat(canonicalLoopRecordPath);
         if (canonicalStats?.isFile()) {
           const loop = await readCanonicalLoopRecord(canonicalLoopRecordPath);
-          return buildDetailedLoopSource({
+          return await attachReceiptIntegrity(buildDetailedLoopSource({
             source: canonicalLoopRecordPath,
             sourceKind: "file",
             runsRoot,
             loop,
             canonicalLoopRecordPath,
             canonicalRunDirectory: path.dirname(canonicalLoopRecordPath)
-          });
+          }));
         }
       }
 
@@ -243,10 +270,10 @@ export async function loadDetailedLoopRecord(input: {
         runsRoot,
         loop
       });
-      return {
+      return await attachReceiptIntegrity({
         ...detail,
         warnings: [...detail.warnings, ...inspected.warnings]
-      };
+      });
     }
 
     const latest = await readLatestLoopRecordFromFile(targetPath);
@@ -256,22 +283,22 @@ export async function loadDetailedLoopRecord(input: {
 
     if (path.basename(targetPath) === "loop-record.json") {
       const loop = await readCanonicalLoopRecord(targetPath);
-      return buildDetailedLoopSource({
+      return await attachReceiptIntegrity(buildDetailedLoopSource({
         source: targetPath,
         sourceKind: "file",
         runsRoot,
         loop,
         canonicalLoopRecordPath: targetPath,
         canonicalRunDirectory: path.dirname(targetPath)
-      });
+      }));
     }
 
-    return await buildDetailedLoopSourceFromDiscoveredLoop({
+    return await attachReceiptIntegrity(await buildDetailedLoopSourceFromDiscoveredLoop({
       source: targetPath,
       sourceKind: "file",
       runsRoot,
       loop: latest as InspectableLoopRecord
-    });
+    }));
   }
 
   if (input.loopId) {
@@ -279,14 +306,14 @@ export async function loadDetailedLoopRecord(input: {
     const canonicalStats = await safeStat(canonicalLoopRecordPath);
     if (canonicalStats?.isFile()) {
       const loop = await readCanonicalLoopRecord(canonicalLoopRecordPath);
-      return buildDetailedLoopSource({
+      return await attachReceiptIntegrity(buildDetailedLoopSource({
         source: canonicalLoopRecordPath,
         sourceKind: "loop_id",
         runsRoot,
         loop,
         canonicalLoopRecordPath,
         canonicalRunDirectory: path.dirname(canonicalLoopRecordPath)
-      });
+      }));
     }
 
     const inspected = await readAllLoopRecordsSafely(runsRoot);
@@ -301,10 +328,10 @@ export async function loadDetailedLoopRecord(input: {
       runsRoot,
       loop
     });
-    return {
+    return await attachReceiptIntegrity({
       ...detail,
       warnings: [...detail.warnings, ...inspected.warnings]
-    };
+    });
   }
 
   const inspected = await readAllLoopRecordsSafely(runsRoot);
@@ -319,10 +346,10 @@ export async function loadDetailedLoopRecord(input: {
     runsRoot,
     loop
   });
-  return {
+  return await attachReceiptIntegrity({
     ...detail,
     warnings: [...detail.warnings, ...inspected.warnings]
-  };
+  });
 }
 
 export async function loadAttemptFromLoop(input: {

--- a/packages/mcp/src/tools/run-store.ts
+++ b/packages/mcp/src/tools/run-store.ts
@@ -46,13 +46,16 @@ export interface DetailedLoopSource {
 }
 
 async function attachReceiptIntegrity(detail: DetailedLoopSource): Promise<DetailedLoopSource> {
+  const ledgerPath = detail.canonicalRunDirectory
+    ? await resolveReceiptEvidencePath(detail.canonicalRunDirectory)
+    : detail.ledgerPath;
   const integrity =
-    detail.canonicalLoopRecordPath && detail.canonicalRunDirectory
+    detail.canonicalLoopRecordPath && detail.canonicalRunDirectory && ledgerPath
       ? await verifyReceiptIntegrityFromFiles({
           runId: detail.loop.loopId,
           runsRoot: detail.runsRoot,
           loopRecordPath: detail.canonicalLoopRecordPath,
-          ledgerPath: path.join(detail.canonicalRunDirectory, "ledger.jsonl")
+          ledgerPath
         }).catch(() => ({
           state: "unsigned" as const,
           reason: "Receipt integrity verification could not be completed."
@@ -61,12 +64,15 @@ async function attachReceiptIntegrity(detail: DetailedLoopSource): Promise<Detai
           state: "unsigned" as const,
           reason: "Receipt integrity is only available for canonical run directories."
         });
+  const receiptScope = resolveReceiptScope(detail.loop, detail.runsRoot);
 
   return {
     ...detail,
+    ...(ledgerPath ? { ledgerPath } : {}),
     loop: {
       ...detail.loop,
-      receiptIntegrity: integrity
+      receiptIntegrity: integrity,
+      ...(receiptScope ? { receiptScope } : {})
     }
   };
 }
@@ -93,6 +99,37 @@ export type LedgerEventsWithDiagnostics = LedgerEvent[] & {
   unreadable?: boolean;
   ledgerPath?: string;
 };
+
+function resolveReceiptScope(
+  loop: InspectableLoopRecord,
+  runsRoot?: string
+): InspectableLoopRecord["receiptScope"] | undefined {
+  if (loop.receiptScope) {
+    return loop.receiptScope;
+  }
+
+  if (!loop.task?.repoRoot && !runsRoot) {
+    return undefined;
+  }
+
+  return {
+    ...(loop.task?.repoRoot ? { repoRoot: loop.task.repoRoot } : {}),
+    ...(loop.task?.repoRoot ? { workingDirectory: loop.task.repoRoot } : {}),
+    ...(runsRoot ? { runsRoot } : {})
+  };
+}
+
+async function resolveReceiptEvidencePath(runDirectory: string): Promise<string | undefined> {
+  for (const candidate of ["ledger.jsonl", "events.jsonl"]) {
+    const candidatePath = path.join(runDirectory, candidate);
+    const candidateStats = await safeStat(candidatePath);
+    if (candidateStats?.isFile()) {
+      return candidatePath;
+    }
+  }
+
+  return undefined;
+}
 
 export async function loadLoopRecordsForInspect(input: {
   file?: string;

--- a/packages/mcp/tests/mcp-tools.test.ts
+++ b/packages/mcp/tests/mcp-tools.test.ts
@@ -12,6 +12,7 @@ import { martinDoctorTool } from "../src/tools/doctor.js";
 import { martinGetVerificationResultsTool } from "../src/tools/get-verification-results.js";
 import { martinListRunsTool } from "../src/tools/list-runs.js";
 import { martinPreflightTool } from "../src/tools/preflight.js";
+import { martinRunDossierTool } from "../src/tools/run-dossier.js";
 import { runLoopTool } from "../src/tools/run-loop.js";
 import { martinTriageRunsTool } from "../src/tools/triage-runs.js";
 
@@ -752,6 +753,65 @@ describe("martinTriageRunsTool", () => {
       );
     });
   });
+
+  it(
+    "detects tampering in canonical persisted runs and surfaces receipt scope",
+    async () => {
+      await withRunsRoot(async (runsRoot) => {
+        const originalEnv = process.env.MARTIN_LIVE;
+        process.env.MARTIN_LIVE = "false";
+
+        try {
+          const result = await runLoopTool({
+            objective: "Create a canonical run, then tamper with the persisted loop record.",
+            workingDirectory: ".",
+            verificationPlan: ["pnpm --filter @martinloop/mcp test -- --runInBand"],
+            maxIterations: 1,
+            maxUsd: 1
+          });
+          const loopRecordPath = join(runsRoot, result.loopId, "loop-record.json");
+          const tamperWarning =
+            "Receipt integrity is tamper_detected; persisted verifier evidence is not trustworthy yet.";
+          const expectedReceiptScope = {
+            workingDirectory: process.cwd(),
+            repoRoot: process.cwd(),
+            runsRoot
+          };
+
+          const baselineRun = await martinGetRunTool({ loopId: result.loopId });
+          expect(baselineRun.receiptIntegrity.state).toBe("verified");
+          expect(baselineRun.receiptScope).toMatchObject(expectedReceiptScope);
+
+          const persisted = JSON.parse(await readFile(loopRecordPath, "utf8"));
+          persisted.task.title = "Tampered after receipt material was created.";
+          await writeFile(loopRecordPath, JSON.stringify(persisted, null, 2), "utf8");
+
+          const run = await martinGetRunTool({ loopId: result.loopId });
+          const verification = await martinGetVerificationResultsTool({ loopId: result.loopId });
+          const dossier = await martinRunDossierTool({ loopId: result.loopId });
+
+          expect(run.receiptIntegrity.state).toBe("tamper_detected");
+          expect(run.receiptScope).toMatchObject(expectedReceiptScope);
+          expect(run.warnings).toContain(tamperWarning);
+
+          expect(verification.receiptIntegrity.state).toBe("tamper_detected");
+          expect(verification.receiptScope).toMatchObject(expectedReceiptScope);
+          expect(verification.warnings).toContain(tamperWarning);
+
+          expect(dossier.receiptIntegrity.state).toBe("tamper_detected");
+          expect(dossier.receiptScope).toMatchObject(expectedReceiptScope);
+          expect(dossier.warnings).toContain(tamperWarning);
+        } finally {
+          if (originalEnv === undefined) {
+            delete process.env.MARTIN_LIVE;
+          } else {
+            process.env.MARTIN_LIVE = originalEnv;
+          }
+        }
+      });
+    },
+    20_000
+  );
 
   it("reports unavailable verification when the latest attempt has conflicting evidence", async () => {
     await withRunsRoot(async (runsRoot) => {

--- a/packages/mcp/tests/mcp-tools.test.ts
+++ b/packages/mcp/tests/mcp-tools.test.ts
@@ -2,6 +2,7 @@ import { chmod, mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile } from "n
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { writeReceiptIntegrityMaterial } from "@martin/core";
 import { createLoopRecord } from "@martin/contracts";
 import { describe, expect, it, vi } from "vitest";
 
@@ -812,6 +813,74 @@ describe("martinTriageRunsTool", () => {
     },
     20_000
   );
+
+  it("verifies canonical events.jsonl receipts and backfills missing receipt scope", async () => {
+    await withRunsRoot(async (runsRoot) => {
+      const repoRoot = join(runsRoot, "workspace");
+      const baseLoop = makeLoopRecord();
+      const loop = {
+        ...baseLoop,
+        task: {
+          ...baseLoop.task,
+          repoRoot
+        },
+        events: [
+          {
+            eventId: "evt_events_1",
+            timestamp: "2026-06-07T12:00:00.000Z",
+            type: "verification.completed" as const,
+            lifecycleState: "verifying" as const,
+            payload: {
+              attemptId: "att_events_1",
+              passed: true,
+              summary: "Verification completed from events.jsonl."
+            }
+          }
+        ]
+      };
+      const loopDir = join(runsRoot, loop.loopId);
+      const loopRecordPath = join(loopDir, "loop-record.json");
+      const eventsPath = join(loopDir, "events.jsonl");
+
+      await mkdir(loopDir, { recursive: true });
+      await writeFile(loopRecordPath, `${JSON.stringify(loop, null, 2)}\n`, "utf8");
+      await writeFile(
+        eventsPath,
+        loop.events.map((entry) => JSON.stringify(entry)).join("\n").concat("\n"),
+        "utf8"
+      );
+      await writeReceiptIntegrityMaterial({
+        runId: loop.loopId,
+        runsRoot,
+        loopRecord: loop,
+        ledgerEntries: loop.events,
+        scope: {
+          repoRoot,
+          workingDirectory: repoRoot,
+          runsRoot
+        },
+        signedAt: loop.updatedAt
+      });
+
+      const run = await martinGetRunTool({ loopId: loop.loopId });
+      const verification = await martinGetVerificationResultsTool({ loopId: loop.loopId });
+
+      expect(run.receiptIntegrity.state).toBe("verified");
+      expect(run.receiptScope).toMatchObject({
+        repoRoot,
+        workingDirectory: repoRoot,
+        runsRoot
+      });
+      expect(run.inspection.ledgerPath).toBe(eventsPath);
+
+      expect(verification.receiptIntegrity.state).toBe("verified");
+      expect(verification.receiptScope).toMatchObject({
+        repoRoot,
+        workingDirectory: repoRoot,
+        runsRoot
+      });
+    });
+  });
 
   it("reports unavailable verification when the latest attempt has conflicting evidence", async () => {
     await withRunsRoot(async (runsRoot) => {


### PR DESCRIPTION
## Summary
- re-verify canonical persisted receipts on MCP read paths before presenting proof state
- surface top-level receipt integrity and receipt scope on persisted-run CLI and MCP outputs
- fail closed on tampered receipt warnings and add regression coverage for canonical tamper replay

## Validation
- pnpm lint
- pnpm test
- pnpm build
- pnpm public:copy-scan
- pnpm public:git-surface
- pnpm oss:validate
- pnpm public:smoke
- pnpm release:matrix:local

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Run outputs now include receipt integrity status and optional receipt scope in dossier, run retrieval, and verification results.
  * Warnings now include both verification and detail-level messages for clearer reporting.
  * Ledger/inspection paths are surfaced for verified canonical runs.

* **Tests**
  * Integration tests added to validate receipt integrity, scope exposure, and tamper-detection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->