### PR TITLE
feat: release martin-loop 0.3.0 share receipts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.3.0]
+
+### Added
+- **`martin share --latest`** - the public CLI can now write a local share bundle for the latest governed run, including a redacted JSON receipt, a Markdown recap, and a proof-card SVG.
+
+### Changed
+- Root public docs now treat share receipts as a first-class part of the governed workflow instead of an internal follow-up step.
+- Public release bookkeeping now reflects the live standalone MCP `0.3.0` baseline and keeps the root and MCP lines separate.
+
 ## [0.2.11]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -29,11 +29,14 @@ npx martin-loop session-start
 npx martin-loop preflight "Summarize the demo workspace and prove tests still pass" --verify "npm test"
 npx martin-loop run "Summarize the demo workspace and prove tests still pass" --proof --verify "npm test"
 npx martin-loop dossier --latest
+npx martin-loop share --latest
 ```
 
 `doctor`, `session-start`, and `preflight` create the local receipts MartinLoop expects before a real governed run. If you intentionally need to bypass that local gate for a one-off run, use `--unsafe-allow-unguarded-run` explicitly.
 
-Release notes for the current root package: [MartinLoop 0.2.11](./docs/release/OSS-0.2.11-RELEASE-NOTES.md).
+`share --latest` writes three files into the selected run directory under `share/`: `run-receipt.json`, `run-receipt.md`, and `proof-card.svg`.
+
+Release notes for the current root package: [MartinLoop 0.3.0](./docs/release/OSS-0.3.0-RELEASE-NOTES.md).
 
 ## What It Does
 
@@ -41,6 +44,7 @@ Release notes for the current root package: [MartinLoop 0.2.11](./docs/release/O
 - Verifier gates require a real check, such as `npm test`, before a run can count as complete.
 - Policy checks block unsafe verifier commands, risky path changes, and secret-like task inputs before execution.
 - Run receipts capture stop reason, verifier evidence, budget posture, integrity state, and the next safe action.
+- `martin share --latest` turns the latest governed run into a local share bundle with a redacted JSON receipt, Markdown recap, and proof-card SVG.
 - MCP integration gives hosts one write-capable execution entrypoint plus richer planning, inspection, and review helpers.
 
 ## How It Works
@@ -68,10 +72,13 @@ martin-loop runs list|get|attempt|verify ...
 martin-loop mcp print-config --host <codex|claude|gemini|generic>
 martin-loop mcp install --host <codex|claude|gemini|generic>
 martin-loop challenge [--loop-id <id> | --file <path> | --latest]
+martin-loop share (--loop-id <id> | --file <path> | --latest) [--out-dir <path>]
 martin-loop badge [--format svg|json] [--runs-dir <path>]
 ```
 
 Examples below use `npx martin-loop` so they work without a global install. If you install `martin-loop` globally, the `martin` alias works too.
+
+Use `martin-loop share --latest` after `dossier` when you want a redacted bundle you can hand to another person without sending raw run-store files.
 
 More detail: [CLI reference](./docs/reference/cli.md) and [configuration reference](./docs/reference/config.md).
 
@@ -100,7 +107,7 @@ npx martin-loop mcp print-config --host gemini --transport stdio --profile full-
 npx martin-loop mcp print-config --host generic --transport stdio --profile github-review
 ```
 
-The root `martin-loop` package and the standalone `@martinloop/mcp` package move on separate version lines. The root package is `0.2.11`; the current standalone MCP package is `0.2.7`.
+The root `martin-loop` package and the standalone `@martinloop/mcp` package move on separate version lines. The root package is `0.3.0`; the current standalone MCP package is `0.3.0`.
 
 The public MCP release train labels are:
 
@@ -108,6 +115,7 @@ The public MCP release train labels are:
 - `0.2.0` cockpit expansion
 - `0.2.5` public MCP package line
 - `0.2.7` usability and review release
+- `0.3.0` host adoption and onboarding release
 
 The standalone MCP registry/server identifier is `io.github.Keesan12/martin-loop`.
 

--- a/docs/getting-started/examples.md
+++ b/docs/getting-started/examples.md
@@ -52,6 +52,20 @@ pnpm run:cli -- run \
   --max-iterations 2
 ```
 
+## Share The Latest Receipt
+
+```sh
+pnpm run:cli -- share --latest
+```
+
+By default MartinLoop writes the bundle into the selected run directory under `share/`:
+
+- `run-receipt.json`
+- `run-receipt.md`
+- `proof-card.svg`
+
+Use `--out-dir <path>` when you want the bundle somewhere else.
+
 ## MCP Invocation Shape
 
 Example `martin_run` payload:

--- a/docs/getting-started/mcp.md
+++ b/docs/getting-started/mcp.md
@@ -2,7 +2,7 @@
 
 The `@martinloop/mcp` package exposes MartinLoop through stdio for MCP-capable hosts.
 
-`0.2.7` is the current public MCP package line. It adds a stronger guided flow for hosts and a stricter run gate so `martin_run` only starts after the matching readiness, planning, and preflight steps have happened.
+`0.3.0` is the current public MCP package line. It adds a stronger guided flow for hosts and a stricter run gate so `martin_run` only starts after the matching readiness, planning, and preflight steps have happened.
 
 ## Install
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -20,6 +20,7 @@ npx martin-loop session-start
 npx martin-loop preflight "Summarize the demo workspace and prove tests still pass" --verify "npm test"
 npx martin-loop run "Summarize the demo workspace and prove tests still pass" --proof --verify "npm test"
 npx martin-loop dossier --latest
+npx martin-loop share --latest
 ```
 
 This path creates the local receipts MartinLoop expects before a real governed run, then proves the run/dossier loop without model spend.
@@ -47,9 +48,12 @@ By default, MartinLoop expects recent `doctor`, `session-start`, and `preflight`
 ```sh
 npx martin-loop triage
 npx martin-loop dossier --latest
