### PR TITLE
Release @martinloop/mcp 0.3.0

### DIFF
--- a/docs/oss/MCP-FOR-AI-AGENTS.md
+++ b/docs/oss/MCP-FOR-AI-AGENTS.md
@@ -1,109 +1,27 @@
 # MCP For AI Agents
 
-`@martinloop/mcp@0.2.7` is the current public governed execution cockpit package for coding-agent hosts. It is built for agents that need one bounded execution tool, a contract-first workflow, strong read-only inspection, and progressive discovery through MCP resources and prompts.
+`@martinloop/mcp@0.2.7` is the current public standalone MCP baseline for MartinLoop.
 
-It is intentionally local-first and stdio-first in the OSS package.
+It is built for hosts that need a governed local-first workflow, not a vague bag of tools.
 
-## Public Release Train
+## What it is good at
 
-- 0.1.4 operator foundation.
-- 0.2.0 cockpit expansion. 0.2.0 adds resources, resource templates, prompts, and read-only cockpit inspection.
-- 0.2.5 public MCP package line. 0.2.5 adds triage and degraded run-store hardening, plus the command-center workflow surfaces.
-- 0.2.7 usability and review release. 0.2.7 clarifies the guided path and tightens public package presentation.
+- guiding a host through the MartinLoop flow in the right order
+- running one bounded execution lane through `martin_run`
+- making saved run records easy to inspect after the work is done
+- giving both humans and agents a clean next step instead of raw receipts only
 
-## What This MCP Is Good At
+## Start here
 
-- governing code-change runs with budgets, retries, and verification gates
-- making persisted Martin run records inspectable after execution
-- giving hosts a small front door for execution and a rich read-only back door for analysis
-- helping both humans and agents debug failed runs without inventing new state
+1. `martin_doctor`
+2. `martin_plan`
+3. `martin_preflight`
+4. `martin_run`
+5. `martin_status` or `martin_logs`
+6. `martin_dossier`
+7. `martin_eval`
 
-It is not meant to be a generic browser, search engine, or shell replacement.
-
-## Published Interface
-
-### Tools
-
-- `martin_doctor`
-- `martin_plan`
-- `martin_preflight`
-- `martin_run`
-- `martin_inspect`
-- `martin_status`
-- `martin_logs`
-- `martin_pause`
-- `martin_cancel`
-- `martin_continue`
-- `martin_list_runs`
-- `martin_triage_runs`
-- `martin_get_run`
-- `martin_get_attempt`
-- `martin_get_verification_results`
-- `martin_run_dossier`
-- `martin_dossier`
-- `martin_eval`
-- `martin_pr_summary`
-- `martin_create_pr`
-- `martin_review_pr`
-
-### Resources
-
-- `martin://server/health`
-- `martin://runs/recent`
-- `martin://runs/triage`
-- `martin://runs/latest`
-- `martin://runs/latest/summary`
-- `martin://runs/latest/proof-card`
-- `martin://runs/latest/budget-status`
-- `martin://runs/latest/verifier-evidence`
-- `martin://runs/latest/rollback-evidence`
-- `martin://policies/current`
-- `martin://repo/risk-map`
-- `martin://verifiers/results`
-- `martin://agent/next-step`
-- `martin://guides/mcp-usage`
-- `martin://guides/agent-start`
-- `martin://guides/publish-readiness`
-
-### Resource templates
-
-- `martin://runs/{loopId}`
-- `martin://runs/{loopId}/dossier`
-- `martin://runs/{loopId}/attempts/{attemptIndex}`
-- `martin://runs/{loopId}/verification`
-
-### Prompts
-
-- `martin_start`
-- `martin_preflight`
-- `martin_triage`
-- `martin_resume`
-- `martin_prove`
-- `martin_release_check`
-- `martin_governed_coding_kickoff`
-- `martin_debug_failed_run`
-- `martin_publish_readiness_review`
-- `martin_triage_run_store`
-- `safe_bug_fix`
-- `write_tests_first`
-- `small_refactor`
-- `security_review`
-- `pr_review`
-- `release_check`
-
-## Host Flow
-
-1. Call `martin_doctor` first.
-2. Call `martin_plan` to propose scope, verifiers, budget, and risk without spending a run.
-3. Call `martin_preflight` to lock the run contract before non-trivial execution.
-4. Use `martin_run` as the only execution entrypoint.
-5. Use `martin_status` or `martin_logs` while the run is live.
-6. Use `martin_dossier` or the `martin_get_*` tools when compact evidence says deeper inspection is needed.
-7. Use `martin_eval` and PR helpers when the host needs review posture, not just raw receipts.
-
-### Recommended minimal allow-list
-
-If your host supports tool allow-lists, start here:
+If your host supports tool allow-lists, start with:
 
 - `martin_doctor`
 - `martin_plan`
@@ -112,7 +30,7 @@ If your host supports tool allow-lists, start here:
 - `martin_triage_runs`
 - `martin_dossier`
 
-Use `diagnostic` when the host needs deeper read-only run archaeology, `full-local` only when the host should execute `martin_run`, and `github-review` only when PR mutation is explicitly desired. This keeps tool bloat down without reducing operator power.
+That keeps the host useful without making execution implicit.
 
 ## Install
 