+npx martin-loop share --latest
 ```
 
-Use `triage` to rank saved runs by urgency. Use `dossier` when you want one run receipt: stop reason, verifier evidence, budget status, rollback or artifact evidence, and the next safe action.
+Use `triage` to rank saved runs by urgency. Use `dossier` when you want one run receipt: stop reason, verifier evidence, budget status, rollback or artifact evidence, and the next safe action. Use `share` when you want a redacted bundle you can attach to a ticket, send to a teammate, or keep with the run directory.
+
+The share bundle contains `run-receipt.json`, `run-receipt.md`, and `proof-card.svg`.
 
 ## Repository Development
 

--- a/docs/oss/MCP-FOR-AI-AGENTS.md
+++ b/docs/oss/MCP-FOR-AI-AGENTS.md
@@ -1,6 +1,6 @@
 # MCP For AI Agents
 
-`@martinloop/mcp@0.2.7` is the current public standalone MCP baseline for MartinLoop.
+`@martinloop/mcp@0.3.0` is the current public standalone MCP baseline for MartinLoop.
 
 It is built for hosts that need a governed local-first workflow, not a vague bag of tools.
 

--- a/docs/oss/QUICKSTART.md
+++ b/docs/oss/QUICKSTART.md
@@ -1,6 +1,6 @@
 # Quickstart
 
-This quickstart covers the public OSS runtime and the standalone `@martinloop/mcp@0.2.7` cockpit line.
+This quickstart covers the public OSS runtime and the standalone `@martinloop/mcp@0.3.0` adoption line.
 
 ## Public Release Train
 
@@ -8,6 +8,7 @@ This quickstart covers the public OSS runtime and the standalone `@martinloop/mc
 - 0.2.0 cockpit expansion. 0.2.0 adds resources, resource templates, prompts, and read-only cockpit inspection.
 - 0.2.5 public MCP package line. 0.2.5 adds triage and degraded run-store hardening, plus the command-center workflow surfaces.
 - 0.2.7 usability and review release. 0.2.7 clarifies the guided path and tightens public package presentation.
+- 0.3.0 adoption release. 0.3.0 makes MartinLoop feel more native inside common agent hosts.
 
 ## Prerequisites
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -16,6 +16,7 @@ martin-loop dossier (--latest | --loop-id <id> | --file <path>)
 martin-loop inspect --file <path>
 martin-loop resume <loopId>
 martin-loop challenge [--loop-id <id> | --file <path> | --latest] [--format markdown|svg]
+martin-loop share (--loop-id <id> | --file <path> | --latest) [--out-dir <path>]
 martin-loop badge [--format svg|json] [--runs-dir <path>]
 martin-loop runs list|get|attempt|verify ...
 martin-loop mcp print-config --host <codex|claude|gemini|generic>
@@ -34,6 +35,7 @@ npx martin-loop doctor
 npx martin-loop session-start
 npx martin-loop preflight "Summarize the workspace and prove tests still pass" --verify "npm test"
 npx martin-loop run "Summarize the workspace and prove tests still pass" --proof --verify "npm test"
+npx martin-loop share --latest
 ```
 
 ## Run Options
@@ -66,6 +68,7 @@ npx martin-loop run "Summarize the workspace and prove tests still pass" --proof
 
 ```text
 --runs-dir <path>       Override the Martin runs root for guided flow receipts, persisted evidence views, and badge generation
+--out-dir <path>        Override where `martin share` writes the local share bundle
 ```
 
 ## Evidence Commands
@@ -88,8 +91,28 @@ Compatibility views remain available:
 npx martin-loop inspect --file ~/.martin/runs/<workspaceId>.jsonl
 npx martin-loop resume <loopId>
 npx martin-loop challenge --latest
+npx martin-loop share --latest
 npx martin-loop badge --format json --runs-dir ~/.martin/runs
 ```
+
+## Share command
+
+Use `share` when you want a reviewable bundle for the latest governed run or a specific saved run.
+
+```sh
+npx martin-loop share --latest
+npx martin-loop share --loop-id <loopId>
+npx martin-loop share --file ~/.martin/runs/<loopId>/loop-record.json
+npx martin-loop share --latest --out-dir ./receipts
+```
+
+By default MartinLoop writes:
+
+- `run-receipt.json`
+- `run-receipt.md`
+- `proof-card.svg`
+
+The default output location is the selected run directory under `share/`.
 
 ## Phase Commands
 

--- a/docs/reference/mcp-compatibility.md
+++ b/docs/reference/mcp-compatibility.md
@@ -7,7 +7,7 @@
 - The root `martin-loop` package provides the public CLI, SDK, demo workspace, and top-level release notes.
 - The standalone `@martinloop/mcp` package stays on its own version line.
 - The server identifier remains `io.github.Keesan12/martin-loop`.
-- The current public standalone MCP package line is `0.2.7`.
+- The current public standalone MCP package line is `0.3.0`.
 
 ## Stability Commitments
 

--- a/docs/release/MCP-COMPATIBILITY.md
+++ b/docs/release/MCP-COMPATIBILITY.md
@@ -1,10 +1,10 @@
 # MCP Compatibility
 
-This document describes the compatibility posture for the public standalone MCP line after `@martinloop/mcp@0.2.7`.
+This document describes the compatibility posture for the public standalone MCP line after `@martinloop/mcp@0.3.0`.
 
 ## Current baseline
 
-`0.2.7` is the current public baseline.
+`0.3.0` is the current public baseline.
 
 It keeps the standalone server local-first and stdio-first, and it assumes a governed MartinLoop workflow:
 

--- a/docs/release/MCP-DELIVERY-SLICE-MAP.md
+++ b/docs/release/MCP-DELIVERY-SLICE-MAP.md
@@ -1,36 +1,12 @@
-# Martin MCP Delivery Slice Map
+# Martin MCP Release Map
 
-This map defines the next public standalone MCP releases after the live `0.2.7` baseline. The point is to keep each release narrow, legible, and easy to validate.
+This map defines the next public standalone MCP releases after the live `0.3.0` baseline. The point is to keep each release narrow, legible, and easy to validate.
 
 ## Live baseline
 
-- public npm baseline: `0.2.7`
-- public GitHub release baseline: `mcp-v0.2.7`
-- next release to prepare: `0.3.0`
-
-## `0.3.0` — Adoption Pack
-
-Story: make MartinLoop feel native inside agent hosts without widening into hosted or non-OSS territory.
-
-Include:
-- stronger setup and bootstrap guidance for Codex, Claude Code, Gemini, Cursor, and VS Code
-- clearer `martin_start` guidance and next-step resources
-- built-in command map and operating-rules resources
-- safer discovery metadata and first-run guidance
-- public docs that show the recommended local-first workflow end to end
-
-Do not include:
-- hosted endpoints
-- bearer-auth remote config defaults
-- tenant or org language
-- billing or mission-control claims
-- non-OSS review routes
-
-Primary public surfaces:
-- `packages/mcp/README.md`
-- `docs/oss/MCP-FOR-AI-AGENTS.md`
-- `docs/oss/QUICKSTART.md`
-- `docs/release/MCP-0.3.0-RELEASE-NOTES.md`
+- public npm baseline: `0.3.0`
+- public GitHub release baseline: `mcp-v0.3.0`
+- next release to prepare: `0.3.1`
 
 ## `0.3.1` — Review And Handoff Controls
 

--- a/docs/release/MCP-PUBLISHING.md
+++ b/docs/release/MCP-PUBLISHING.md
@@ -4,8 +4,8 @@ The standalone MCP line is published as its own package. Treat it like a product
 
 ## Current public truth
 
-- live public standalone release: `@martinloop/mcp@0.2.7`
-- next planned standalone release: `0.3.0`
+- live public standalone release: `@martinloop/mcp@0.3.0`
+- next planned standalone release: `0.3.1`
 - publish authority: GitHub Actions trusted publishing / OIDC
 
 ## Before publish

--- a/docs/release/OSS-0.3.0-RELEASE-NOTES.md
+++ b/docs/release/OSS-0.3.0-RELEASE-NOTES.md
@@ -1,0 +1,60 @@
+# MartinLoop 0.3.0
+
+MartinLoop `0.3.0` adds a real share command to the public root CLI.
+
+It is a small release on purpose: finish a governed run, package the evidence cleanly, and hand it to another person without leaking workstation paths.
+
+## What changed
+
+- `martin share --latest` now writes a local share bundle for the latest governed run.
+- The bundle includes:
+  - `run-receipt.json`
+  - `run-receipt.md`
+  - `proof-card.svg`
+- Generated share artifacts redact absolute workstation paths so the bundle is safe to hand to another person or attach to a ticket.
+- The share bundle uses the canonical run directory by default and supports `--out-dir` when you want to write somewhere else.
+
+## Why it matters
+
+Before `0.3.0`, the public CLI could inspect a run, but sharing usually meant copying raw JSON or screenshots by hand. `share` turns the existing run evidence into a tidy bundle that is easier to review, attach, archive, or pass to another engineer.
+
+## Start here
+
+```sh
+npx martin-loop doctor
+npx martin-loop session-start
+npx martin-loop preflight "Summarize the workspace and prove tests still pass" --verify "npm test"
+npx martin-loop run "Summarize the workspace and prove tests still pass" --proof --verify "npm test"
+npx martin-loop dossier --latest
+npx martin-loop share --latest
+```
+
+## What you get
+
+After a successful run, `martin share --latest` writes a bundle under the selected run directory in `share/`:
+
+- `run-receipt.json` for machine-readable audit data
+- `run-receipt.md` for a human summary
+- `proof-card.svg` for a portable visual proof card
+
+If you want the bundle somewhere else, pass `--out-dir <path>`.
+
+## Upgrade notes
+
+- `share` is a packaging step for existing governed evidence; it does not replace `dossier`, `triage`, or `runs get`.
+- The public `0.3.0` share surface is local-first. It does not post anywhere, upload anything, or assume hosted infrastructure.
+- Absolute paths and file URIs are redacted before the share bundle is written.
+
+## Validation
+
+`0.3.0` ships through the standard public root release gate:
+
+- `pnpm install --frozen-lockfile`
+- `pnpm lint`
+- `pnpm test`
+- `pnpm build`
+- `pnpm public:git-surface`
+- `pnpm oss:validate`
+- `pnpm public:smoke`
+- `pnpm release:matrix:local`
+- `node ./scripts/root-release-guard.mjs --tag v0.3.0 --pack`

--- a/docs/release/OSS-0.3.1-RELEASE-NOTES.md
+++ b/docs/release/OSS-0.3.1-RELEASE-NOTES.md
@@ -1,0 +1,19 @@
+# MartinLoop 0.3.1
+
+`0.3.1` is reserved for the next root-package slice after share receipts.
+
+## Planned scope
+
+- multi-model compatibility polish
+- broader local IDE setup guidance
+- compatibility docs that match the adapters already shipped in the public package
+
+## Out of scope
+
+- hosted transport
+- control-plane features
+- billing, team, or tenant workflows
+
+## Release gate
+
+The shipped adapter and IDE guidance must match the public package exactly, with no hosted or private-product bleed.

--- a/docs/release/ROOT-DELIVERY-SLICE-MAP.md
+++ b/docs/release/ROOT-DELIVERY-SLICE-MAP.md
@@ -1,0 +1,51 @@
+# Root Release Map
+
+This map keeps the public root-package release train narrow and readable. The root `martin-loop` package and the standalone `@martinloop/mcp` package move on separate version lines.
+
+## Baseline
+
+- live root baseline: `0.2.11`
+- next root release to cut: `0.3.0`
+- next follow-on after that: `0.3.1`
+
+## `0.3.0` — Shareable Run Receipts
+
+Story: make governed MartinLoop runs easier to hand to another person without copying raw JSON by hand.
+
+Includes:
+
+- `martin share --latest`
+- `martin share --loop-id <id>`
+- `martin share --file <path>`
+- redacted `run-receipt.json`
+- human-readable `run-receipt.md`
+- `proof-card.svg`
+
+Does not include:
+
+- automatic social posting
+- hosted upload flows
+- PNG rendering
+- browser or clipboard integration
+
+Release gate:
+
+- the share command works from a packed install
+- the bundle lands in the canonical run directory by default, or an explicit `--out-dir`
+- absolute workstation paths are redacted from the generated artifacts
+
+## `0.3.1` — Multi-Model And Multi-IDE Compatibility
+
+Story: broaden local compatibility after the share flow is established.
+
+Includes:
+
+- compatibility docs and examples for the adapters that are already shipped
+- clearer host coverage for local-first IDE and model setups
+- install guidance that matches the actual public package surfaces
+
+Does not include:
+
+- hosted transport
+- private control-plane features
+- billing, team, or tenant language

--- a/docs/release/VERSION-LEDGER.md
+++ b/docs/release/VERSION-LEDGER.md
@@ -1,6 +1,6 @@
 # Version Ledger
 
-This file is the internal source of truth for release work. Check it before you cut a branch, update docs, or talk about npm state.
+This file is the release source of truth for package/version mapping in this repo. Check it before you cut a branch, update docs, or talk about npm state.
 
 ## Root package: `martin-loop`
 
@@ -17,13 +17,12 @@ This file is the internal source of truth for release work. Check it before you 
 
 ## Standalone package: `@martinloop/mcp`
 
-- live npm dist-tag `latest`: `0.2.7`
-- live public GitHub release: `mcp-v0.2.7`
-- live public baseline in this train: `0.2.7`
-- standalone MCP public baseline: `0.2.7`
-- next planned standalone release: `0.3.0` for host adoption and onboarding
+- live npm dist-tag `latest`: `0.3.0`
+- live public GitHub release: `mcp-v0.3.0`
+- live public baseline in this train: `0.3.0`
+- standalone MCP public baseline: `0.3.0`
+- next planned standalone release: `0.3.1` for review and handoff controls
 - next planned follow-ons:
-  - `0.3.1` review and handoff controls
   - `0.3.2` opt-in execution controls
 
 ## Release rules

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "martin-loop",
   "private": false,
-  "version": "0.2.11",
+  "version": "0.3.0",
   "type": "module",