@@ -142,94 +60,10 @@ claude mcp add --transport stdio --scope user martin-loop -- cmd /c npx -y @mart
 }
 ```
 
-Codex-oriented hosts can also use `~/.codex/config.toml` or project-scoped `.codex/config.toml`:
+## What comes next in the train
 
-```toml
-[mcp_servers."martin-loop"]
-command = "npx"
-args = ["-y", "@martinloop/mcp"]
-cwd = "C:\\path\\to\\repo"
-startup_timeout_sec = 20
-tool_timeout_sec = 180
-enabled_tools = [
-  "martin_doctor",
-  "martin_preflight",
-  "martin_list_runs",
-  "martin_triage_runs",
-  "martin_run_dossier",
-]
-env = { MARTIN_RUNS_DIR = "C:\\path\\to\\runs" }
-```
+- `0.3.0` focuses on adoption and host onboarding.
+- `0.3.1` focuses on review and handoff.
+- `0.3.2` focuses on opt-in execution controls.
 
-If you generate config from the CLI, `npx martin-loop mcp install` stays conservative: it only writes when the target file is absent or when it already detects a Martin Loop block. For broader hand-maintained host configs, use `npx martin-loop mcp print-config` and merge the Martin section intentionally.
-
-If `CODEX_HOME` is set, Codex user-scope installs target `CODEX_HOME\\config.toml` instead of the default user path.
-
-### Gemini and generated profiles
-
-Martin Loop’s CLI can emit host-ready stdio config for:
-
-- `codex`
-- `claude`
-- `gemini`
-- `generic`
-
-Examples:
-
-```sh
-npx martin-loop mcp print-config --host codex --transport stdio --profile minimal
-npx martin-loop mcp print-config --host claude --transport stdio --profile diagnostic
-npx martin-loop mcp print-config --host gemini --transport stdio --profile full-local
-npx martin-loop mcp print-config --host generic --transport stdio --profile github-review
-```
-
-`npx martin-loop mcp install` accepts the same public local host, profile, scope, and platform options.
-
-Host notes:
-
-- Claude `local` scope is CLI-managed, not a repo file. Martin Loop calls Claude Code directly for that scope.
-- Gemini config uses `includeTools` and `trust` in `settings.json`.
-- The current live host matrix is proven with `pnpm --filter @martin/cli verify:hosts:live`.
-
-## Local Package Mode
-
-Use local `stdio` when you want the fastest local iteration loop and fully local execution. The OSS package docs describe the package-first MCP surface and do not claim hosted transport availability.
-
-## Safety and Data Model
-
-- `workingDirectory` remains bounded to the configured workspace root.
-- `file` and `runsDir` remain bounded to the configured Martin runs root.
-- `allowedPaths` and `deniedPaths` must stay repo-relative.
-- `martin_doctor` now scores repo hygiene, verifier readiness, safeguard posture, and recommended policy strength for the current workspace.
-- `martin_plan` is read-only and proposes file scope, verifier coverage, risk factors, and approval posture before preflight.
-- `martin_preflight` now emits a structured run contract with policy-pack, blocked paths, budgets, and risk scoring.
-- `martin_status`, `martin_logs`, `martin_pause`, `martin_cancel`, and `martin_continue` are the live control layer around `martin_run`.
-- `martin_dossier` is the preferred evidence entrypoint; `martin_run_dossier` remains for compatibility.
-- `martin_eval` converts raw receipts into mergeability and reviewability guidance.
-- Verification summaries come only from persisted `verification.completed` evidence. Missing evidence is reported as `unavailable`, not guessed.
-- Resources and prompts reuse the same persisted run data as the tools.
-- Compact resources are cheap by default: latest summary, proof card, budget status, verifier evidence, rollback evidence, and one next-step recommendation.
-- Resource JSON includes `metadata.serverVersion` and `metadata.discoveryRevision` so hosts can confirm which discovery surface they actually loaded.
-- Prompt descriptions include the same version/revision stamp for the same reason.
-- `listChanged` is not advertised yet. Martin Loop prefers an honest, versioned discovery surface over fake change notifications.
-- Martin Loop targets MCP-capable hosts and wrappers, not raw model weights directly. Open-source model families such as Gemma and Nemotron should use the `generic` host path through an MCP-aware shell or runtime.
-
-## Debugging
-
-Use the packaged live-inspection path before debugging a host config:
-
-```sh
-pnpm --filter @martinloop/mcp inspect:live
-```
-
-For UI-driven investigation with the official MCP Inspector:
-
-```sh
-npx @modelcontextprotocol/inspector --command npx --args "-y,@martinloop/mcp"
-```
-
-If those two paths look sane, move on to the host-specific config and timeout settings.
-
-## Recommendation Blurb
-
-> `@martinloop/mcp` is a stdio MCP server for governed AI coding work. It gives hosts a bounded execution entrypoint, contract-first planning and preflight, compact proof receipts, live run observability, rich read-only run inspection, MCP resources for discovery, and prompts for kickoff, debugging, review, and release checks.
+None of those slices should imply hosted transport, tenant features, or billing surfaces.

--- a/docs/release/MCP-0.2.7-RELEASE-NOTES.md
+++ b/docs/release/MCP-0.2.7-RELEASE-NOTES.md
@@ -1,34 +1,18 @@
-# @martinloop/mcp v0.2.7
+# @martinloop/mcp 0.2.7
 
-`@martinloop/mcp@0.2.7` is a usability and review release for the standalone MartinLoop MCP server.
-
-The package already had the core pieces for governed coding work. This release makes that flow easier to adopt in real hosts and harder to use incorrectly.
-
-## Public Release Train
-
-- `0.1.4` operator foundation
-- `0.2.0` cockpit expansion
-- `0.2.5` public MCP package line
-- `0.2.7` usability and review release
+`@martinloop/mcp@0.2.7` is the current public baseline for the standalone MartinLoop MCP server.
 
 ## What changed
 
-- `martin_run` now refuses to start until matching `martin_doctor`, `martin_plan`, and `martin_preflight` receipts exist for the same task
-- guide resources now cover command mapping, IDE onboarding, and the operating rules MartinLoop expects hosts to follow
-- the review loop is easier to navigate through dossier, eval, triage, and publish-readiness helpers
-- package metadata, server metadata, and public docs now describe the same `0.2.7` MCP surface
-
-## Current cockpit surface
-
-- read-only inspection still includes `martin_list_runs`, `martin_get_run`, `martin_get_attempt`, `martin_get_verification_results`, and `martin_run_dossier`
-- run triage remains part of the public cockpit through `martin_triage_runs` and the run triage flow
-- the package continues to ship resources, resource templates, and prompts alongside the write-capable `martin_run` entrypoint
+- made the guided MartinLoop flow clearer inside MCP hosts
+- tightened the run gate so hosts cannot jump straight to execution without matching planning and preflight receipts
+- cleaned up package metadata, docs, and release surfaces so they describe the same product
 
 ## Why it matters
 
-This release is about trust and flow.
+This release is less about adding more surface area and more about making the existing surface easier to trust.
 
-If an MCP host is going to drive real coding work, it should not have to guess which MartinLoop step comes next, and it should not be able to skip straight to execution by accident. `0.2.7` makes the guided path much clearer while keeping the server local-first and stdio-first.
+A host should not have to guess which MartinLoop command comes next, and it should not be able to skip the safety steps by accident.
 
 ## Recommended flow
 
@@ -40,35 +24,11 @@ If an MCP host is going to drive real coding work, it should not have to guess w
 6. `martin_dossier`
 7. `martin_eval`
 
-For a fresh machine, start with the root CLI first:
-
-```sh
-npx martin-loop demo
-cd martin-loop-demo
-npx martin-loop doctor
-npx martin-loop session-start
-```
-
-Then install the standalone server:
-
-```sh
-codex mcp add martin-loop -- npx -y @martinloop/mcp
-```
-
-## Docs
-
-- [MCP setup](../getting-started/mcp.md)
-- [MCP tool reference](../reference/mcp-tools.md)
-- [MCP compatibility](../reference/mcp-compatibility.md)
-- [Package README](../../packages/mcp/README.md)
-
 ## Verification
 
-```sh
-pnpm --filter @martinloop/mcp lint
-pnpm --filter @martinloop/mcp test
-pnpm --filter @martinloop/mcp build
-pnpm --filter @martinloop/mcp smoke:pack
-pnpm --filter @martinloop/mcp smoke:published:pack
-pnpm --filter @martinloop/mcp verify:release
-```
+- `pnpm --filter @martinloop/mcp lint`
+- `pnpm --filter @martinloop/mcp test`
+- `pnpm --filter @martinloop/mcp build`
+- `pnpm --filter @martinloop/mcp smoke:pack`
+- `pnpm --filter @martinloop/mcp smoke:published:pack`
+- `pnpm --filter @martinloop/mcp verify:release`

--- a/docs/release/MCP-0.2.7-RELEASE-PACKET.md
+++ b/docs/release/MCP-0.2.7-RELEASE-PACKET.md
@@ -1,90 +1,31 @@
 # Martin MCP `0.2.7` Release Packet
 
-This packet is the proof bundle for `@martinloop/mcp@0.2.7`, the usability and review release for the standalone MartinLoop MCP server.
+This packet records the public baseline we are now building from.
 
-## Version Truth
+## Release summary
 
-- standalone package: `@martinloop/mcp@0.2.7`
-- public release train:
-  - `0.1.4` operator foundation
-  - `0.2.0` cockpit expansion
-  - `0.2.5` public MCP package line
-  - `0.2.7` usability and review release
+- package: `@martinloop/mcp@0.2.7`
+- release tag: `mcp-v0.2.7`
+- public role: standalone local-first MCP server for governed coding work
 
-See [VERSION-LEDGER.md](./VERSION-LEDGER.md) for the canonical version map.
+## What `0.2.7` established
 
-## Public Boundary
+- guided adoption for real MCP hosts
+- clearer operating rules and next-step guidance
+- a harder default gate around `martin_run`
+- consistent package metadata, release notes, and public docs
 
-This packet covers only the public MCP package surface documented in this repo: tools, resources, resource templates, prompts, packaging metadata, and public release evidence.
+## Commands run before release
 
-## Commands Run
+- `pnpm --filter @martinloop/mcp lint`
+- `pnpm --filter @martinloop/mcp test`
+- `pnpm --filter @martinloop/mcp build`
+- `pnpm --filter @martinloop/mcp smoke:pack`
+- `pnpm --filter @martinloop/mcp smoke:published:pack`
+- `pnpm --filter @martinloop/mcp verify:release`
 
-```powershell
-pnpm --filter @martinloop/mcp lint
-pnpm --filter @martinloop/mcp test
-pnpm --filter @martinloop/mcp build
-pnpm --filter @martinloop/mcp smoke:pack
-pnpm --filter @martinloop/mcp smoke:published:pack
-pnpm --filter @martinloop/mcp verify:release
-pnpm lint
-pnpm test
-pnpm build
-pnpm oss:validate
-pnpm public:smoke
-```
+## Why this packet exists
 
-## Versions Tested
+This is the release boundary for the next train.
 
-- root package current repo manifest: `martin-loop@0.2.11`
-- standalone MCP current repo manifest: `@martinloop/mcp@0.2.7`
-
-## Host Matrix Receipts
-
-Local proof for this package line covers:
-
-- Codex config generation and smoke validation
-- Claude Code config generation and smoke validation
-- Gemini config generation and smoke validation
-- generic stdio config generation and smoke validation
-
-The release rule remains unchanged: the exact release CI must be green on Windows, Linux, and macOS before calling the line ready to push.
-
-## Source Parity Receipts
-
-- `packages/mcp/package.json` matches the standalone MCP server metadata
-- `packages/mcp/server.json` matches the standalone MCP package metadata
-- `packages/mcp/src/package-version.ts` matches the standalone MCP package metadata
-- public docs and release docs describe the same current cockpit surface
-
-## What `0.2.7` Adds
-
-- stronger guided-flow material for hosts through command-map, IDE-onboarding, and operating-rules resources
-- a clearer review loop around dossier, triage, eval, and publish-readiness helpers
-- tighter parity between package metadata, server metadata, and public docs
-
-## Known Non-Goals
-
-- no second write-capable MCP execution entrypoint
-- no registry publication in this packet
-- no hosted remote-server claim in this packet
-- no undocumented host profile or unpublished surface in public docs
-
-## Publish Gates Still Pending Explicit Approval
-
-These steps remain intentionally blocked until explicit approval:
-
-- create the exact release branch for the next public delivery
-- push that release branch
-- tag the release
-- publish npm
-- update public GitHub releases
-
-## Ready-To-Push Rule
-
-Do not call this line ready to push until all of these are true:
-
-- version truth is still consistent with [VERSION-LEDGER.md](./VERSION-LEDGER.md)
-- release docs, manifest, and `server.json` all align
-- source parity still holds
-- local release gates remain green
-- the exact release CI is green on Windows, Linux, and macOS
+`0.3.0`, `0.3.1`, and `0.3.2` should extend the standalone MCP line from this baseline without dragging in hosted, tenant, billing, or control-plane language.

--- a/docs/release/MCP-0.3.0-RELEASE-NOTES.md
+++ b/docs/release/MCP-0.3.0-RELEASE-NOTES.md
@@ -1,0 +1,25 @@
+# @martinloop/mcp 0.3.0
+
+`0.3.0` is the adoption release for the standalone MartinLoop MCP server.
+
+## Release story
+
+Make MartinLoop feel native inside real agent hosts.
+
+## Planned scope
+
+- stronger host bootstrap for Codex, Claude Code, Gemini, Cursor, and VS Code
+- clearer agent-start guidance
+- built-in command-map and operating-rules resources
+- cleaner host-facing docs and troubleshooting
+
+## Out of scope
+
+- hosted transport
+- organization-specific config
+- business-dashboard claims
+- private review routes
+
+## Release gate
+
+A fresh MCP host install should make the governed MartinLoop flow obvious without needing internal context.

--- a/docs/release/MCP-0.3.1-RELEASE-NOTES.md
+++ b/docs/release/MCP-0.3.1-RELEASE-NOTES.md
@@ -1,0 +1,25 @@
+# @martinloop/mcp 0.3.1
+
+`0.3.1` is the review and handoff release for the standalone MartinLoop MCP server.
+
+## Release story
+
+Make post-run review feel crisp instead of forensic.
+
+## Planned scope
+
+- stronger dossier and eval guidance
+- clearer triage and publish-readiness prompts
+- compact review resources that answer what happened, what failed, and what comes next
+- handoff-safe outputs for humans and agents
+
+## Out of scope
+
+- hosted evidence explorer
+- audit export
+- org policy
+- fleet controls
+
+## Release gate
+
+A human reviewer or AI host should be able to understand a governed run without reconstructing MartinLoop from raw receipts.

--- a/docs/release/MCP-0.3.2-RELEASE-NOTES.md
+++ b/docs/release/MCP-0.3.2-RELEASE-NOTES.md
@@ -1,0 +1,25 @@
+# @martinloop/mcp 0.3.2
+
+`0.3.2` is the opt-in execution-controls release for the standalone MartinLoop MCP server.
+
+## Release story
+
+Give power users more control without making execution feel automatic.
+
+## Planned scope
+
+- explicit execution-capable profiles
+- clearer refusal and escalation messages
+- docs that separate read-only-safe usage from execution-capable usage
+- host snippets that make the default posture obvious
+
+## Out of scope
+
+- hidden auto-execution
+- hosted orchestration
+- organization-specific controls
+- non-OSS transport modes
+
+## Release gate
+
+Read-only stays the default story. Execution stays explicit.

--- a/docs/release/MCP-COMPATIBILITY.md
+++ b/docs/release/MCP-COMPATIBILITY.md
@@ -1,24 +1,37 @@
-# Martin MCP Compatibility
+# MCP Compatibility
 
-This document is the compatibility statement for the governed execution cockpit line currently at `@martinloop/mcp@0.2.7`.
+This document describes the compatibility posture for the public standalone MCP line after `@martinloop/mcp@0.2.7`.
 
-## Stable Contract
+## Current baseline
 
-- MartinLoop compatibility guarantee: martin_run remains the only execution entrypoint.
-- `martin_inspect`, `martin_status`, `martin_doctor`, and `martin_preflight` remain available and backward-compatible.
-- `martin_list_runs`, `martin_triage_runs`, `martin_get_run`, `martin_get_attempt`, `martin_get_verification_results`, and `martin_run_dossier` are additive read-only surfaces.
-- resources, resource templates, and prompts are additive discovery surfaces over the same persisted Martin run data.
+`0.2.7` is the current public baseline.
 
-## Data Expectations
+It keeps the standalone server local-first and stdio-first, and it assumes a governed MartinLoop workflow:
 
-- run inspection is sourced from persisted loop records, artifacts, and verification events
-- missing verification evidence is reported as unavailable instead of synthesized
-- safe-root behavior for `workingDirectory`, `file`, and `runsDir` remains enforced
+1. `martin_doctor`
+2. `martin_plan`
+3. `martin_preflight`
+4. `martin_run`
+5. `martin_status` or `martin_logs`
+6. `martin_dossier`
+7. `martin_eval`
 
-## Follow-On Direction
+## What later `0.3.x` releases must preserve
 
-Any follow-on release after `0.2.7` should:
+- `martin_run` stays the single execution entrypoint.
+- Read-only inspection remains available without requiring execution-capable profiles.
+- Hosts can discover the guided MartinLoop workflow without private context.
+- Public docs stay local-first and do not imply hosted transport or private control-plane features.
 
-- preserve the `0.2.5` public MCP package line compatibility expectations unless migration notes explicitly say otherwise
-- avoid adding new write-capable MCP tools without a documented approval model
-- keep install snippets, manifests, and discovery docs in parity with the actual server surface
+## What later `0.3.x` releases may add
+
+- stronger onboarding resources and examples
+- clearer handoff and review helpers
+- explicit opt-in execution profiles
+- broader host coverage and compatibility guidance
+
+## What later `0.3.x` releases may not imply
+
+- that MartinLoop automatically intercepts agent behavior invisibly
+- that hosted or tenant-aware transport is part of the public package
+- that billing, mission-control, or evidence-explorer surfaces are part of the standalone OSS package

--- a/docs/release/MCP-DELIVERY-SLICE-MAP.md
+++ b/docs/release/MCP-DELIVERY-SLICE-MAP.md
@@ -1,136 +1,84 @@
-# Martin MCP Release Lane Map
+# Martin MCP Delivery Slice Map
 
-Use this map when preparing scheduled public deliveries from the current repo checkout. The goal is to keep the public release train honest against live npm truth while keeping docs, tests, and packaging scoped to the intended release.
+This map defines the next public standalone MCP releases after the live `0.2.7` baseline. The point is to keep each release narrow, legible, and easy to validate.
 
-## Public Version Train
+## Live baseline
 
-- live npm baseline: `0.2.7`
-- staged public deliveries:
-  - `0.1.4` operator foundation
-  - `0.2.0` cockpit expansion
-  - `0.2.5` public MCP package line
-  - `0.2.7` usability and review release
-- current repo package manifest: `0.2.7`
+- public npm baseline: `0.2.7`
+- public GitHub release baseline: `mcp-v0.2.7`
+- next release to prepare: `0.3.0`
 
-See [VERSION-LEDGER.md](./VERSION-LEDGER.md) for the canonical version truth.
+## `0.3.0` — Adoption Pack
 
-## Public Boundary
-
-- the standalone `@martinloop/mcp` train is the public MCP surface in this repo
-- public release notes, packets, and README files should describe only shipped public capabilities
-- keep experimental, unpublished, or unrelated material out of the OSS MCP train
-
-## Delivery `0.1.4`
-
-Scope: operator foundation for the Free / OSS operator lane.
+Story: make MartinLoop feel native inside agent hosts without widening into hosted or non-OSS territory.
 
 Include:
+- stronger setup and bootstrap guidance for Codex, Claude Code, Gemini, Cursor, and VS Code
+- clearer `martin_start` guidance and next-step resources
+- built-in command map and operating-rules resources
+- safer discovery metadata and first-run guidance
+- public docs that show the recommended local-first workflow end to end
 
-- `martin_doctor`
-- `martin_preflight`
-- install/config generation improvements
-- version-truth and release-evidence docs
-- public verification hardening needed to support the operator foundation story
+Do not include:
+- hosted endpoints
+- bearer-auth remote config defaults
+- tenant or org language
+- billing or mission-control claims
+- non-OSS review routes
 
-Primary surfaces:
-
-- `packages/mcp/src/tools/doctor.ts`
-- `packages/mcp/src/tools/preflight.ts`
-- `packages/mcp/src/server.ts`
-- `packages/cli/src/index.ts`
-- `packages/cli/src/mcp-config.ts`
+Primary public surfaces:
 - `packages/mcp/README.md`
 - `docs/oss/MCP-FOR-AI-AGENTS.md`
 - `docs/oss/QUICKSTART.md`
-- `docs/release/MCP-0.1.4-RELEASE-NOTES.md`
+- `docs/release/MCP-0.3.0-RELEASE-NOTES.md`
 
-Do not include:
+## `0.3.1` — Review And Handoff Controls
 
-- resources
-- resource templates
-- prompts
-- dossier/triage-heavy discovery story
-
-## Delivery `0.2.0`
-
-Scope: cockpit expansion for the Free / OSS public cockpit lane.
+Story: make review, triage, and handoff easier after a governed run finishes.
 
 Include:
-
-- additive read-only inspection expansion
-- resources
-- resource templates
-- prompts
-- dossier/discovery surfaces
-
-Primary surfaces:
-
-- `packages/mcp/src/resources.ts`
-- `packages/mcp/src/prompts.ts`
-- `packages/mcp/src/discovery-metadata.ts`
-- `packages/mcp/src/discovery-support.ts`
-- `packages/mcp/src/tools/list-runs.ts`
-- `packages/mcp/src/tools/get-run.ts`
-- `packages/mcp/src/tools/get-attempt.ts`
-- `packages/mcp/src/tools/get-verification-results.ts`
-- `packages/mcp/src/tools/run-dossier.ts`
-- `packages/mcp/tests/mcp-discovery.test.ts`
-- `packages/mcp/tests/server-live.test.ts`
-- `docs/release/MCP-0.2.0-RELEASE-NOTES.md`
-
-Keep public execution semantics unchanged:
-
-- `martin_run` remains the only write-capable entrypoint
+- stronger dossier and eval guidance
+- clearer failed-run and publish-readiness flows
+- compact review resources for what happened, what failed, and what to do next
+- handoff-safe expected outputs for humans and agents
 
 Do not include:
+- hosted audit export
+- org policy
+- fleet controls
+- evidence-dashboard claims
 
-- unpublished remote experiments
-- capabilities without public code and reproducible proof
-- unrelated workflow or packaging changes
+Primary public surfaces:
+- `packages/mcp/README.md`
+- `docs/oss/MCP-FOR-AI-AGENTS.md`
+- `docs/release/MCP-0.3.1-RELEASE-NOTES.md`
 
-## Delivery `0.2.5`
+## `0.3.2` — Opt-In Execution Controls
 
-Scope: the public MCP package line, including the polish and hardening needed to keep that line honest.
+Story: widen control for power users without making execution feel implicit or invisible.
 
 Include:
+- explicit execution-capable profiles
+- clearer refusal and escalation messages
+- stronger docs for read-only versus execution-capable usage
+- install snippets that make the safe default obvious
 
-- triage
-- degraded run-store handling
-- release documentation bundle
-- compatibility and publishing docs
-- stronger release guards
-- final proof artifacts for the public cockpit line
+Do not include:
+- hidden auto-execution
+- hosted orchestration
+- tenant or billing features
+- non-OSS transport
 
-Primary surfaces:
+Primary public surfaces:
+- `packages/mcp/README.md`
+- `docs/oss/MCP-FOR-AI-AGENTS.md`
+- `docs/release/MCP-0.3.2-RELEASE-NOTES.md`
 
-- `packages/mcp/src/tools/triage-runs.ts`
-- `packages/mcp/src/tools/run-store.ts`
-- `packages/mcp/src/tools/tool-errors.ts`
-- `packages/mcp/src/tools/tool-response.ts`
-- `packages/mcp/src/tools/tool-support.ts`
-- `packages/mcp/tests/mcp-tools.test.ts`
-- `scripts/tests/mcp-release-docs.test.mjs`
-- `docs/release/MCP-0.2.5-RELEASE-NOTES.md`
-- `docs/release/MCP-0.2.5-RELEASE-PACKET.md`
-- `docs/release/MCP-COMPATIBILITY.md`
-- `docs/release/MCP-PUBLISHING.md`
-- `docs/release/MCP-RELEASE-CHECKLIST.md`
+## Release cut rule
 
-## Explicit Exclusions From The Public Train
+Before a public-prep branch opens:
 
-These stay out of the public MCP npm release train for this wave:
-
-- unpublished or experimental capabilities
-- unrelated application packages
-- unrelated tracing or routing packages
-- remote metadata that is not part of the shipped public package
-- credentials, rate limits, or operational material that is not part of the public package contract
-
-## Release Cut Rule
-
-Before cutting any staged public branch:
-
-1. Confirm [VERSION-LEDGER.md](./VERSION-LEDGER.md) still matches live npm and public GitHub `main`.
-2. Confirm the target delivery includes only the intended public slice from above.
-3. Confirm the exact release branch or commit is what goes to CI for Windows, Linux, and macOS proof.
-4. Keep unrelated changes out of the release branch; only ship the files required for the release slice.
+1. Reconfirm `VERSION-LEDGER.md` against live npm and public GitHub.
+2. Keep the changed-path set limited to the slice being shipped.
+3. Run the full public release gates on the exact candidate commit.
+4. Audit packed tarball contents, README, and release notes before publish.

--- a/docs/release/MCP-PUBLISHING.md
+++ b/docs/release/MCP-PUBLISHING.md
@@ -1,101 +1,34 @@
 # MCP Publishing
 
-Use npm trusted publishing from GitHub Actions for `@martinloop/mcp`.
+The standalone MCP line is published as its own package. Treat it like a product surface, not a side effect of the root package.
 
-For `@martinloop/mcp@0.2.7`, the publish claim covers the public MCP package line: tools, resources, resource templates, and prompts, plus the run-triage surface layered into that package. The docs and release checks must describe that surface honestly, while the public scheduled train stays `0.1.4 -> 0.2.0 -> 0.2.5 -> 0.2.7`.
+## Current public truth
 
-## Public Boundary
+- live public standalone release: `@martinloop/mcp@0.2.7`
+- next planned standalone release: `0.3.0`
+- publish authority: GitHub Actions trusted publishing / OIDC
 
-Publishing `@martinloop/mcp` only updates the public MCP package surface documented in this repo.
-Do not expand release notes, README copy, or publish claims beyond the tools, resources, prompts, docs, and verification artifacts shipped here.
+## Before publish
 
-The scheduled public labels are:
+- confirm package metadata, server metadata, and release notes all describe the same version
+- confirm docs and README copy match the exact shipped MCP surface
+- confirm the release notes sound customer-facing, not internal
+- confirm packed tarball contents stay limited to the package payload
 
-- `0.1.4` operator foundation
-- `0.2.0` cockpit expansion
-- `0.2.5` public MCP package line
-- `0.2.7` usability and review release
+## Required gates
 
-## Canonical Release Path
+- `pnpm --filter @martinloop/mcp lint`
+- `pnpm --filter @martinloop/mcp test`
+- `pnpm --filter @martinloop/mcp build`
+- `pnpm --filter @martinloop/mcp smoke:pack`
+- `pnpm --filter @martinloop/mcp smoke:published:pack`
+- `pnpm --filter @martinloop/mcp verify:release`
 
-1. Bump `packages/mcp/package.json` and `packages/mcp/server.json`.
-2. Confirm `docs/release/VERSION-LEDGER.md` still matches live npm, public GitHub `main`, and the current repo package manifests.
-3. Refresh:
-   - `packages/mcp/README.md`
-   - `docs/oss/MCP-FOR-AI-AGENTS.md`
-   - `docs/oss/QUICKSTART.md`
-   - `docs/release/MCP-X.Y.Z-RELEASE-NOTES.md`
-   - `docs/release/MCP-X.Y.Z-RELEASE-PACKET.md`
-   - `docs/release/MCP-COMPATIBILITY.md`
-   - `docs/release/MCP-RELEASE-CHECKLIST.md`
-4. Run the pre-publish gates:
-   - `pnpm --filter @martinloop/mcp lint`
-   - `pnpm --filter @martinloop/mcp test`
-   - `pnpm --filter @martinloop/mcp build`
-   - `pnpm --filter @martinloop/mcp smoke:pack`
-   - `pnpm --filter @martinloop/mcp smoke:published:pack`
-   - `pnpm --filter @martinloop/mcp verify:release`
-5. Merge the release branch.
-6. Trigger `.github/workflows/publish-mcp.yml` with `workflow_dispatch` or `mcp-vX.Y.Z`.
-7. Let the workflow publish npm and re-run `pnpm --filter @martinloop/mcp smoke:published`.
+## Release-note rule
 
-## Docs and Parity Checklist
+Each standalone release needs release notes that answer four things plainly:
 
-Before calling the release ready, confirm:
-
-- the matching `docs/release/MCP-X.Y.Z-RELEASE-PACKET.md` exists and includes the commands run, versions tested, host matrix receipts, known non-goals, and pending publish gates
-- docs list the current tools:
-  - `martin_doctor`
-  - `martin_preflight`
-  - `martin_run`
-  - `martin_inspect`
-  - `martin_status`
-  - `martin_list_runs`
-  - `martin_triage_runs`
-  - `martin_get_run`
-  - `martin_get_attempt`
-  - `martin_get_verification_results`
-  - `martin_run_dossier`
-- docs list the current resources and prompts
-- docs keep current Codex and Claude Code install snippets
-- release notes describe the actual discovery surface as shipped, not as future work
-- docs describe only the public MCP package surface shipped from this repo
-- docs do not present experimental or non-public capabilities as part of the public npm package claim
-- `scripts/tests/mcp-release-docs.test.mjs` verifies the tool list, resource list, prompt list, and cockpit flow
-
-## Gate Semantics
-
-- `smoke:pack` is the pre-publish local-pack gate
-- `smoke:published:pack` is the install-from-pack gate
-- `smoke:published` is the post-publish npm gate
-
-They are separate gates and should stay separate.
-
-## Trusted Publishing Notes
-
-- package: `@martinloop/mcp`
-- registry/server identifier: `io.github.Keesan12/martin-loop`
-- GitHub owner: `Keesan12`
-- repository: `martin-loop`
-- workflow: `publish-mcp.yml`
-
-## Emergency Local Fallback
-
-Only use local publish when automation is unavailable:
-
-```powershell
-pnpm --dir packages/mcp lint
-pnpm --dir packages/mcp test
-pnpm --dir packages/mcp build
-pnpm --dir packages/mcp smoke:pack
-pnpm --dir packages/mcp smoke:published:pack
-pnpm --dir packages/mcp verify:release
-npm publish --access public --workspace @martinloop/mcp
-```
-
-Then verify:
-
-```powershell
-npm view @martinloop/mcp version
-pnpm --filter @martinloop/mcp smoke:published
-```
+- what changed
+- why it matters
+- how to start using it
+- what was verified before release

--- a/docs/release/VERSION-LEDGER.md
+++ b/docs/release/VERSION-LEDGER.md
@@ -1,45 +1,52 @@
 # Version Ledger
 
-This file is the canonical version map for release work. Do not push, tag, or publish from memory when the root `martin-loop` package and the standalone `@martinloop/mcp` package move on different lines.
+This file is the internal source of truth for release work. Check it before you cut a branch, update docs, or talk about npm state.
 
 ## Root package: `martin-loop`
 
 - live npm dist-tag `latest`: `0.2.11`
-- live npm versions include: `0.1.0`, `0.1.1`, `0.1.2`, `0.1.3`, `0.1.4`, `0.1.5`, `0.1.6`, `0.1.7`, `0.1.8`, `0.2.0`, `0.2.1`, `0.2.2`, `0.2.3`, `0.2.4`, `0.2.5`, `0.2.6`, `0.2.7`, `0.2.8`, `0.2.9`, `0.2.10`, `0.2.11`, and a historical anomaly `1.3.0`
-- public GitHub `main`: `0.2.11`
-- current repo package manifest: `0.2.11`
-- next root-package target version: derive from the approved release scope; do not assume from history alone
-- release rule: treat the root package as its own public semver line and do not infer standalone MCP versioning from it
+- live public GitHub release: `v0.2.11`
+- live public baseline in this train: `0.2.11`
+- root public baseline: `0.2.11`
+- releases consumed since the original `0.2.8` launch:
+  - `0.2.9` fixed proof-run classification, Windows `.cmd` resolution, and public provider defaults
+  - `0.2.10` tightened verifier evidence, `--runs-dir` consistency, and public help output
+  - `0.2.11` fixed `runs verify --latest` selector parity in the public CLI
+- next planned root release: `0.3.0` for shareable run receipts
+- next planned root follow-on: `0.3.1` for multi-model and multi-IDE compatibility
 
-## Standalone MCP package: `@martinloop/mcp`
+## Standalone package: `@martinloop/mcp`
 
 - live npm dist-tag `latest`: `0.2.7`
-- live npm versions include: `0.1.1`, `0.1.2`, `0.1.3`, `0.1.4`, `0.2.0`, `0.2.5`, `0.2.7`
-- public GitHub `main`: `0.2.7`
-- current repo package manifest: `0.2.7`
-- public scheduled release train:
-  - `0.1.4` for operator foundation
-  - `0.2.0` for cockpit expansion
-  - `0.2.5` for the public MCP package line
-  - `0.2.7` for usability and review hardening
+- live public GitHub release: `mcp-v0.2.7`
+- live public baseline in this train: `0.2.7`
+- standalone MCP public baseline: `0.2.7`
+- next planned standalone release: `0.3.0` for host adoption and onboarding
+- next planned follow-ons:
+  - `0.3.1` review and handoff controls
+  - `0.3.2` opt-in execution controls
 
-## Public Release Labels
+## Release rules
 
-The public MCP train labels are:
+- The root package line and the standalone MCP line move independently.
+- Do not infer standalone MCP release state from the root package, or the other way around.
+- Public release notes must be written for customers and evaluators, not for internal operators.
+- Public-facing examples, screenshots, README copy, and changelog entries must stay free of internal repo names, absolute system paths, private branch names, or process noise.
+- Publish only through GitHub Actions trusted publishing / OIDC.
 
-- `0.1.4` operator foundation
-- `0.2.0` cockpit expansion
-- `0.2.5` public MCP package line
-- `0.2.7` usability and review release
+## Validation baseline before any public prep branch
 
-## Rules
-
-- do not use `0.3.0` as an active standalone MCP release label in OSS or mirror surfaces
-- do not let the root package version line drive standalone MCP release numbering
-- do not use public MCP release docs to imply capabilities that are not shipped from this repo
-- keep non-public operational details out of OSS release docs
-- before any push candidate, confirm this ledger against:
-  - `npm view martin-loop version versions --json`
-  - `npm view @martinloop/mcp version versions --json`
-  - public GitHub `main`
-  - current repo package manifests
+- `pnpm install --frozen-lockfile`
+- `pnpm lint`
+- `pnpm test`
+- `pnpm build`
+- `pnpm public:git-surface`
+- `pnpm oss:validate`
+- `pnpm public:smoke`
+- `pnpm release:matrix:local`
+- `pnpm --filter @martinloop/mcp lint`
+- `pnpm --filter @martinloop/mcp test`
+- `pnpm --filter @martinloop/mcp build`
+- `pnpm --filter @martinloop/mcp smoke:pack`
+- `pnpm --filter @martinloop/mcp smoke:published:pack`
+- `pnpm --filter @martinloop/mcp verify:release`

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,21 +1,19 @@
 # @martinloop/mcp
 
-Governed execution cockpit for AI coding agents over MCP stdio.
+Governed MCP server for AI coding agents over local stdio.
 
-`@martinloop/mcp@0.2.7` is the current public governed execution cockpit package in the MCP release train. It gives hosts one bounded execution entrypoint, a contract-first workflow, live run observability, evaluator-backed receipts, and discoverable resources on top of MartinLoop’s persisted run records.
+`@martinloop/mcp@0.2.7` is the current public baseline. It gives hosts one bounded execution entrypoint, strong read-only inspection, clear next-step guidance, and a safer default MartinLoop workflow.
 
-This package stays local-first and stdio-first in public packaging today.
+This package stays local-first and stdio-first in the public OSS lane.
 
-For host-facing guidance, see [MCP for AI Agents](https://github.com/Keesan12/martin-loop/blob/main/docs/oss/MCP-FOR-AI-AGENTS.md).
+## Public release train
 
-## Public Release Train
+- `0.2.7` made the guided MCP workflow easier to adopt and harder to misuse.
+- `0.3.0` is the next adoption release.
+- `0.3.1` is planned for review and handoff controls.
+- `0.3.2` is planned for opt-in execution controls.
 
-- 0.1.4 operator foundation.
-- 0.2.0 cockpit expansion. 0.2.0 adds resources, resource templates, prompts, and read-only cockpit inspection.
-- 0.2.5 public MCP package line. 0.2.5 adds triage and degraded run-store hardening, plus the command-center workflow surfaces.
-- 0.2.7 usability and review release. 0.2.7 clarifies the guided path and tightens public package presentation.
-
-## What Ships
+## What ships today
 
 ### Tools
 
@@ -60,13 +58,6 @@ For host-facing guidance, see [MCP for AI Agents](https://github.com/Keesan12/ma
 - `martin://guides/agent-start`
 - `martin://guides/publish-readiness`
 
-### Resource templates
-
-- `martin://runs/{loopId}`
-- `martin://runs/{loopId}/dossier`
-- `martin://runs/{loopId}/attempts/{attemptIndex}`
-- `martin://runs/{loopId}/verification`
-
 ### Prompts
 
 - `martin_start`
@@ -79,39 +70,30 @@ For host-facing guidance, see [MCP for AI Agents](https://github.com/Keesan12/ma
 - `martin_debug_failed_run`
 - `martin_publish_readiness_review`
 - `martin_triage_run_store`
-- `safe_bug_fix`
-- `write_tests_first`
-- `small_refactor`
-- `security_review`
-- `pr_review`
-- `release_check`
 
-## Recommended Flow
+## Recommended flow
 
 1. `martin_doctor`
 2. `martin_plan`
 3. `martin_preflight`
 4. `martin_run`
 5. `martin_status` or `martin_logs`
-6. `martin_dossier` or `martin_get_*` when compact evidence says the full record is needed
-7. `martin_eval` for mergeability scoring and reviewer posture
-8. `martin_pr_summary` or `martin_review_pr` when the host is preparing GitHub review output
+6. `martin_dossier`
+7. `martin_eval`
 
 ## Install
-
-Run the packaged server directly:
 
 ```sh
 npx -y @martinloop/mcp
 ```
 
-Add it to Codex:
+Codex:
 
 ```sh
 codex mcp add martin-loop -- npx -y @martinloop/mcp
 ```
 
-Add it to Claude Code:
+Claude Code:
 
 ```sh
 # macOS/Linux
@@ -121,106 +103,23 @@ claude mcp add --transport stdio --scope user martin-loop -- npx -y @martinloop/
 claude mcp add --transport stdio --scope user martin-loop -- cmd /c npx -y @martinloop/mcp
 ```
 
-Generate host config from the root CLI package when you want minimal, diagnostic, full-local, or GitHub-review profiles:
+If you want generated host config, use the MartinLoop CLI:
 
 ```sh
-npx -y martin-loop mcp print-config --host codex --transport stdio --profile minimal
-npx -y martin-loop mcp print-config --host claude --transport stdio --profile diagnostic
-npx -y martin-loop mcp print-config --host gemini --transport stdio --profile full-local
-npx -y martin-loop mcp print-config --host generic --transport stdio --profile github-review
+martin mcp print-config --host codex --transport stdio --profile minimal
+martin mcp print-config --host claude --transport stdio --profile diagnostic
+martin mcp print-config --host gemini --transport stdio --profile full-local
+martin mcp print-config --host generic --transport stdio --profile github-review
 ```
 
-`npx -y martin-loop mcp install` supports the same local host set and only writes when the target file is absent or already contains a Martin Loop block. The standalone `@martinloop/mcp` package exposes only the server binaries (`mcp` and `martin-loop-mcp`); the `martin` command comes from the root `martin-loop` package.
+## Compatibility posture
 
-Codex also supports `~/.codex/config.toml` and project-scoped `.codex/config.toml`:
-
-```toml
-[mcp_servers."martin-loop"]
-command = "npx"
-args = ["-y", "@martinloop/mcp"]
-cwd = "C:\\path\\to\\repo"
-startup_timeout_sec = 20
-tool_timeout_sec = 180
-enabled_tools = [
-  "martin_doctor",
-  "martin_plan",
-  "martin_preflight",
-  "martin_list_runs",
-  "martin_triage_runs",
-  "martin_dossier",
-]
-env = { MARTIN_RUNS_DIR = "C:\\path\\to\\runs" }
-```
-
-If you use `npx -y martin-loop mcp install`, it will only write a starter host config when the target file is absent, or when it detects an existing Martin Loop block and can remain idempotent. Otherwise it refuses to overwrite mixed host config so you can merge safely.
-
-When `CODEX_HOME` is set, Codex user-scope installs target `CODEX_HOME\\config.toml` instead of the default user path.
-
-Registry/server identifier: `io.github.Keesan12/martin-loop`
-
-## Host coverage
-
-- `codex`: local stdio profiles
-- `claude`: local, user, and project scopes
-- `gemini`: local `settings.json` snippets with `includeTools`
-- `generic`: JSON config for MCP-aware wrappers
-
-Operating-system launcher behavior is explicit:
-
-- Windows: `cmd /c npx -y @martinloop/mcp`
-- macOS/Linux: `npx -y @martinloop/mcp`
-
-Claude `--scope local` remains CLI-managed. `npx -y martin-loop mcp install --host claude --scope local` shells out to Claude Code directly instead of fabricating a repo config file for that scope.
-
-## Discovery metadata
-
-- JSON resources now carry `metadata.serverVersion`, `metadata.discoveryRevision`, and freshness context such as the resolved `runsRoot`.
-- Compact resources expose low-token latest-run summaries, proof cards, budget status, verifier evidence, rollback evidence, and a single recommended next step.
-- Prompts stamp the current server version and discovery revision into their descriptions so hosts can confirm which surface they discovered.
-- The server does **not** advertise `listChanged` yet. That is deliberate: the current discovery surface is stable and versioned, but it does not yet emit authoritative change notifications.
-
-## Runtime Model
-
-- `martin_run` is the only execution entrypoint.
-- `martin_plan`, `martin_doctor`, `martin_preflight`, `martin_status`, `martin_logs`, `martin_dossier`, `martin_eval`, and the `martin_get_*` family are read-only workflow surfaces.
-- `martin_create_pr` is opt-in and intended for GitHub-enabled profiles, not the minimal default profile.
-- Live runs require `claude`, `codex`, or `gemini` on `PATH`.
-- Stub or smoke flows use `MARTIN_LIVE=false`.
-- Paths stay bounded to the configured workspace root and runs root.
-- Direct raw-model compatibility is not the target. Martin Loop supports hosts and wrappers that speak MCP; open-source model families such as Gemma or Nemotron should use the `generic` host path through an MCP-capable shell or runtime.
-
-## Operator Notes
-
-- `martin_doctor` now reports repo hygiene, verifier readiness, safeguard posture, and a readiness score instead of only install health.
-- `martin_plan` is the default read-only planning step before preflight. It proposes scope, verifiers, budget, and approval posture without spending a run.
-- `martin_preflight` now emits a structured run contract with policy-pack, allowed paths, blocked paths, budgets, and risk scoring.
-- `martin_status`, `martin_logs`, `martin_pause`, `martin_cancel`, and `martin_continue` give hosts a safer live-control layer without inventing extra execution tools.
-- `martin_dossier` is the alias-first evidence surface; `martin_run_dossier` remains supported for compatibility.
-- `martin_eval` grades task completion, verifier posture, regression risk, security risk, and reviewability for the completed run.
-- Resources and prompts reuse the same run-store selectors as the tools; they are discovery surfaces, not a second data model.
-- The recommended host default is the `minimal` profile: `martin_doctor`, `martin_plan`, `martin_preflight`, `martin_list_runs`, `martin_triage_runs`, and `martin_dossier`. Use `diagnostic` for read-only archaeology, `full-local` when the host should execute runs, and `github-review` only when PR mutation is explicitly desired.
-
-## Debugging
-
-Use the live handshake inspector before you blame the host:
-
-```sh
-pnpm --filter @martinloop/mcp inspect:live
-```
-
-If you want the official MCP Inspector UI, point it at the same stdio launch command:
-
-```sh
-npx @modelcontextprotocol/inspector --command npx --args "-y,@martinloop/mcp"
-```
-
-The stdio server keeps protocol output on stdout and diagnostic logging on stderr. When a host integration goes sideways, confirm the live discovery surface first, then move on to the host config.
-
-For WSL or Linux validation, do a native install on that platform before you smoke the package. Reusing Windows-installed `node_modules` across WSL will fail on native dependencies such as `esbuild`, which looks like a transport failure but is really a cross-platform install mismatch.
+- `martin_run` remains the single execution entrypoint.
+- Read-only inspection stays available without execution-capable profiles.
+- The OSS package stays focused on local stdio workflows. Hosted and team features live on a separate product track.
+- Later `0.3.x` releases should widen adoption and guidance without blurring those boundaries.
 
 ## Verification
-
-From the repository root:
 
 ```sh
 pnpm --filter @martinloop/mcp lint
@@ -229,23 +128,4 @@ pnpm --filter @martinloop/mcp build
 pnpm --filter @martinloop/mcp smoke:pack
 pnpm --filter @martinloop/mcp smoke:published:pack
 pnpm --filter @martinloop/mcp verify:release
-pnpm --filter @martin/cli verify:hosts:live
-pnpm --filter @martinloop/mcp smoke:published
-pnpm --filter @martinloop/mcp inspect:live
 ```
-
-- `smoke:pack` verifies the packed tarball and stdio launch path.
-- `smoke:published:pack` verifies install-and-run behavior from a freshly packed local tarball through the installed `mcp` bin before npm publish.
-- `verify:release` checks metadata parity, release-note presence, install docs, and discovery-surface claims.
-- `@martin/cli verify:hosts:live` is an optional local proof step for generated host config against installed and authenticated Codex, Claude, and Gemini CLIs.
-- `smoke:published` remains a post-publish npm gate.
-
-## Compatibility
-
-`0.2.7` is the current public governed execution cockpit line. `0.2.5` introduced the first full public cockpit package line:
-
-- `martin_run`, `martin_inspect`, `martin_status`, `martin_doctor`, and `martin_preflight` remain backward-compatible.
-- The command-center additions are additive: planning, logs, live controls, evaluation, dossier aliasing, GitHub review helpers, more resources, and prompt packs.
-- `martin_create_pr` is the only new outward-mutating helper and stays out of the default minimal profile.
-
-See `docs/release/MCP-COMPATIBILITY.md`, `docs/release/MCP-0.2.0-RELEASE-NOTES.md`, `docs/release/MCP-0.2.5-RELEASE-NOTES.md`, and `docs/release/MCP-0.2.7-RELEASE-NOTES.md` for the public release contract and delivery sequence.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@martinloop/mcp",
-  "version": "0.2.7",
+  "version": "0.3.0",
   "mcpName": "io.github.Keesan12/martin-loop",
   "private": false,
   "type": "module",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/Keesan12/martin-loop",
     "source": "github"
   },