-  "description": "Open-source command center for governed AI coding agents with built-in onboarding, hard gates, CLI, MCP, and run receipts.",
+  "description": "Open-source command center for governed AI coding agents with built-in onboarding, hard gates, MCP, and shareable run receipts.",
   "packageManager": "pnpm@10.33.0",
   "keywords": [
     "mcp",
@@ -14,6 +14,8 @@
     "budget-enforcement",
     "verifier-gates",
     "audit-trail",
+    "run-receipts",
+    "agent-receipts",
     "claude-code",
     "codex",
     "llmops",

--- a/packages/adapters/src/runtime-support.ts
+++ b/packages/adapters/src/runtime-support.ts
@@ -12,6 +12,7 @@ export function createAdapterCapabilities(
     diffArtifacts: false,
     structuredErrors: false,
     cachingSignals: false,
+    workspaceMutations: true,
     ...overrides
   };
 }

--- a/packages/adapters/src/stub-direct-provider.ts
+++ b/packages/adapters/src/stub-direct-provider.ts
@@ -16,6 +16,9 @@ export function createStubDirectProviderAdapter(
     providerId: options.providerId,
     model: options.model,
     label: options.label ?? `Stub direct provider (${options.providerId}/${options.model})`,
+    capabilities: {
+      workspaceMutations: false
+    },
     responder: options.responder
   });
 }