-  "version": "0.2.7",
+  "version": "0.3.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@martinloop/mcp",
-      "version": "0.2.7",
+      "version": "0.3.0",
       "transport": {
         "type": "stdio"
       }

--- a/packages/mcp/src/package-version.ts
+++ b/packages/mcp/src/package-version.ts
@@ -1,3 +1,3 @@
 // Keep this aligned with packages/mcp/package.json during version bumps so the
 // runtime does not depend on package.json being present in every hosted bundle.
-export const MARTIN_MCP_PACKAGE_VERSION = "0.2.7";
+export const MARTIN_MCP_PACKAGE_VERSION = "0.3.0";

--- a/scripts/tests/mcp-release-docs.test.mjs
+++ b/scripts/tests/mcp-release-docs.test.mjs
@@ -9,104 +9,6 @@ import serverJson from "../../packages/mcp/server.json" with { type: "json" };
 
 const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 
-const EXPECTED_TOOLS = [
-  "martin_run",
-  "martin_inspect",
-  "martin_status",
-  "martin_doctor",
-  "martin_plan",
-  "martin_preflight",
-  "martin_logs",
-  "martin_pause",
-  "martin_cancel",
-  "martin_continue",
-  "martin_list_runs",
-  "martin_triage_runs",
-  "martin_get_run",
-  "martin_get_attempt",
-  "martin_get_verification_results",
-  "martin_run_dossier",
-  "martin_dossier",
-  "martin_eval",
-  "martin_pr_summary",
-  "martin_create_pr",
-  "martin_review_pr"
-];
-
-const EXPECTED_RESOURCES = [
-  "martin://server/health",
-  "martin://runs/recent",
-  "martin://runs/triage",
-  "martin://runs/latest",
-  "martin://runs/latest/summary",
-  "martin://runs/latest/proof-card",
-  "martin://runs/latest/budget-status",
-  "martin://runs/latest/verifier-evidence",
-  "martin://runs/latest/rollback-evidence",
-  "martin://policies/current",
-  "martin://repo/risk-map",
-  "martin://verifiers/results",
-  "martin://agent/next-step",
-  "martin://guides/mcp-usage",
-  "martin://guides/agent-start",
-  "martin://guides/publish-readiness"
-];
-
-const EXPECTED_PROMPTS = [
-  "martin_start",
-  "martin_preflight",
-  "martin_triage",
-  "martin_resume",
-  "martin_prove",
-  "martin_release_check",
-  "martin_governed_coding_kickoff",
-  "martin_debug_failed_run",
-  "martin_publish_readiness_review",
-  "martin_triage_run_store",
-  "safe_bug_fix",
-  "write_tests_first",
-  "small_refactor",
-  "security_review",
-  "pr_review",
-  "release_check"
-];
-
-const COCKPIT_020_TOOLS = [
-  "martin_list_runs",
-  "martin_get_run",
-  "martin_get_attempt",
-  "martin_get_verification_results",
-  "martin_run_dossier"
-];
-
-const COCKPIT_020_RESOURCES = [
-  "martin://server/health",
-  "martin://runs/recent",
-  "martin://guides/mcp-usage",
-  "martin://guides/publish-readiness"
-];
-
-const COCKPIT_020_PROMPTS = [
-  "martin_governed_coding_kickoff",
-  "martin_debug_failed_run",
-  "martin_publish_readiness_review"
-];
-
-const LATER_025_SURFACES = [
-  "martin_triage_runs",
-  "martin://runs/triage",
-  "martin_triage_run_store",
-  "degraded run-store hardening"
-];
-
-const PUBLIC_CONTRACT_DOCS = [
-  "docs/release/MCP-0.2.0-RELEASE-NOTES.md",
-  "docs/release/MCP-0.2.0-RELEASE-PACKET.md",
-  "packages/mcp/README.md",
-  "docs/oss/MCP-FOR-AI-AGENTS.md",
-  "docs/oss/QUICKSTART.md"
-];
-
 async function readRepoFile(relativePath) {
   return readFile(path.join(ROOT_DIR, relativePath), "utf8");
 }