--- a/packages/adapters/src/verifier-only.ts
+++ b/packages/adapters/src/verifier-only.ts
@@ -29,16 +29,24 @@ export function createVerifierOnlyAdapter(
       })
     },
     async execute(request) {
-      const baselineChangedFiles = new Set(await readGitChangedFiles(workingDirectory, 5_000));
+      const shouldTrackVerifierWrites =
+        request.context.verificationPlan.length > 0 ||
+        (request.context.verificationStack?.length ?? 0) > 0;
+
+      const baselineChangedFiles = shouldTrackVerifierWrites
+        ? new Set(await readGitChangedFiles(workingDirectory, 5_000))
+        : new Set<string>();
       const verification = await runVerification(
         request.context.verificationPlan,
         workingDirectory,
         verifyTimeoutMs,
         request.context.verificationStack
       );
-      const changedFiles = (await readGitChangedFiles(workingDirectory, 5_000)).filter(
-        (file) => !baselineChangedFiles.has(file)
-      );
+      const changedFiles = shouldTrackVerifierWrites
+        ? (await readGitChangedFiles(workingDirectory, 5_000)).filter(
+            (file) => !baselineChangedFiles.has(file)
+          )
+        : [];
       const execution = { changedFiles };
 
       if (verification.passed) {

--- a/packages/adapters/tests/stub-adapters.test.ts
+++ b/packages/adapters/tests/stub-adapters.test.ts
@@ -20,6 +20,7 @@ describe("createStubDirectProviderAdapter", () => {
     expect(adapter.metadata.providerId).toBe("openai");
     expect(adapter.metadata.transport).toBe("http");
     expect(adapter.metadata.capabilities.usageSettlement).toBe(true);
+    expect(adapter.metadata.capabilities.workspaceMutations).toBe(false);
     expect(result.status).toBe("failed");
     expect(result.failure?.message).toContain("not configured");
     expect(result.usage.actualUsd).toBe(0);

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -13,6 +13,7 @@ The CLI now treats execution, diagnosis, persisted-run inspection, and MCP host 
 - `martin run`
 - `martin triage`
 - `martin dossier`
+- `martin share`
 - `martin runs list|get|attempt|verify`
 - `martin mcp print-config`
 - `martin mcp install`
@@ -54,10 +55,13 @@ martin preflight "repair the flaky MCP release lane" --verify "pnpm --filter @ma
 martin run "repair the flaky MCP release lane" --verify "pnpm --filter @martinloop/mcp test"
 martin triage
 martin dossier --latest
+martin share --latest
 martin mcp print-config --host codex --profile minimal
 ```
 
 `martin session-start` and `martin phase` are local-first command-center helpers. They read local phase state and local MartinLoop run receipts, then produce an explicit run contract before any work is executed. Existing `.gsd` workspaces are imported as a compatibility format when present. `martin phase preflight` and `martin phase run` are dry-run by default; add `--execute` only after the generated contract has the right verifier, budget, allowed paths, and blocked paths.
+
+`martin share --latest` is the handoff step. It writes a redacted JSON receipt, a Markdown summary, and a proof-card SVG for the selected run.
 
 ## Compatibility aliases
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,4 +1,4 @@
-import { cp, mkdir, readFile, readdir, rm, stat } from "node:fs/promises";
+import { cp, mkdir, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { dirname, isAbsolute, join, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
@@ -220,6 +220,12 @@ type ChallengeCommand = {
   format: "markdown" | "svg";
 };
 
+type ShareCommand = {
+  command: "share";
+  selector: MartinRunSelector;
+  outputDir?: string;
+};
+
 type BadgeCommand = {
   command: "badge";
   format: "svg" | "json";
@@ -295,6 +301,7 @@ export type ParsedCliArguments =
   | RunsCommand
   | McpCommand
   | ChallengeCommand
+  | ShareCommand
   | BadgeCommand;
 
 export async function executeCli(args: string[]): Promise<{
@@ -363,6 +370,8 @@ export async function executeCli(args: string[]): Promise<{
         return await executeMcpInstallCommand(parsed, outputMode);
       case "challenge":
         return await executeChallengeCommand(parsed, outputMode);
+      case "share":
+        return await executeShareCommand(parsed, outputMode);
       case "badge":
         return await executeBadgeCommand(parsed, outputMode);
     }
@@ -558,6 +567,14 @@ export function parseCliArguments(args: string[]): ParsedCliArguments {
     };
   }
 
+  if (command === "share") {
+    return {
+      command: "share",
+      selector: parseRunSelector(rest, { allowLatest: true }),
+      ...(readOption(rest, "--out-dir") ? { outputDir: readOption(rest, "--out-dir") } : {})
+    };
+  }
+
   if (command === "badge") {
     return {
       command: "badge",
@@ -595,6 +612,7 @@ export function renderCliHelp(): string {
     "  martin-loop resume <loopId>              (published alias)",
     "  martin bench --suite <suiteId>",
     "  martin challenge [--loop-id <id> | --file <path> | --latest] [--format markdown|svg]",
+    "  martin share (--loop-id <id> | --file <path> | --latest) [--out-dir <path>]",
     "  martin badge [--format svg|json]",
     "",
     "Operator commands:",
@@ -614,6 +632,7 @@ export function renderCliHelp(): string {
     "  mcp print-config  Print a known-good MCP config snippet for Codex, Claude, Gemini, or generic hosts.",
     "  mcp install       Write a starter MCP config, or call Claude Code directly for local scope.",
     "  challenge    Print a shareable local proof card for the Under-$3 challenge.",
+    "  share        Write a local share bundle with a redacted receipt JSON, proof Markdown, and proof SVG.",
     "  badge        Print an agent reliability readiness badge from local evidence.",
     "",
     "Compatibility aliases:",
@@ -630,6 +649,7 @@ export function renderCliHelp(): string {
     "  --file <path>            Select a persisted loop via file or run directory.",
     "  --latest                 Select the most recently updated loop.",
     "  --attempt-index <n>      Select a specific attempt for attempt inspection.",
+    "  --out-dir <path>         Override where `martin share` writes the local bundle.",
     "",
     "Phase command-center options:",
     "  --cwd <path>             Repo root containing phase state; imports .gsd state when present.",
@@ -2447,6 +2467,206 @@ function latestExitReason(loop: LoopRecord): string {
 function parseChallengeFormat(tokens: string[]): "markdown" | "svg" {
   const format = readOption(tokens, "--format");
   return format === "svg" ? "svg" : "markdown";
+}
+
+async function executeShareCommand(
+  command: ShareCommand,
+  outputMode: MartinOutputMode
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  const selected = await loadPersistedLoop(command.selector);
+  const detail =
+    command.outputDir || selected.runDirectory
+      ? selected
+      : await loadPersistedLoop({
+          loopId: selected.loop.loopId,
+          ...(command.selector.runsDir ? { runsDir: command.selector.runsDir } : {})
+        });
+  const outputDir = resolveShareOutputDirectory(detail, command.outputDir);
+  const shareBundle = buildShareBundle(detail);
+
+  await mkdir(outputDir, { recursive: true });
+
+  const files = {
+    receiptJson: join(outputDir, "run-receipt.json"),
+    receiptMarkdown: join(outputDir, "run-receipt.md"),
+    proofCardSvg: join(outputDir, "proof-card.svg")
+  };
+
+  await writeFile(files.receiptJson, `${JSON.stringify(shareBundle.receipt, null, 2)}\n`, "utf8");
+  await writeFile(files.receiptMarkdown, shareBundle.markdown, "utf8");
+  await writeFile(files.proofCardSvg, shareBundle.svg, "utf8");
+
+  return renderCliSuccess(outputMode, {
+    data: {
+      command: "share",
+      loopId: detail.loop.loopId,
+      outputDir,
+      files,
+      receipt: shareBundle.receipt
+    },
+    human: [
+      `Share bundle written for ${detail.loop.loopId}`,
+      `Output directory: ${outputDir}`,
+      `JSON receipt: ${files.receiptJson}`,
+      `Markdown receipt: ${files.receiptMarkdown}`,
+      `Proof card SVG: ${files.proofCardSvg}`
+    ],
+    quiet: outputDir,
+    warnings: dedupeWarnings([...selected.warnings, ...detail.warnings, ...shareBundle.warnings])
+  });
+}
+
+function buildShareBundle(detail: Awaited<ReturnType<typeof loadPersistedLoop>>): {
+  receipt: Record<string, unknown>;
+  markdown: string;
+  svg: string;
+  warnings: string[];
+} {
+  const dossier = buildRunDossier(detail);
+  const verification = buildVerificationSummary(detail.loop);
+  const card = buildMartinProofCard(proofCardInputFromLoop(detail.loop));
+  const receiptWarnings = dedupeWarnings([...detail.warnings, ...verification.warnings]);
+  const receipt = redactShareValue({
+    schemaVersion: "martin.share-receipt.v1",
+    generatedAt: new Date().toISOString(),
+    loop: {
+      loopId: detail.loop.loopId,
+      title: detail.loop.task.title,
+      objective: detail.loop.task.objective,
+      status: detail.loop.status,
+      lifecycleState: detail.loop.lifecycleState,
+      updatedAt: detail.loop.updatedAt,
+      attempts: detail.loop.attempts.length,
+      spendUsd: detail.loop.cost.actualUsd,
+      budgetUsd: detail.loop.budget.maxUsd
+    },
+    receiptIntegrity: detail.integrity,
+    verification: dossier["verification"],
+    receipt: dossier["receipt"],
+    artifacts: dossier["artifacts"],
+    proofCard: {
+      title: card.title,
+      evidenceLine: card.evidenceLine,
+      completeEvidence: card.completeEvidence,
+      generatedAt: card.generatedAt,
+      fields: card.fields
+    },
+    warnings: receiptWarnings
+  }) as Record<string, unknown>;
+
+  return {
+    receipt,
+    markdown: renderShareReceiptMarkdown({
+      loop: detail.loop,
+      card,
+      verification,
+      receipt: receipt["receipt"] as {
+        nextSafeAction?: string;
+      },
+      receiptIntegrity: detail.integrity.state,
+      warnings: receiptWarnings
+    }),
+    svg: renderMartinProofCardSvg(card),
+    warnings: receiptWarnings
+  };
+}
+
+function renderShareReceiptMarkdown(input: {
+  loop: LoopRecord;
+  card: ReturnType<typeof buildMartinProofCard>;
+  verification: ReturnType<typeof buildVerificationSummary>;
+  receipt: {
+    nextSafeAction?: string;
+  };
+  receiptIntegrity: string;
+  warnings: string[];
+}): string {
+  const proofCardMarkdown = renderMartinProofCardMarkdown(input.card).trimEnd();
+  return [
+    "# Martin Loop Share Receipt",
+    "",
+    `Generated from local Martin Loop evidence for loop ${redactAbsolutePaths(input.loop.loopId)}.`,
+    "",
+    `- Status: ${redactAbsolutePaths(input.loop.status)} / ${redactAbsolutePaths(input.loop.lifecycleState)}`,
+    `- Receipt integrity: ${redactAbsolutePaths(input.receiptIntegrity)}`,
+    `- Verification: ${redactAbsolutePaths(input.verification.status)}`,
+    `- Attempts: ${String(input.loop.attempts.length)}`,
+    `- Next safe action: ${redactAbsolutePaths(input.receipt.nextSafeAction ?? "Run preflight before the next attempt.")}`,
+    "",
+    "## Proof Card",
+    "",
+    proofCardMarkdown,
+    ...(input.warnings.length > 0
+      ? ["", "## Warnings", "", ...input.warnings.map((warning) => `- ${redactAbsolutePaths(warning)}`)]
+      : []),
+    "",
+    "## Notes",
+    "",
+    "- This bundle is generated from local Martin Loop run evidence.",
+    "- Absolute machine paths are redacted so the receipt can be shared without leaking workstation details.",
+    ""
+  ].join("\n");
+}
+
+function resolveShareOutputDirectory(
+  detail: Awaited<ReturnType<typeof loadPersistedLoop>>,
+  outputDir?: string
+): string {
+  if (outputDir && outputDir.trim().length > 0) {
+    return isAbsolute(outputDir) ? outputDir : resolve(resolveInvocationRoot(), outputDir);
+  }
+
+  if (detail.runDirectory) {
+    return join(detail.runDirectory, "share");
+  }
+
+  throw new CliCommandError(
+    "invalid_input",
+    "martin share needs a canonical run directory or an explicit --out-dir.",
+    {
+      suggestion:
+        "Use --latest or --loop-id against the Martin runs root, or pass --out-dir when sharing from an ad hoc file."
+    }
+  );
+}
+
+function redactShareValue(value: unknown): unknown {
+  if (typeof value === "string") {
+    return redactAbsolutePaths(value);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => redactShareValue(item));
+  }
+
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [key, redactShareValue(item)])
+    );
+  }
+
+  return value;
+}
+
+function redactAbsolutePaths(text: string): string {
+  return text
+    .replace(/file:\/\/\/[^\s")\]]+/gu, redactPathMatch)
+    .replace(/\\\\[^\\/\r\n]+[\\/][^\r\n]+/gu, redactPathMatch)
+    .replace(/[A-Za-z]:[\\/][^\r\n]+/gu, redactPathMatch)
+    .replace(/\/(?:Users|home|tmp|var|private|mnt|workspace|repo|opt)\/[^\r\n]+/gu, redactPathMatch);
+}
+
+function redactPathMatch(match: string): string {
+  const normalized = match.replace(/^file:\/\/\//u, "").replace(/\\/gu, "/").trim();
+  const trimmed = normalized.replace(/[),.;:]+$/u, "");
+  const suffix = normalized.slice(trimmed.length);
+  const basename = trimmed.split("/").filter(Boolean).at(-1) ?? "artifact";
+
+  return `[redacted-path]/${basename}${suffix}`;
+}
+
+function dedupeWarnings(warnings: string[]): string[] {
+  return [...new Set(warnings.filter((warning) => warning.trim().length > 0))];
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/tests/operator-commands.test.ts
+++ b/packages/cli/tests/operator-commands.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -434,6 +434,54 @@ describe("challenge command", () => {
       );
       expect(payload.markdown).not.toContain("Martin stopped Ralph here.");
       expect(payload.markdown).not.toContain(runsRoot);
+    });
+  });
+});
+
+describe("share command", () => {
+  it("writes a shareable receipt bundle for the latest persisted run", async () => {
+    await withRunsRoot(async (runsRoot) => {
+      const loop = makeLoopRecord();
+      const loopDir = join(runsRoot, loop.loopId);
+      await mkdir(loopDir, { recursive: true });
+      await writeFile(join(loopDir, "loop-record.json"), JSON.stringify(loop, null, 2), "utf8");
+      await writeFile(
+        join(runsRoot, `${loop.workspaceId}.jsonl`),
+        `${JSON.stringify({ loopId: loop.loopId, status: loop.status, updatedAt: loop.updatedAt })}\n`,
+        "utf8"
+      );
+
+      const result = await executeCli(["--json", "share", "--latest"]);
+      const payload = JSON.parse(result.stdout) as {
+        command: string;
+        loopId: string;
+        outputDir: string;
+        files: {
+          receiptJson: string;
+          receiptMarkdown: string;
+          proofCardSvg: string;
+        };
+      };
+
+      expect(result.exitCode).toBe(0);
+      expect(payload.command).toBe("share");
+      expect(payload.loopId).toBe(loop.loopId);
+      expect(payload.outputDir).toBe(join(loopDir, "share"));
+
+      const receiptJson = await readFile(payload.files.receiptJson, "utf8");
+      const receiptMarkdown = await readFile(payload.files.receiptMarkdown, "utf8");
+      const proofCardSvg = await readFile(payload.files.proofCardSvg, "utf8");
+
+      expect(receiptJson).toContain('"schemaVersion": "martin.share-receipt.v1"');
+      expect(receiptJson).toContain('"loopId": "loop_');
+      expect(receiptJson).not.toContain(runsRoot);
+      expect(receiptJson).not.toContain("file:///tmp/diff.patch");
+      expect(receiptJson).toContain("[redacted-path]/diff.patch");
+      expect(receiptMarkdown).toContain("# Martin Loop Share Receipt");
+      expect(receiptMarkdown).toContain("Receipt integrity unavailable: Martin proof is not yet trustworthy.");
+      expect(receiptMarkdown).not.toContain(runsRoot);
+      expect(proofCardSvg).toContain("Martin Loop Proof Card");
+      expect(proofCardSvg).not.toContain(runsRoot);
     });
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -275,6 +275,7 @@ export interface MartinAdapter {
       diffArtifacts?: boolean;
       structuredErrors?: boolean;
       cachingSignals?: boolean;
+      workspaceMutations?: boolean;
     };
     [key: string]: unknown;
   };
@@ -817,10 +818,16 @@ export async function runMartin(input: RunMartinInput): Promise<RunMartinResult>
       previousAttempts: loop.attempts
     };
 
-    const rollbackBoundary = await captureRollbackBoundary({
-      repoRoot: request.context.repoRoot,
-      capturedAt: attemptStartedAt
-    });
+    const tracksWorkspaceMutations =
+      request.context.repoRoot !== undefined &&
+      executingAdapter.metadata.capabilities?.workspaceMutations !== false;
+
+    const rollbackBoundary = tracksWorkspaceMutations
+      ? await captureRollbackBoundary({
+          repoRoot: request.context.repoRoot,
+          capturedAt: attemptStartedAt
+        })
+      : undefined;
     const result = await executingAdapter.execute(request);
     const attemptCompletedAt = now();
     const compiledContext = compilePromptPacket(request);
@@ -1050,7 +1057,9 @@ export async function runMartin(input: RunMartinInput): Promise<RunMartinResult>
       );
     }
 
-    const changedFiles = resolveChangedFiles(result, request.context.repoRoot);
+    const changedFiles = tracksWorkspaceMutations
+      ? resolveChangedFiles(result, request.context.repoRoot)
+      : [];
     // Evidence is only reliable when the adapter explicitly reported files OR git actually
     // returned a non-empty list. A repoRoot alone is insufficient — git may fail (e.g. not
     // a git repo) and silently return [], which would falsely trigger no_code_change.

--- a/packages/core/tests/runtime.test.ts
+++ b/packages/core/tests/runtime.test.ts
@@ -702,6 +702,88 @@ describe("runMartin", () => {
     expect(result.loop.attempts[0]?.failureClass).toBeUndefined();
   });
 
+  it("skips rollback snapshots for adapters that cannot mutate the workspace", async () => {
+    const runsRoot = await mkdtemp(join(tmpdir(), "martin-proof-no-rollback-"));
+    const repoRoot = join(runsRoot, "repo");
+    await mkdir(join(repoRoot, "src"), { recursive: true });
+    await writeFile(join(repoRoot, "src", "real.ts"), "export const real = 1;\n", "utf8");
+    initializeGitRepo(repoRoot);
+    await writeFile(join(repoRoot, "src", "real.ts"), "export const real = 2;\n", "utf8");
+
+    const store = createFileRunStore({ runsRoot });
+    const adapter: MartinAdapter = {
+      adapterId: "direct:proof:no-mutation",
+      kind: "direct-provider",
+      label: "Proof adapter without workspace mutation",
+      metadata: {
+        providerId: "stub",
+        model: "stub",
+        capabilities: {
+          preflight: true,
+          usageSettlement: true,
+          diffArtifacts: false,
+          structuredErrors: true,
+          cachingSignals: false,
+          workspaceMutations: false
+        }
+      },
+      async execute() {
+        return {
+          status: "failed",
+          summary: "Proof adapter refused live inference, but it did not edit the workspace.",
+          usage: {
+            actualUsd: 0,
+            tokensIn: 0,
+            tokensOut: 0,
+            provenance: "unavailable"
+          },
+          verification: {
+            passed: false,
+            summary: "No live provider request was attempted."
+          },
+          failure: {
+            message: "Proof adapter is not configured for live inference."
+          }
+        };
+      }
+    };
+
+    const result = await runMartin({
+      workspaceId: "ws_ops",
+      projectId: "proj_runtime",
+      task: {
+        title: "Confirm proof-mode runs stay off the rollback path",
+        objective: "Keep non-mutating proof adapters from snapshotting the dirty repo.",
+        verificationPlan: ["pnpm --filter @martin/core test"],
+        repoRoot
+      },
+      budget: {
+        maxUsd: 10,
+        softLimitUsd: 6,
+        maxIterations: 1,
+        maxTokens: 2_000
+      },
+      adapter,
+      store,
+      now: createTimestampSource([
+        "2026-05-11T12:20:00.000Z",
+        "2026-05-11T12:20:01.000Z",
+        "2026-05-11T12:20:02.000Z",
+        "2026-05-11T12:20:03.000Z",
+        "2026-05-11T12:20:04.000Z"
+      ]),
+      idFactory: createIdFactory()
+    });
+
+    await expect(
+      readFile(
+        join(runsRoot, result.loop.loopId, "artifacts", "attempt-001", "rollback-boundary.json"),
+        "utf8"
+      )
+    ).rejects.toThrow();
+    expect(result.loop.attempts).toHaveLength(1);
+  });
+
   it("exits on budget pressure after repeated failed attempts", async () => {
     const timestamps = createTimestampSource([
       "2026-03-27T16:10:00.000Z",

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -2,14 +2,14 @@
 
 Governed MCP server for AI coding agents over local stdio.
 
-`@martinloop/mcp@0.2.7` is the current public baseline. It gives hosts one bounded execution entrypoint, strong read-only inspection, clear next-step guidance, and a safer default MartinLoop workflow.
+`@martinloop/mcp@0.3.0` is the current public baseline. It gives hosts one bounded execution entrypoint, strong read-only inspection, clear next-step guidance, and a safer default MartinLoop workflow.
 
 This package stays local-first and stdio-first in the public OSS lane.
 
 ## Public release train
 
 - `0.2.7` made the guided MCP workflow easier to adopt and harder to misuse.
-- `0.3.0` is the next adoption release.
+- `0.3.0` is the adoption release that makes host setup and onboarding clearer.
 - `0.3.1` is planned for review and handoff controls.
 - `0.3.2` is planned for opt-in execution controls.
 

--- a/packages/mcp/src/tools/tool-support.ts
+++ b/packages/mcp/src/tools/tool-support.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from "node:child_process";
+import { accessSync, constants } from "node:fs";
 import { readdir, stat } from "node:fs/promises";
 import { join } from "node:path";
 
@@ -181,22 +181,11 @@ export function detectCliAvailability(command: string): CliAvailability {
     return cached.value;
   }
 
-  const locator = process.platform === "win32" ? "where.exe" : "which";
-  const result = spawnSync(locator, [command], {
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"]
-  });
-
-  const resolvedPath =
-    result.status === 0
-      ? (result.stdout ?? "")
-          .split(/\r?\n/u)
-          .map((line) => line.trim())
-          .find(Boolean)
-      : undefined;
+  const locator = process.platform === "win32" ? "path-scan(win32)" : "path-scan(posix)";
+  const resolvedPath = findCommandOnPath(command);
 
   const value: CliAvailability =
-    result.status === 0
+    resolvedPath
       ? {
           command,
           available: true,
@@ -217,6 +206,52 @@ export function detectCliAvailability(command: string): CliAvailability {
   });
 
   return value;
+}
+
+function findCommandOnPath(command: string): string | undefined {
+  const pathKey = Object.keys(process.env).find((key) => key.toLowerCase() === "path");
+  const rawPath = pathKey ? process.env[pathKey] : undefined;
+  if (!rawPath) {
+    return undefined;
+  }
+
+  const pathEntries = rawPath
+    .split(process.platform === "win32" ? ";" : ":")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+
+  const hasExtension = /\.[A-Za-z0-9]+$/u.test(command);
+  const candidateNames =
+    process.platform === "win32" && !hasExtension
+      ? (process.env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD")
+          .split(";")
+          .map((extension) => extension.trim())
+          .filter(Boolean)
+          .map((extension) => `${command}${extension.toLowerCase()}`)
+      : [command];
+
+  for (const directory of pathEntries) {
+    for (const candidateName of candidateNames) {
+      const candidatePath = join(directory, candidateName);
+      if (isExecutablePath(candidatePath)) {
+        return candidatePath;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function isExecutablePath(candidatePath: string): boolean {
+  try {
+    accessSync(
+      candidatePath,
+      process.platform === "win32" ? constants.F_OK : constants.X_OK
+    );
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export function getEngineAvailability(engine: MartinEngine): CliAvailability {

--- a/packages/mcp/src/tools/workflow-governance.ts
+++ b/packages/mcp/src/tools/workflow-governance.ts
@@ -146,6 +146,12 @@ const HOST_COMMANDS = {
   gemini: "gemini"
 } as const;
 
+const GIT_STATE_CACHE_TTL_MS = 60_000;
+const repoGitStateCache = new Map<
+  string,
+  { expiresAt: number; value: RepoGitState }
+>();
+
 const POLICY_PACKS: Record<MartinPolicyPack, Omit<MartinPolicyPackDefinition, "defaultVerifiers">> = {
   "solo-founder": {
     name: "solo-founder",
@@ -612,54 +618,62 @@ function detectVerifierCommands(
 }
 
 function detectGitState(workingDirectory: string): RepoGitState {
-  const availability = spawnSync("git", ["--version"], {
-    cwd: workingDirectory,
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"]
-  });
-
-  if (availability.status !== 0) {
-    return {
-      available: false,
-      isRepo: false,
-      clean: false
-    };
+  const cacheKey = workingDirectory;
+  const cached = repoGitStateCache.get(cacheKey);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.value;
   }
 
-  const isRepo = spawnSync("git", ["rev-parse", "--is-inside-work-tree"], {
-    cwd: workingDirectory,
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"]
-  });
-  if (isRepo.status !== 0 || !/true/u.test(isRepo.stdout ?? "")) {
-    return {
-      available: true,
-      isRepo: false,
-      clean: false
-    };
-  }
-
-  const branch = spawnSync("git", ["branch", "--show-current"], {
-    cwd: workingDirectory,
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"]
-  }).stdout.trim();
   const status = spawnSync("git", ["status", "--porcelain", "--branch"], {
     cwd: workingDirectory,
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"]
   });
+
+  if (status.status !== 0) {
+    const availability = spawnSync("git", ["--version"], {
+      cwd: workingDirectory,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"]
+    });
+
+    const value =
+      availability.status !== 0
+        ? {
+            available: false,
+            isRepo: false,
+            clean: false
+          }
+        : {
+            available: true,
+            isRepo: false,
+            clean: false
+          };
+
+    repoGitStateCache.set(cacheKey, {
+      expiresAt: Date.now() + GIT_STATE_CACHE_TTL_MS,
+      value
+    });
+
+    return value;
+  }
+
   const statusLines = (status.stdout ?? "")
     .split(/\r?\n/u)
     .map((line) => line.trim())
     .filter(Boolean);
   const dirty = statusLines.some((line) => !line.startsWith("##"));
   const header = statusLines.find((line) => line.startsWith("##"));
+  const branch = header
+    ?.replace(/^##\s+/u, "")
+    .split("...")[0]
+    ?.trim()
+    .replace(/\s+\[.*$/u, "");
   const upstream = header?.match(/\.\.\.([^\s[]+)/u)?.[1];
   const ahead = parseCount(header, /ahead (\d+)/u);
   const behind = parseCount(header, /behind (\d+)/u);
 
-  return {
+  const value: RepoGitState = {
     available: true,
     isRepo: true,
     clean: !dirty,
@@ -668,6 +682,13 @@ function detectGitState(workingDirectory: string): RepoGitState {
     ...(ahead !== undefined ? { ahead } : {}),
     ...(behind !== undefined ? { behind } : {})
   };
+
+  repoGitStateCache.set(cacheKey, {
+    expiresAt: Date.now() + GIT_STATE_CACHE_TTL_MS,
+    value
+  });
+
+  return value;
 }
 
 function detectSensitivePaths(workingDirectory: string): string[] {

--- a/scripts/root-release-guard.mjs
+++ b/scripts/root-release-guard.mjs
@@ -7,7 +7,7 @@ import { fileURLToPath } from "node:url";
 
 import { resolveRcCommandExecution } from "./rc-validation.mjs";
 
-const ROOT_VERSION_PATTERN = /^0\.2\.\d+$/;
+const ROOT_VERSION_PATTERN = /^0\.(?:2|3)\.\d+$/;
 const ALLOWED_FILES = [
   "benchmarks/fixtures",
   "CODE_OF_CONDUCT.md",
@@ -74,7 +74,7 @@ export async function runRootReleaseGuard(options = {}) {
 
 export function assertRootVersionPolicy(version) {
   if (!ROOT_VERSION_PATTERN.test(version)) {
-    throw new Error(`Root martin-loop version must stay on the 0.2.x line. Received ${version}.`);
+    throw new Error(`Root martin-loop version must stay on the 0.2.x or 0.3.x line. Received ${version}.`);
   }
 }
 

--- a/scripts/tests/mcp-release-docs.test.mjs
+++ b/scripts/tests/mcp-release-docs.test.mjs
@@ -31,11 +31,10 @@ test("version ledger records live public truth and the next release train", asyn
 
   for (const requiredText of [
     "root public baseline: `0.2.11`",
-    "standalone MCP public baseline: `0.2.7`",
+    "standalone MCP public baseline: `0.3.0`",
     "next planned root release: `0.3.0`",
     "next planned root follow-on: `0.3.1`",
-    "next planned standalone release: `0.3.0`",
-    "`0.3.1` review and handoff controls",
+    "next planned standalone release: `0.3.1`",
     "`0.3.2` opt-in execution controls"
   ]) {
     assert.match(ledger, new RegExp(escapeRegex(requiredText)));
@@ -46,12 +45,11 @@ test("MCP slice map defines the 0.3.x train without private-hosted bleed", async
   const sliceMap = await readRepoFile(path.join("docs", "release", "MCP-DELIVERY-SLICE-MAP.md"));
 
   for (const requiredText of [
-    "## `0.3.0` — Adoption Pack",
     "## `0.3.1` — Review And Handoff Controls",
     "## `0.3.2` — Opt-In Execution Controls",
-    "hosted endpoints",
-    "tenant or org language",
-    "billing or mission-control claims"
+    "hosted audit export",
+    "tenant or billing features",
+    "non-OSS transport"
   ]) {
     assert.match(sliceMap, new RegExp(escapeRegex(requiredText)));
   }
@@ -66,7 +64,6 @@ test("public MCP docs describe the current baseline and the next train in human-
   ]);
 
   for (const contents of [packageReadme, aiGuide]) {
-    assert.match(contents, /0\.2\.7/);
     assert.match(contents, /0\.3\.0/);
     assert.match(contents, /local-first/i);
     assert.match(contents, /martin_doctor/);

--- a/scripts/tests/root-release-guard.test.mjs
+++ b/scripts/tests/root-release-guard.test.mjs
@@ -28,8 +28,12 @@ test("runRootReleaseGuard accepts the current OSS-safe root package shape", asyn
   assert.equal(result.packChecked, false);
 });
 
-test("assertRootVersionPolicy rejects non-0.2.x root versions", () => {
-  assert.throws(() => assertRootVersionPolicy("1.3.0"), /0\.2\.x/);
+test("assertRootVersionPolicy accepts the public 0.3.x root release line", () => {
+  assert.doesNotThrow(() => assertRootVersionPolicy("0.3.0"));
+});
+
+test("assertRootVersionPolicy rejects versions outside the public 0.2.x and 0.3.x lines", () => {
+  assert.throws(() => assertRootVersionPolicy("1.3.0"), /0\.2\.x or 0\.3\.x/);
 });
 
 test("assertPackedSurface rejects unexpected non-OSS paths", () => {


### PR DESCRIPTION
## Summary
- add a real `martin share --latest` flow to the public root CLI
- ship polished public-facing docs, README copy, npm metadata, and `0.3.0` release notes for share receipts
- fix the proof-mode runtime slow path by skipping rollback and git-change tracking when an adapter cannot mutate the workspace or when verifier-only runs have no verifier work

## Validation
- pnpm release:matrix:local
- pnpm public:copy-scan
- pnpm public:git-surface
- pnpm oss:validate
- pnpm public:smoke
- node ./scripts/root-release-guard.mjs --tag v0.3.0 --pack

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `martin share --latest` command to generate a local share bundle for the latest governed run, including a redacted JSON receipt, Markdown recap, and proof-card SVG.
  * Support for `--out-dir` option to specify custom output location; absolute paths are automatically redacted in generated artifacts.

* **Documentation**
  * Updated quickstart, examples, and CLI reference with new `share` command usage and expected output details.
  * Updated MCP compatibility baseline documentation to version 0.3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->