@@ -115,67 +17,69 @@ function escapeRegex(input) {
   return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-function extractMartinToolNames(serverSource) {
-  return [...new Set([...serverSource.matchAll(/name:\s*"(martin_[a-z_]+)"/g)].map((match) => match[1]))];
-}
-
-function assertOrderedSubstrings(contents, expectedOrder) {
-  let previousIndex = -1;
-
-  for (const value of expectedOrder) {
-    const index = contents.indexOf(value);
-    assert.notEqual(index, -1, `Expected to find "${value}" in document`);
-    assert.ok(index > previousIndex, `Expected "${value}" to appear after the prior cockpit step`);
-    previousIndex = index;
-  }
-}
-
-function sectionBetween(contents, startHeading, endHeading) {
-  const startIndex = contents.indexOf(startHeading);
-  assert.notEqual(startIndex, -1, `Expected to find section "${startHeading}"`);
-
-  const endIndex = endHeading === null ? contents.length : contents.indexOf(endHeading, startIndex + startHeading.length);
-  assert.notEqual(endIndex, -1, `Expected to find section "${endHeading}" after "${startHeading}"`);
-
-  return contents.slice(startIndex, endIndex);
-}
-
-test("current MCP release note exists for the package version", async () => {
+test("current MCP metadata stays aligned for the release cut", async () => {
+  assert.equal(packageJson.version, "0.3.0");
   assert.equal(packageJson.version, serverJson.version);
 
-  const releaseNotesPath = path.join(
-    ROOT_DIR,
-    "docs",
-    "release",
-    `MCP-${packageJson.version}-RELEASE-NOTES.md`
-  );
+  const releaseNotesPath = path.join(ROOT_DIR, "docs", "release", `MCP-${packageJson.version}-RELEASE-NOTES.md`);
 
   await access(releaseNotesPath);
 });
 
-test("current MCP release packet exists for the package version and records proof gates", async () => {
-  const releasePacketPath = path.join(
-    ROOT_DIR,
-    "docs",
-    "release",
-    `MCP-${packageJson.version}-RELEASE-PACKET.md`
-  );
+test("version ledger records live public truth and the next release train", async () => {
+  const ledger = await readRepoFile(path.join("docs", "release", "VERSION-LEDGER.md"));
 
-  await access(releasePacketPath);
-
-  const releasePacket = await readFile(releasePacketPath, "utf8");
-
-  for (const requiredPhrase of [
-    "Commands Run",
-    "Versions Tested",
-    "Host Matrix Receipts",
-    "Source Parity Receipts",
-    "Known Non-Goals",
-    "Publish Gates Still Pending Explicit Approval",
-    "Ready-To-Push Rule"
+  for (const requiredText of [
+    "root public baseline: `0.2.11`",
+    "standalone MCP public baseline: `0.2.7`",
+    "next planned root release: `0.3.0`",
+    "next planned root follow-on: `0.3.1`",
+    "next planned standalone release: `0.3.0`",
+    "`0.3.1` review and handoff controls",
+    "`0.3.2` opt-in execution controls"
   ]) {
-    assert.match(releasePacket, new RegExp(escapeRegex(requiredPhrase)));
+    assert.match(ledger, new RegExp(escapeRegex(requiredText)));
   }
+});
+
+test("MCP slice map defines the 0.3.x train without private-hosted bleed", async () => {
+  const sliceMap = await readRepoFile(path.join("docs", "release", "MCP-DELIVERY-SLICE-MAP.md"));
+
+  for (const requiredText of [
+    "## `0.3.0` — Adoption Pack",
+    "## `0.3.1` — Review And Handoff Controls",
+    "## `0.3.2` — Opt-In Execution Controls",
+    "hosted endpoints",
+    "tenant or org language",
+    "billing or mission-control claims"
+  ]) {
+    assert.match(sliceMap, new RegExp(escapeRegex(requiredText)));
+  }
+});
+
+test("public MCP docs describe the current baseline and the next train in human-facing language", async () => {
+  const [packageReadme, aiGuide, releaseNotes030, releaseNotes031] = await Promise.all([
+    readRepoFile(path.join("packages", "mcp", "README.md")),
+    readRepoFile(path.join("docs", "oss", "MCP-FOR-AI-AGENTS.md")),
+    readRepoFile(path.join("docs", "release", "MCP-0.3.0-RELEASE-NOTES.md")),
+    readRepoFile(path.join("docs", "release", "MCP-0.3.1-RELEASE-NOTES.md"))
+  ]);
+
+  for (const contents of [packageReadme, aiGuide]) {
+    assert.match(contents, /0\.2\.7/);
+    assert.match(contents, /0\.3\.0/);
+    assert.match(contents, /local-first/i);
+    assert.match(contents, /martin_doctor/);
+    assert.match(contents, /martin_plan/);
+    assert.match(contents, /martin_preflight/);
+    assert.match(contents, /martin_run/);
+  }
+  assert.match(releaseNotes030, /adoption release/i);
+  assert.match(releaseNotes031, /review and handoff release/i);
+});
+
+test("release packet for 0.2.7 records the public verification gates", async () => {
+  const releasePacket = await readRepoFile(path.join("docs", "release", "MCP-0.2.7-RELEASE-PACKET.md"));
 
   for (const requiredCommand of [
     "pnpm --filter @martinloop/mcp lint",
@@ -187,270 +91,42 @@ test("current MCP release packet exists for the package version and records proo
   ]) {
     assert.match(releasePacket, new RegExp(escapeRegex(requiredCommand)));
   }
-
-  assert.match(releasePacket, new RegExp(escapeRegex(`@martinloop/mcp@${packageJson.version}`)));
-  assert.match(releasePacket, /0\.1\.4/);
-  assert.match(releasePacket, /0\.2\.0/);
-  assert.match(releasePacket, /0\.2\.5/);
 });
 
-test("MCP 0.2.0 release packet proves the cockpit-expansion contract without inheriting 0.2.5 hardening", async () => {
-  const [releaseNotes, releasePacket, packageReadme, aiGuide, quickstart] = await Promise.all([
-    readRepoFile(path.join("docs", "release", "MCP-0.2.0-RELEASE-NOTES.md")),
-    readRepoFile(path.join("docs", "release", "MCP-0.2.0-RELEASE-PACKET.md")),
+test("release notes for 0.3.0 describe the adoption slice in customer-facing language", async () => {
+  const releaseNotes = await readRepoFile(path.join("docs", "release", "MCP-0.3.0-RELEASE-NOTES.md"));
+
+  assert.match(releaseNotes, /0\.3\.0/);
+  assert.match(releaseNotes, /adoption/i);
+  assert.match(releaseNotes, /Codex|Claude Code|Gemini|Cursor|VS Code/);
+  assert.doesNotMatch(releaseNotes, /tenant|billing|mission-control|control-plane/i);
+});
+
+test("public MCP docs stay free of internal workspace leakage", async () => {
+  const docsToScan = await Promise.all([
     readRepoFile(path.join("packages", "mcp", "README.md")),
     readRepoFile(path.join("docs", "oss", "MCP-FOR-AI-AGENTS.md")),
-    readRepoFile(path.join("docs", "oss", "QUICKSTART.md"))
+    readRepoFile(path.join("docs", "release", "MCP-0.2.7-RELEASE-NOTES.md")),
+    readRepoFile(path.join("docs", "release", "MCP-0.3.0-RELEASE-NOTES.md")),
+    readRepoFile(path.join("docs", "release", "MCP-0.3.1-RELEASE-NOTES.md")),
+    readRepoFile(path.join("docs", "release", "MCP-0.3.2-RELEASE-NOTES.md"))
   ]);
 
-  assert.match(releasePacket, /Martin MCP `0\.2\.0` Release Packet/);
-  assert.match(releasePacket, /0\.2\.0 cockpit expansion contract/i);
-  assert.match(releasePacket, /Cockpit Expansion Contract/);
-  assert.match(releasePacket, /Contract Boundary/);
-  assert.match(releasePacket, /Evidence/);
-  assert.match(releasePacket, /Known Non-Goals/);
-  assert.match(releasePacket, /Later-Line Boundary/);
-
-  for (const contents of [releaseNotes, releasePacket]) {
-    assert.match(contents, /resources/i);
-    assert.match(contents, /resource templates/i);
-    assert.match(contents, /prompts/i);
-    assert.match(contents, /read-only/i);
-
-    for (const toolName of COCKPIT_020_TOOLS) {
-      assert.match(contents, new RegExp(escapeRegex(toolName)));
-    }
-
-    for (const resourceUri of COCKPIT_020_RESOURCES) {
-      assert.match(contents, new RegExp(escapeRegex(resourceUri)));
-    }
-
-    for (const promptName of COCKPIT_020_PROMPTS) {
-      assert.match(contents, new RegExp(escapeRegex(promptName)));
-    }
-  }
-
-  const releaseNotesContract = sectionBetween(releaseNotes, "## What Shipped", "## Release Verification Gates");
-  const releasePacketContract = sectionBetween(releasePacket, "## Cockpit Expansion Contract", "## Later-Line Boundary");
-
-  for (const contents of [releaseNotesContract, releasePacketContract]) {
-    for (const laterSurface of LATER_025_SURFACES) {
-      assert.doesNotMatch(contents, new RegExp(escapeRegex(laterSurface), "i"));
-    }
-    assert.doesNotMatch(contents, /public MCP package line/i);
-  }
-
-  assert.match(releasePacket, /0\.2\.5 public MCP package line/i);
-  for (const laterSurface of LATER_025_SURFACES) {
-    assert.match(releasePacket, new RegExp(escapeRegex(laterSurface), "i"));
-  }
-
-  for (const contents of [packageReadme, aiGuide, quickstart]) {
-    assert.match(contents, /0\.2\.0 cockpit expansion/i);
-    assert.match(contents, /0\.2\.5 public MCP package line/i);
-    assert.match(contents, /0\.2\.0 adds resources, resource templates, prompts, and read-only cockpit inspection/i);
-    assert.match(contents, /0\.2\.5 adds triage and degraded run-store hardening/i);
-  }
-});
-
-test("MCP 0.2.0 public contract docs avoid private workspace leakage", async () => {
   const forbiddenPatterns = [
-    /\b[A-Za-z0-9._-]+_Internal\b/,
-    /martin-Loop\/[A-Za-z0-9._-]+/,
-    /[A-Z]:\\Users\\/,
-    /[A-Z]:\\[^\\\r\n]+\\OneDrive\\/i,
-    /\/Users\//,
-    /\/home\//,
-    /docs\/internal/i,
-    /private mirror/i,
-    /private package/i,
-    /private hosted/i,
-    /private beta/i,
-    /control-plane/i,
-    /enterprise\/apps/i,
-    /principal-aware remote config/i,
-    /autonomy\/router/i
+    /ML_Main_Repo_Internal/,
+    /ML_Core_OSS_Internal/,
+    /martin-Loop\/ML_/,
+    /martin-loop_MAIN_FULL_REPO/,
+    /C:\\Users\\/,
+    /OneDrive/,
+    /docs\/internal/,
+    /codex\//,
+    /enterprise\/apps\/control-plane/
   ];
 
-  for (const relativePath of PUBLIC_CONTRACT_DOCS) {
-    const contents = await readRepoFile(relativePath);
-
+  for (const contents of docsToScan) {
     for (const pattern of forbiddenPatterns) {
-      assert.doesNotMatch(contents, pattern, `${relativePath} must not leak ${pattern}`);
+      assert.doesNotMatch(contents, pattern);
     }
-  }
-});
-
-test("MCP docs stay aligned with the actual cockpit surface", async () => {
-  const [serverSource, readme, aiGuide, quickstart, ossReadme, rootReadme, resourcesSource, promptsSource] = await Promise.all([
-    readRepoFile(path.join("packages", "mcp", "src", "server.ts")),
-    readRepoFile(path.join("packages", "mcp", "README.md")),
-    readRepoFile(path.join("docs", "oss", "MCP-FOR-AI-AGENTS.md")),
-    readRepoFile(path.join("docs", "oss", "QUICKSTART.md")),
-    readRepoFile(path.join("docs", "oss", "README.md")),
-    readRepoFile("README.md"),
-    readRepoFile(path.join("packages", "mcp", "src", "resources.ts")),
-    readRepoFile(path.join("packages", "mcp", "src", "prompts.ts"))
-  ]);
-
-  const codexSnippet = "codex mcp add martin-loop -- npx -y @martinloop/mcp";
-  const claudeUnixSnippet =
-    "claude mcp add --transport stdio --scope user martin-loop -- npx -y @martinloop/mcp";
-  const claudeWindowsSnippet =
-    "claude mcp add --transport stdio --scope user martin-loop -- cmd /c npx -y @martinloop/mcp";
-  const toolNames = extractMartinToolNames(serverSource);
-
-  assert.deepEqual(toolNames, EXPECTED_TOOLS);
-  assert.match(serverSource, /capabilities:\s*\{\s*tools:\s*\{\s*\},\s*resources:\s*\{\s*\},\s*prompts:\s*\{\s*\}\s*\}/);
-  assert.match(serverSource, /ListResourcesRequestSchema/);
-  assert.match(serverSource, /ListResourceTemplatesRequestSchema/);
-  assert.match(serverSource, /ReadResourceRequestSchema/);
-  assert.match(serverSource, /ListPromptsRequestSchema/);
-  assert.match(serverSource, /GetPromptRequestSchema/);
-
-  for (const contents of [readme, aiGuide, quickstart]) {
-    assert.match(contents, new RegExp(escapeRegex(codexSnippet)));
-    assert.match(contents, new RegExp(escapeRegex(claudeUnixSnippet)));
-    assert.match(contents, new RegExp(escapeRegex(claudeWindowsSnippet)));
-
-    for (const toolName of EXPECTED_TOOLS) {
-      assert.match(contents, new RegExp(escapeRegex(toolName)));
-    }
-
-    for (const resourceUri of EXPECTED_RESOURCES) {
-      assert.match(contents, new RegExp(escapeRegex(resourceUri)));
-    }
-
-    for (const promptName of EXPECTED_PROMPTS) {
-      assert.match(contents, new RegExp(escapeRegex(promptName)));
-    }
-  }
-
-  for (const resourceUri of EXPECTED_RESOURCES) {
-    assert.match(resourcesSource, new RegExp(escapeRegex(resourceUri)));
-  }
-
-  for (const promptName of EXPECTED_PROMPTS) {
-    assert.match(promptsSource, new RegExp(escapeRegex(promptName)));
-  }
-
-  assertOrderedSubstrings(readme, [
-    "martin_doctor",
-    "martin_plan",
-    "martin_preflight",
-    "martin_run",
-    "martin_status",
-    "martin_dossier"
-  ]);
-  assertOrderedSubstrings(aiGuide, [
-    "martin_doctor",
-    "martin_plan",
-    "martin_preflight",
-    "martin_run",
-    "martin_status",
-    "martin_dossier"
-  ]);
-  assertOrderedSubstrings(quickstart, [
-    "martin_doctor",
-    "martin_plan",
-    "martin_preflight",
-    "martin_run",
-    "martin_status",
-    "martin_dossier"
-  ]);
-  assert.match(readme, new RegExp(escapeRegex(`docs/release/MCP-${packageJson.version}-RELEASE-NOTES.md`)));
-  assert.match(readme, /io\.github\.Keesan12\/martin-loop/);
-  assert.match(ossReadme, /mcp:published:smoke:pack/);
-  assert.match(ossReadme, /post-publish npm gate/i);
-  assert.match(rootReadme, /smoke:published:pack/);
-  assert.match(rootReadme, /verify:release/);
-  assert.match(rootReadme, /io\.github\.Keesan12\/martin-loop/);
-  for (const contents of [readme, aiGuide, quickstart, ossReadme, rootReadme]) {
-    assert.doesNotMatch(contents, /paid-remote/i);
-    assert.doesNotMatch(contents, /principal-aware remote config/i);
-  }
-});
-
-test("MCP release docs preserve publish gates and current cockpit claims", async () => {
-  const [publishingDoc, releaseNotes, compatibilityDoc, checklistDoc, versionLedger, releasePacket, deliveryMap] = await Promise.all([
-    readRepoFile(path.join("docs", "release", "MCP-PUBLISHING.md")),
-    readRepoFile(path.join("docs", "release", `MCP-${packageJson.version}-RELEASE-NOTES.md`)),
-    readRepoFile(path.join("docs", "release", "MCP-COMPATIBILITY.md")),
-    readRepoFile(path.join("docs", "release", "MCP-RELEASE-CHECKLIST.md")),
-    readRepoFile(path.join("docs", "release", "VERSION-LEDGER.md")),
-    readRepoFile(path.join("docs", "release", `MCP-${packageJson.version}-RELEASE-PACKET.md`)),
-    readRepoFile(path.join("docs", "release", "MCP-DELIVERY-SLICE-MAP.md"))
-  ]);
-
-  assert.match(publishingDoc, /smoke:published:pack/);
-  assert.match(publishingDoc, /smoke:published/);
-  assert.match(publishingDoc, /separate gates/i);
-  assert.match(publishingDoc, /tools, resources, resource templates, and prompts/i);
-  assert.match(publishingDoc, /run-triage surface/i);
-  assert.match(publishingDoc, /martin_run_dossier/);
-  assert.match(publishingDoc, /martin_triage_runs/);
-  assert.match(publishingDoc, /io\.github\.Keesan12\/martin-loop/);
-
-  assert.match(releaseNotes, new RegExp(`@martinloop/mcp v${packageJson.version.replaceAll(".", "\\.")}`));
-  assert.match(releaseNotes, /martin_list_runs/);
-  assert.match(releaseNotes, /martin_triage_runs/);
-  assert.match(releaseNotes, /martin_run_dossier/);
-  assert.match(releaseNotes, /resources/i);
-  assert.match(releaseNotes, /prompts/i);
-  assert.match(releaseNotes, /run triage/i);
-
-  assert.match(compatibilityDoc, /martin_run remains the only execution entrypoint/i);
-  assert.match(compatibilityDoc, /resources, resource templates, and prompts are additive/i);
-  assert.match(checklistDoc, /MCP-X\.Y\.Z-RELEASE-PACKET\.md/);
-  assert.match(checklistDoc, /Release Proof/i);
-  assert.match(checklistDoc, /packages\/mcp/);
-  assert.match(checklistDoc, /candidate checkout/i);
-  assert.match(versionLedger, /@martinloop\/mcp/);
-  assert.match(versionLedger, /0\.1\.3/);
-  assert.match(versionLedger, /0\.2\.5/);
-  assert.match(releasePacket, /release CI is green on Windows, Linux, and macOS/i);
-  assert.match(deliveryMap, /0\.1\.4/);
-  assert.match(deliveryMap, /0\.2\.0/);
-  assert.match(deliveryMap, /0\.2\.5/);
-  assert.match(deliveryMap, /unrelated application packages/i);
-  assert.match(deliveryMap, /martin_run` remains the only write-capable entrypoint/i);
-
-  for (const contents of [publishingDoc, compatibilityDoc, releaseNotes]) {
-    assert.doesNotMatch(contents, /0\.3\.0/);
-  }
-});
-
-test("public release docs avoid non-public release language", async () => {
-  const [rootReadme, contextDoc, versionLedger, deliveryMap, publishingDoc, releaseNotes, releasePacket] =
-    await Promise.all([
-      readRepoFile("README.md"),
-      readRepoFile("CONTEXT.md"),
-      readRepoFile(path.join("docs", "release", "VERSION-LEDGER.md")),
-      readRepoFile(path.join("docs", "release", "MCP-DELIVERY-SLICE-MAP.md")),
-      readRepoFile(path.join("docs", "release", "MCP-PUBLISHING.md")),
-      readRepoFile(path.join("docs", "release", `MCP-${packageJson.version}-RELEASE-NOTES.md`)),
-      readRepoFile(path.join("docs", "release", `MCP-${packageJson.version}-RELEASE-PACKET.md`))
-    ]);
-
-  for (const contents of [rootReadme, contextDoc, versionLedger, deliveryMap, publishingDoc, releaseNotes, releasePacket]) {
-    assert.match(contents, /0\.1\.4/);
-    assert.match(contents, /operator foundation/i);
-    assert.match(contents, /0\.2\.0/);
-    assert.match(contents, /cockpit expansion/i);
-    assert.match(contents, /0\.2\.5/);
-    assert.match(contents, /public MCP package line/i);
-  }
-
-  for (const contents of [rootReadme, contextDoc, deliveryMap, publishingDoc, releaseNotes, releasePacket]) {
-    assert.doesNotMatch(contents, /\bPro\b/);
-    assert.doesNotMatch(contents, /\bGrowth\b/);
-    assert.doesNotMatch(contents, /\bEnterprise\b/);
-    assert.doesNotMatch(contents, /\bInternal\b/);
-    assert.doesNotMatch(contents, /control-plane/i);
-    assert.doesNotMatch(contents, /autonomy/i);
-    assert.doesNotMatch(contents, /router/i);
-    assert.doesNotMatch(contents, /paid-remote/i);
-    assert.doesNotMatch(contents, /remote MCP private beta/i);
-    assert.doesNotMatch(contents, /principal-aware remote config/i);
   }
 });


### PR DESCRIPTION
## Summary
- publish the standalone MCP adoption release as 0.3.0
- refresh MCP release notes, delivery maps, and compatibility docs
- align package metadata and release-doc tests with the 0.3.0 cut

## Validation
- pnpm test
- pnpm build
- pnpm public:git-surface
- pnpm oss:validate
- pnpm public:smoke
- pnpm release:matrix:local
- pnpm --filter @martinloop/mcp lint
- pnpm --filter @martinloop/mcp test
- pnpm --filter @martinloop/mcp build
- pnpm --filter @martinloop/mcp smoke:pack
- pnpm --filter @martinloop/mcp smoke:published:pack
- pnpm --filter @martinloop/mcp verify:release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Simplified MCP documentation and public-facing guidance for clarity and easier onboarding.
  * Added comprehensive release notes for upcoming versions 0.3.0, 0.3.1, and 0.3.2.
  * Updated compatibility expectations and delivery roadmap documentation.
  * Reorganized package README with streamlined installation and usage instructions.

* **Chores**
  * Upgraded MCP package version to 0.3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->