### PR TITLE
Improve Codex launcher diagnostics and fail-closed readiness

### DIFF
--- a/docs/release/MCP-DELIVERY-SLICE-MAP.md
+++ b/docs/release/MCP-DELIVERY-SLICE-MAP.md
@@ -1,4 +1,4 @@
-# Martin MCP Delivery Slice Map
+# Martin MCP Release Map
 
 This map defines the next public standalone MCP releases after the live `0.2.7` baseline. The point is to keep each release narrow, legible, and easy to validate.
 
@@ -34,13 +34,13 @@ Primary public surfaces:
 
 ## `0.3.1` — Review And Handoff Controls
 
-Story: make review, triage, and handoff easier after a governed run finishes.
+Story: make review, triage, and follow-through easier after a governed run finishes.
 
 Include:
 - stronger dossier and eval guidance
 - clearer failed-run and publish-readiness flows
 - compact review resources for what happened, what failed, and what to do next
-- handoff-safe expected outputs for humans and agents
+- compact expected outputs for humans and agents
 
 Do not include:
 - hosted audit export
@@ -79,6 +79,6 @@ Primary public surfaces:
 Before a public-prep branch opens:
 
 1. Reconfirm `VERSION-LEDGER.md` against live npm and public GitHub.
-2. Keep the changed-path set limited to the slice being shipped.
+2. Keep the changed-path set limited to the release in progress.
 3. Run the full public release gates on the exact candidate commit.
 4. Audit packed tarball contents, README, and release notes before publish.

--- a/packages/adapters/src/claude-cli.ts
+++ b/packages/adapters/src/claude-cli.ts
@@ -21,10 +21,12 @@ import type {
 
 import {
   readGitExecutionArtifacts,
+  resolveGitRepositoryRoot,
   runSubprocess,
   runVerification,
   type SpawnLike
 } from "./cli-bridge.js";
+import { buildCodexExecArgs } from "./codex-launcher.js";
 import {
   createAdapterCapabilities,
   normalizeStructuredErrors,
@@ -433,6 +435,8 @@ export interface ClaudeCliAdapterOptions {
 }
 
 export interface CodexCliAdapterOptions {
+  /** Override the executable or absolute command path used to launch Codex. */
+  command?: string;
   workingDirectory?: string;
   timeoutMs?: number;
   verifyTimeoutMs?: number;
@@ -588,6 +592,32 @@ export function createAgentCliAdapter(options: AgentCliAdapterOptions): MartinAd
         !supportsJsonOutput && options.command === "gemini"
           ? extractGeminiJsonResult(agentResult.stdout, options.model)
           : undefined;
+      const producedStructuredCompletion =
+        parsed?.result !== undefined ||
+        codexJsonlResult !== undefined ||
+        geminiJsonResult !== undefined;
+      if (agentResult.exitCode !== 0 && !producedStructuredCompletion) {
+        const failureMessage = formatPreVerifierSubprocessFailure(
+          options.command,
+          agentResult.stderr || agentResult.stdout,
+          agentResult.exitCode
+        );
+        return {
+          status: "failed",
+          summary: `${options.command} subprocess exited before verifier execution.`,
+          usage: normalizeUsage({
+            actualUsd: 0,
+            tokensIn: 0,
+            tokensOut: 0,
+            provenance: "unavailable"
+          }),
+          verification: { passed: false, summary: `Verifier not run: ${failureMessage}` },
+          failure: {
+            message: failureMessage
+          }
+        };
+      }
+
       const agentText =
         codexJsonlResult?.summary ??
         geminiJsonResult?.summary ??
@@ -641,25 +671,26 @@ export function createAgentCliAdapter(options: AgentCliAdapterOptions): MartinAd
 
       // Check for zero-diff (agent ran but made no file changes)
       const repoRoot = (request.context as { repoRoot?: string }).repoRoot;
+      const gitRepoRoot = repoRoot ? resolveGitRepositoryRoot(repoRoot) : undefined;
       let noDiff = false;
-      if (repoRoot) {
-        noDiff = await checkNoDiff(repoRoot, options.spawnImpl);
+      if (gitRepoRoot) {
+        noDiff = await checkNoDiff(gitRepoRoot, options.spawnImpl);
       }
 
       // Extract structured errors from stderr/stdout for better failure context
       const structuredErrors = normalizeStructuredErrors(
         extractStructuredErrors(agentResult.stderr, agentResult.stdout)
       );
-      const executionArtifacts = repoRoot
-        ? await readGitExecutionArtifacts(repoRoot, 5000, options.spawnImpl)
+      const executionArtifacts = gitRepoRoot
+        ? await readGitExecutionArtifacts(gitRepoRoot, 5000, options.spawnImpl)
         : undefined;
 
       // Scope contract enforcement: check touched files against allowedPaths/deniedPaths
       let scopeViolations: string[] = [];
       const scopeCtx = request.context as { allowedPaths?: string[]; deniedPaths?: string[] };
-      if (repoRoot && (scopeCtx.allowedPaths?.length || scopeCtx.deniedPaths?.length)) {
+      if (gitRepoRoot && (scopeCtx.allowedPaths?.length || scopeCtx.deniedPaths?.length)) {
         const diffResult = await runSubprocess("git", ["diff", "--name-only", "HEAD"], {
-          cwd: repoRoot,
+          cwd: gitRepoRoot,
           timeoutMs: 5000,
           spawnImpl: options.spawnImpl
         });
@@ -743,7 +774,12 @@ export function createAgentCliAdapter(options: AgentCliAdapterOptions): MartinAd
 
         // Reset tracked files to HEAD so next attempt starts from clean state
         try {
-          await runSubprocess("git", ["restore", "--staged", "--worktree", "."], { cwd: repoRoot, timeoutMs: 5000 });
+          if (gitRepoRoot) {
+            await runSubprocess("git", ["restore", "--staged", "--worktree", "."], {
+              cwd: gitRepoRoot,
+              timeoutMs: 5000
+            });
+          }
         } catch {
           // Non-fatal
         }
@@ -844,13 +880,13 @@ export function createClaudeCliAdapter(options: ClaudeCliAdapterOptions = {}): M
  *   npm install -g @openai/codex
  */
 export function createCodexCliAdapter(options: CodexCliAdapterOptions = {}): MartinAdapter {
-  const modelArgs: string[] = options.model ? ["--model", options.model] : [];
   const extraArgs = options.extraArgs ?? [];
   const sandbox = options.sandbox ?? "workspace-write";
   const workingDirectory = options.workingDirectory ?? process.cwd();
+  const command = options.command ?? "codex";
 
   return createAgentCliAdapter({
-    command: "codex",
+    command,
     adapterIdSuffix: "codex",
     model: options.model ?? "codex",
     label: options.label ?? "Codex CLI adapter",
@@ -859,19 +895,14 @@ export function createCodexCliAdapter(options: CodexCliAdapterOptions = {}): Mar
     verifyTimeoutMs: options.verifyTimeoutMs,
     supportsJsonOutput: false,
     spawnImpl: options.spawnImpl,
-    argsBuilder: () => [
-      "exec",
-      "--cd",
-      workingDirectory,
-      "--sandbox",
-      sandbox,
-      "--json",
-      "--color",
-      "never",
-      ...modelArgs,
-      ...extraArgs,
-      "-"
-    ],
+    argsBuilder: () =>
+      buildCodexExecArgs({
+        workingDirectory,
+        sandbox,
+        ...(options.model ? { model: options.model } : {}),
+        extraArgs,
+        mode: "prompt"
+      }),
     stdinBuilder: (prompt) => prompt
   });
 }

--- a/packages/adapters/src/cli-bridge.ts
+++ b/packages/adapters/src/cli-bridge.ts
@@ -1,5 +1,5 @@
 import { spawn, type ChildProcess, type SpawnOptions } from "node:child_process";
-import { delimiter, extname, isAbsolute, join, resolve } from "node:path";
+import { delimiter, dirname, extname, isAbsolute, join, resolve } from "node:path";
 import { existsSync } from "node:fs";
 
 import { diffStatsFromNumstat } from "./runtime-support.js";
@@ -21,6 +21,8 @@ export interface VerificationOutcome {
   passed: boolean;
   summary: string;
 }
+
+const gitRepositoryRootCache = new Map<string, string | null>();
 
 export async function runSubprocess(
   command: string,
@@ -182,6 +184,10 @@ export async function readGitExecutionArtifacts(
   changedFiles?: string[];
   diffStats?: ReturnType<typeof diffStatsFromNumstat>;
 }> {
+  if (!resolveGitRepositoryRoot(repoRoot)) {
+    return {};
+  }
+
   const changedFilesResult = await runSubprocess(
     "git",
     ["diff", "--name-only", "HEAD"],
@@ -214,9 +220,13 @@ export async function readGitChangedFiles(
   timeoutMs: number,
   spawnImpl?: SpawnLike
 ): Promise<string[]> {
+  if (!resolveGitRepositoryRoot(repoRoot)) {
+    return [];
+  }
+
   const statusResult = await runSubprocess(
     "git",
-    ["status", "-z", "--porcelain=v1", "--untracked-files=all", "--ignore-submodules=all"],
+    ["status", "-z", "--porcelain=v1", "--untracked-files=all", "--ignore-submodules=all", "--", "."],
     { cwd: repoRoot, timeoutMs, spawnImpl }
   );
 
@@ -227,6 +237,46 @@ export async function readGitChangedFiles(
   return parsePorcelainEntries(statusResult.stdout).filter(
     (entry): entry is string => typeof entry === "string" && entry.length > 0
   );
+}
+
+export function resolveGitRepositoryRoot(workingDirectory: string): string | undefined {
+  const resolvedWorkingDirectory = resolve(workingDirectory);
+  const cached = gitRepositoryRootCache.get(resolvedWorkingDirectory);
+  if (cached !== undefined) {
+    return cached ?? undefined;
+  }
+
+  const visited: string[] = [];
+  let current = resolvedWorkingDirectory;
+
+  while (true) {
+    visited.push(current);
+
+    const currentCached = gitRepositoryRootCache.get(current);
+    if (currentCached !== undefined) {
+      for (const candidate of visited) {
+        gitRepositoryRootCache.set(candidate, currentCached);
+      }
+      return currentCached ?? undefined;
+    }
+
+    if (existsSync(resolve(current, ".git"))) {
+      for (const candidate of visited) {
+        gitRepositoryRootCache.set(candidate, current);
+      }
+      return current;
+    }
+
+    const parent = dirname(current);
+    if (parent === current) {
+      for (const candidate of visited) {
+        gitRepositoryRootCache.set(candidate, null);
+      }
+      return undefined;
+    }
+
+    current = parent;
+  }
 }
 
 export interface SpawnPlan {
@@ -251,19 +301,17 @@ export function createSpawnPlan(
   // Windows can resolve the command itself — this covers cases like `pnpm` where the npm global
   // bin directory is present in the shell PATH but not yet visible to this Node.js process.
   if (resolvedOrUndefined === undefined) {
-    const cmdStr = [quoteWindowsCmdArg(command), ...args.map(quoteWindowsCmdArg)].join(" ");
     return {
       command: process.env.ComSpec || "cmd.exe",
-      args: ["/d", "/c", cmdStr]
+      args: ["/d", "/c", command, ...args]
     };
   }
 
   const extension = extname(resolvedOrUndefined).toLowerCase();
   if (extension === ".cmd" || extension === ".bat") {
-    const cmdStr = [quoteWindowsCmdArg(resolvedOrUndefined), ...args.map(quoteWindowsCmdArg)].join(" ");
     return {
       command: process.env.ComSpec || "cmd.exe",
-      args: ["/d", "/s", "/c", cmdStr]
+      args: ["/d", "/c", resolvedOrUndefined, ...args]
     };
   }
 
@@ -352,17 +400,6 @@ function windowsPathDirectories(): string[] {
     .split(delimiter)
     .map((entry) => entry.trim().replace(/^"|"$/g, ""))
     .filter(Boolean);
-}
-
-function quoteWindowsCmdArg(value: string): string {
-  const normalized = value.replace(/\r?\n/gu, " ");
-  const escaped = normalized
-    .replace(/\^/gu, "^^")
-    .replace(/"/gu, '^"')
-    .replace(/%/gu, "%%")
-    .replace(/!/gu, "^^!")
-    .replace(/[&|<>()]/gu, (match) => `^${match}`);
-  return `"${escaped}"`;
 }
 
 export function splitCommand(command: string): string[] {

--- a/packages/adapters/src/codex-launcher.ts
+++ b/packages/adapters/src/codex-launcher.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
-import { dirname, extname, resolve } from "node:path";
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { dirname, extname, join, resolve } from "node:path";
 
 export interface CliCommandAvailability {
   command: string;
@@ -8,13 +8,29 @@ export interface CliCommandAvailability {
   locator: string;
   detail: string;
   resolvedPath?: string;
+  candidatePaths?: string[];
 }
 
 export type CodexHostPlatform = "windows" | "linux" | "wsl" | "macos";
 
+export type CodexInstallKind =
+  | "missing"
+  | "native"
+  | "windows_shim"
+  | "windows_mounted_path";
+
+export type CodexInvocationMode = "direct" | "cmd_shell" | "powershell";
+
 export interface CodexHostDiagnosis {
   hostPlatform: CodexHostPlatform;
   nativeInstallValid: boolean;
+  installKind: CodexInstallKind;
+  invocationMode: CodexInvocationMode;
+  sandboxMode: "workspace-write";
+  sandboxCompatible: boolean;
+  resolvedPath?: string;
+  nativeDependencyStatus?: "unknown" | "missing";
+  nativeDependencyPackage?: string;
   warnings: string[];
   remediation?: string;
 }
@@ -29,9 +45,70 @@ export interface CodexLaunchProbeResult {
   exitCode?: number;
   stdout?: string;
   stderr?: string;
+  candidateProbeResults?: CodexProbeCandidateResult[];
+}
+
+export interface CodexExecArgsOptions {
+  workingDirectory: string;
+  sandbox?: "read-only" | "workspace-write" | "danger-full-access";
+  model?: string;
+  extraArgs?: string[];
+  mode?: "prompt" | "probe";
 }
 
 type SpawnSyncLike = typeof spawnSync;
+const codexLaunchProbeCache = new Map<string, CodexLaunchProbeResult>();
+
+export interface CodexProbeCandidateResult {
+  path: string;
+  installKind: CodexInstallKind;
+  invocationMode: CodexInvocationMode;
+  nativeInstallValid: boolean;
+  sandboxCompatible: boolean;
+  launchReady: boolean;
+  summary: string;
+  remediation?: string;
+  nativeDependencyStatus?: "unknown" | "missing";
+  nativeDependencyPackage?: string;
+}
+
+interface CodexProbeJsonEvent {
+  type?: string;
+  item?: {
+    type?: string;
+    status?: string;
+    exit_code?: number | null;
+    aggregated_output?: string;
+  };
+}
+
+interface OrderedProbeCandidate {
+  path: string;
+  diagnosis: CodexHostDiagnosis;
+  preference: number;
+  discoveryIndex: number;
+}
+
+const CODEX_LAUNCH_PROBE_PROMPT = [
+  "You are validating MartinLoop Codex host readiness.",
+  "Do not edit files.",
+  "Use the shell command executor exactly once to run: git status --short -- .",
+  "Do not use MCP tools, Node REPL, or any fallback tool if shell execution fails.",
+  "If the shell command succeeds, reply with READY only.",
+  "If it fails, reply with the exact failure in one sentence."
+].join("\n");
+
+function buildProbeCacheKey(input: {
+  workingDirectory: string;
+  platform: NodeJS.Platform;
+  candidatePaths: string[];
+}): string {
+  return JSON.stringify({
+    workingDirectory: resolve(input.workingDirectory),
+    platform: input.platform,
+    candidatePaths: input.candidatePaths
+  });
+}
 
 function isInsideGitRepository(workingDirectory: string): boolean {
   let current = resolve(workingDirectory);
@@ -49,62 +126,126 @@ function isInsideGitRepository(workingDirectory: string): boolean {
   }
 }
 
-function selectResolvedPath(candidates: string[], platform: NodeJS.Platform): string | undefined {
-  const cleaned = candidates
-    .map((line) => line.trim())
-    .filter(Boolean);
+function normalizeCandidates(lines: string[]): string[] {
+  return [...new Set(lines.map((line) => line.trim()).filter(Boolean))];
+}
 
-  if (cleaned.length === 0) {
-    return undefined;
-  }
+function readLocatorCandidates(
+  command: string,
+  platform: NodeJS.Platform,
+  spawnSyncImpl: SpawnSyncLike
+): { locator: string; candidates: string[]; foundOnPath: boolean } {
+  const locator = platform === "win32" ? "where.exe" : "which";
+  const result = spawnSyncImpl(locator, [command], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"]
+  });
 
-  if (platform !== "win32") {
-    return cleaned[0];
-  }
-
-  const preference = (candidate: string): number => {
-    switch (extname(candidate).toLowerCase()) {
-      case ".cmd":
-        return 0;
-      case ".bat":
-        return 1;
-      case ".ps1":
-        return 2;
-      case ".exe":
-        return 3;
-      case "":
-        return 4;
-      default:
-        return 5;
-    }
+  return {
+    locator,
+    candidates:
+      result.status === 0
+        ? normalizeCandidates((result.stdout ?? "").split(/\r?\n/u))
+        : [],
+    foundOnPath: result.status === 0
   };
+}
 
-  const [firstCandidate, ...remainingCandidates] = cleaned;
-  if (firstCandidate === undefined) {
-    return undefined;
+function discoverWindowsDesktopCodexCandidates(env: NodeJS.ProcessEnv): string[] {
+  const localAppData = env["LOCALAPPDATA"];
+  if (!localAppData) {
+    return [];
   }
 
-  let bestCandidate = firstCandidate;
-  let bestPreference = preference(bestCandidate);
+  const baseDirectory = join(localAppData, "OpenAI", "Codex", "bin");
+  if (!existsSync(baseDirectory)) {
+    return [];
+  }
 
-  for (const candidate of remainingCandidates) {
-    const candidatePreference = preference(candidate);
-    if (candidatePreference < bestPreference) {
-      bestCandidate = candidate;
-      bestPreference = candidatePreference;
+  const candidates: Array<{ path: string; mtimeMs: number }> = [];
+  const directCandidate = join(baseDirectory, "codex.exe");
+  if (existsSync(directCandidate)) {
+    candidates.push({ path: directCandidate, mtimeMs: statSync(directCandidate).mtimeMs });
+  }
+
+  for (const entry of readdirSync(baseDirectory, { withFileTypes: true })) {
+    if (!entry.isDirectory()) {
+      continue;
     }
+    const candidate = join(baseDirectory, entry.name, "codex.exe");
+    if (!existsSync(candidate)) {
+      continue;
+    }
+    candidates.push({ path: candidate, mtimeMs: statSync(candidate).mtimeMs });
   }
 
-  return bestCandidate;
+  candidates.sort((left, right) => right.mtimeMs - left.mtimeMs);
+  return normalizeCandidates(candidates.map((candidate) => candidate.path));
+}
+
+function codexProbePreference(diagnosis: CodexHostDiagnosis): number {
+  if (diagnosis.installKind === "native" && diagnosis.invocationMode === "direct") {
+    return 0;
+  }
+  if (diagnosis.installKind === "native") {
+    return 1;
+  }
+  if (diagnosis.installKind === "windows_shim") {
+    return 2;
+  }
+  return 3;
+}
+
+function buildProbeCandidates(input: {
+  availability: CliCommandAvailability;
+  env: NodeJS.ProcessEnv;
+  platform: NodeJS.Platform;
+  includeDesktopCandidates: boolean;
+}): OrderedProbeCandidate[] {
+  const pathCandidates = normalizeCandidates(
+    input.availability.candidatePaths ?? [input.availability.resolvedPath ?? input.availability.command]
+  );
+  const desktopCandidates =
+    input.platform === "win32" && input.includeDesktopCandidates
+      ? discoverWindowsDesktopCodexCandidates(input.env).filter(
+          (candidatePath) => !pathCandidates.includes(candidatePath)
+        )
+      : [];
+
+  return [...pathCandidates, ...desktopCandidates]
+    .map((path, discoveryIndex) => {
+      const diagnosis = diagnoseCodexHost(
+        {
+          ...input.availability,
+          resolvedPath: path
+        },
+        {
+          env: input.env,
+          platform: input.platform
+        }
+      );
+
+      return {
+        path,
+        diagnosis,
+        preference: input.platform === "win32" ? codexProbePreference(diagnosis) : 0,
+        discoveryIndex
+      };
+    })
+    .sort((left, right) =>
+      left.preference === right.preference
+        ? left.discoveryIndex - right.discoveryIndex
+        : left.preference - right.preference
+    );
 }
 
 function buildProbeCommand(
   command: string,
   args: string[],
   platform: NodeJS.Platform
-): { command: string; args: string[] } {
+): { command: string; args: string[]; invocationMode: CodexInvocationMode } {
   if (platform !== "win32") {
-    return { command, args };
+    return { command, args, invocationMode: "direct" };
   }
 
   const extension = extname(command).toLowerCase();
@@ -113,50 +254,193 @@ function buildProbeCommand(
     case ".bat":
       return {
         command: process.env.ComSpec || "cmd.exe",
-        args: ["/d", "/c", command, ...args]
+        args: ["/d", "/c", command, ...args],
+        invocationMode: "cmd_shell"
       };
     case ".ps1":
       return {
         command: "powershell.exe",
-        args: ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", command, ...args]
+        args: ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", command, ...args],
+        invocationMode: "powershell"
       };
     default:
-      return { command, args };
+      return { command, args, invocationMode: "direct" };
   }
+}
+
+function detectInstallKind(
+  resolvedPath: string | undefined,
+  hostPlatform: CodexHostPlatform
+): CodexInstallKind {
+  if (!resolvedPath) {
+    return "missing";
+  }
+
+  const normalizedPath = resolvedPath.replace(/\\/gu, "/").toLowerCase();
+  const looksWindowsShim =
+    normalizedPath.endsWith(".cmd") ||
+    normalizedPath.endsWith(".bat") ||
+    normalizedPath.endsWith(".ps1") ||
+    normalizedPath.includes("/appdata/roaming/npm/");
+  const looksMountedWindowsPath = normalizedPath.startsWith("/mnt/c/");
+
+  if ((hostPlatform === "linux" || hostPlatform === "wsl") && looksMountedWindowsPath) {
+    return "windows_mounted_path";
+  }
+
+  if (looksWindowsShim) {
+    return "windows_shim";
+  }
+
+  return "native";
+}
+
+function detectInvocationMode(resolvedPath: string | undefined, platform: NodeJS.Platform): CodexInvocationMode {
+  if (platform !== "win32" || !resolvedPath) {
+    return "direct";
+  }
+
+  const extension = extname(resolvedPath).toLowerCase();
+  if (extension === ".ps1") {
+    return "powershell";
+  }
+  if (extension === ".cmd" || extension === ".bat") {
+    return "cmd_shell";
+  }
+  return "direct";
+}
+
+function classifyProbeFailure(
+  stderr: string,
+  stdout: string,
+  diagnosis: CodexHostDiagnosis
+): { summary?: string; diagnosis?: CodexHostDiagnosis } {
+  const combined = `${stderr}\n${stdout}`;
+
+  if (
+    /@openai\/codex-linux-x64/iu.test(combined) ||
+    /cannot find module ['"]@openai\/codex-linux-x64['"]/iu.test(combined)
+  ) {
+    const warnings = [...diagnosis.warnings];
+    const missingDependencyWarning =
+      "Codex is missing the native Linux package '@openai/codex-linux-x64' required for this host.";
+    if (!warnings.includes(missingDependencyWarning)) {
+      warnings.push(missingDependencyWarning);
+    }
+    return {
+      summary:
+        "Codex native dependency '@openai/codex-linux-x64' is missing for this Linux/WSL environment.",
+      diagnosis: {
+        ...diagnosis,
+        nativeInstallValid: false,
+        sandboxCompatible: false,
+        warnings,
+        nativeDependencyStatus: "missing",
+        nativeDependencyPackage: "@openai/codex-linux-x64",
+        remediation:
+          "Reinstall Codex natively inside this Linux/WSL environment so the '@openai/codex-linux-x64' package is present before running governed Codex work."
+      }
+    };
+  }
+
+  if (
+    /CreateProcessAsUserW failed:\s*5/iu.test(combined) ||
+    /windows sandbox: runner error: CreateProcessAsUserW failed:\s*5/iu.test(combined) ||
+    /spawn setup refresh/iu.test(combined)
+  ) {
+    const warnings = [...diagnosis.warnings];
+    const sandboxFailureWarning =
+      "Codex workspace-write sandbox could not launch subprocesses on this Windows host.";
+    if (!warnings.includes(sandboxFailureWarning)) {
+      warnings.push(sandboxFailureWarning);
+    }
+    return {
+      summary:
+        "Codex workspace-write sandbox could not launch subprocesses on this Windows host.",
+      diagnosis: {
+        ...diagnosis,
+        sandboxCompatible: false,
+        warnings,
+        remediation:
+          "Update or reinstall Codex on this Windows host until `codex exec --sandbox workspace-write` can launch a simple shell command before running governed Codex work."
+      }
+    };
+  }
+
+  return {};
+}
+
+export function buildCodexExecArgs(options: CodexExecArgsOptions): string[] {
+  const sandbox = options.sandbox ?? "workspace-write";
+  const modelArgs = options.model ? ["--model", options.model] : [];
+  const extraArgs = options.extraArgs ?? [];
+
+  return [
+    "exec",
+    "--cd",
+    options.workingDirectory,
+    "--sandbox",
+    sandbox,
+    "--json",
+    "--color",
+    "never",
+    ...modelArgs,
+    ...extraArgs,
+    "-"
+  ];
+}
+
+function parseCodexProbeEvents(stdout: string): CodexProbeJsonEvent[] {
+  return stdout
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      try {
+        return JSON.parse(line) as CodexProbeJsonEvent;
+      } catch {
+        return undefined;
+      }
+    })
+    .filter((event): event is CodexProbeJsonEvent => event !== undefined);
+}
+
+function hasSuccessfulCommandExecution(events: CodexProbeJsonEvent[]): boolean {
+  return events.some(
+    (event) =>
+      event.type === "item.completed" &&
+      event.item?.type === "command_execution" &&
+      event.item?.status === "completed" &&
+      event.item?.exit_code === 0
+  );
 }
 
 export function resolveCliCommandAvailability(
   command: string,
   options: {
     platform?: NodeJS.Platform;
+    env?: NodeJS.ProcessEnv;
     spawnSyncImpl?: SpawnSyncLike;
   } = {}
 ): CliCommandAvailability {
   const platform = options.platform ?? process.platform;
   const spawnSyncImpl = options.spawnSyncImpl ?? spawnSync;
-  const locator = platform === "win32" ? "where.exe" : "which";
-  const result = spawnSyncImpl(locator, [command], {
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"]
-  });
+  const discovery = readLocatorCandidates(command, platform, spawnSyncImpl);
+  const resolvedPath = discovery.candidates[0];
 
-  const resolvedPath =
-    result.status === 0
-      ? selectResolvedPath((result.stdout ?? "").split(/\r?\n/u), platform)
-      : undefined;
-
-  return result.status === 0
+  return discovery.candidates.length > 0
     ? {
         command,
         available: true,
-        locator,
+        locator: discovery.locator,
         detail: `${command} is available on PATH.`,
-        ...(resolvedPath ? { resolvedPath } : {})
+        ...(resolvedPath ? { resolvedPath } : {}),
+        candidatePaths: discovery.candidates
       }
     : {
         command,
         available: false,
-        locator,
+        locator: discovery.locator,
         detail: `${command} is not available on PATH.`
       };
 }
@@ -191,32 +475,40 @@ export function diagnoseCodexHost(
     options.env ?? process.env,
     options.platform ?? process.platform
   );
+  const resolvedPath = availability.resolvedPath;
+  const installKind = detectInstallKind(resolvedPath, hostPlatform);
+  const invocationMode = detectInvocationMode(resolvedPath, options.platform ?? process.platform);
   const warnings: string[] = [];
 
   if (!availability.available) {
     return {
       hostPlatform,
       nativeInstallValid: false,
+      installKind,
+      invocationMode,
+      sandboxMode: "workspace-write",
+      sandboxCompatible: false,
+      ...(resolvedPath ? { resolvedPath } : {}),
       warnings,
       remediation: "Install or expose the Codex CLI on PATH before running governed Codex work."
     };
   }
 
-  const resolvedPath = availability.resolvedPath?.replace(/\\/gu, "/").toLowerCase() ?? "";
-  const looksWindowsShim =
-    resolvedPath.endsWith(".cmd") ||
-    resolvedPath.endsWith(".bat") ||
-    resolvedPath.endsWith(".ps1") ||
-    resolvedPath.includes("/appdata/roaming/npm/");
-  const looksMountedWindowsPath = resolvedPath.startsWith("/mnt/c/");
-
-  if ((hostPlatform === "linux" || hostPlatform === "wsl") && (looksWindowsShim || looksMountedWindowsPath)) {
+  if (
+    (hostPlatform === "linux" || hostPlatform === "wsl") &&
+    (installKind === "windows_shim" || installKind === "windows_mounted_path")
+  ) {
     warnings.push(
       "Codex resolves to a Windows-hosted install from a Linux/WSL environment."
     );
     return {
       hostPlatform,
       nativeInstallValid: false,
+      installKind,
+      invocationMode,
+      sandboxMode: "workspace-write",
+      sandboxCompatible: false,
+      ...(resolvedPath ? { resolvedPath } : {}),
       warnings,
       remediation:
         "Install Codex natively inside this Linux/WSL environment instead of relying on a Windows PATH shim."
@@ -226,6 +518,14 @@ export function diagnoseCodexHost(
   return {
     hostPlatform,
     nativeInstallValid: true,
+    installKind,
+    invocationMode,
+    sandboxMode: "workspace-write",
+    sandboxCompatible: true,
+    ...(resolvedPath ? { resolvedPath } : {}),
+    ...(hostPlatform === "linux" || hostPlatform === "wsl"
+      ? { nativeDependencyStatus: "unknown" as const }
+      : {}),
     warnings
   };
 }
@@ -249,17 +549,10 @@ export function probeCodexLaunch(
     env: input.env,
     platform: input.platform
   });
-  const args = [
-    "exec",
-    "--cd",
-    input.workingDirectory,
-    "--sandbox",
-    "workspace-write",
-    "--json",
-    "--color",
-    "never",
-    "--help"
-  ];
+  const args = buildCodexExecArgs({
+    workingDirectory: input.workingDirectory,
+    mode: "probe"
+  });
 
   if (!availability.available) {
     return {
@@ -268,17 +561,6 @@ export function probeCodexLaunch(
       availability,
       diagnosis,
       command: availability.command,
-      args
-    };
-  }
-
-  if (!diagnosis.nativeInstallValid) {
-    return {
-      ok: false,
-      summary: diagnosis.remediation ?? "Codex host installation is not valid for this environment.",
-      availability,
-      diagnosis,
-      command: availability.resolvedPath ?? availability.command,
       args
     };
   }
@@ -297,53 +579,203 @@ export function probeCodexLaunch(
 
   const spawnSyncImpl = input.spawnSyncImpl ?? spawnSync;
   const platform = input.platform ?? process.platform;
-  const spawnPlan = buildProbeCommand(availability.resolvedPath ?? availability.command, args, platform);
-  const result = spawnSyncImpl(spawnPlan.command, spawnPlan.args, {
-    cwd: input.workingDirectory,
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"]
+  const env = input.env ?? process.env;
+  const probeCandidates = buildProbeCandidates({
+    availability,
+    env,
+    platform,
+    includeDesktopCandidates: input.spawnSyncImpl === undefined
   });
-
-  if (result.error) {
-    return {
-      ok: false,
-      summary: `Codex launch probe failed: ${result.error.message}`,
-      availability,
-      diagnosis,
-      command: availability.resolvedPath ?? availability.command,
-      args,
-      stderr: result.stderr ?? "",
-      stdout: result.stdout ?? ""
-    };
+  const candidatePaths = probeCandidates.map((candidate) => candidate.path);
+  const cacheKey = buildProbeCacheKey({
+    workingDirectory: input.workingDirectory,
+    platform,
+    candidatePaths
+  });
+  if (input.spawnSyncImpl === undefined) {
+    const cached = codexLaunchProbeCache.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
   }
+  const candidateResults: Array<{
+    path: string;
+    diagnosis: CodexHostDiagnosis;
+    ok: boolean;
+    summary: string;
+    exitCode?: number;
+    stdout?: string;
+    stderr?: string;
+  }> = [];
 
-  if (result.status !== 0) {
-    const stderr = (result.stderr ?? "").trim();
-    return {
-      ok: false,
-      summary:
-        stderr.length > 0
-          ? `Codex launch probe failed: ${stderr}`
-          : "Codex launch probe exited non-zero.",
-      availability,
-      diagnosis,
-      command: availability.resolvedPath ?? availability.command,
-      args,
+  const probeCandidatePath = (candidate: OrderedProbeCandidate): boolean => {
+    const candidateDiagnosis = candidate.diagnosis;
+
+    if (!candidateDiagnosis.nativeInstallValid) {
+      candidateResults.push({
+        path: candidate.path,
+        diagnosis: candidateDiagnosis,
+        ok: false,
+        summary:
+          candidateDiagnosis.remediation ?? "Codex host installation is not valid for this environment."
+      });
+      return false;
+    }
+
+    const spawnPlan = buildProbeCommand(candidate.path, args, platform);
+    const result = spawnSyncImpl(spawnPlan.command, spawnPlan.args, {
+      cwd: input.workingDirectory,
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "pipe"],
+      input: CODEX_LAUNCH_PROBE_PROMPT
+    });
+    const probedDiagnosis = {
+      ...candidateDiagnosis,
+      invocationMode: spawnPlan.invocationMode
+    };
+
+    if (result.error) {
+      const classifiedFailure = classifyProbeFailure(result.stderr ?? "", result.stdout ?? "", probedDiagnosis);
+      candidateResults.push({
+        path: candidate.path,
+        diagnosis: classifiedFailure.diagnosis ?? probedDiagnosis,
+        ok: false,
+        summary: classifiedFailure.summary ?? `Codex launch probe failed: ${result.error.message}`,
+        stderr: result.stderr ?? "",
+        stdout: result.stdout ?? ""
+      });
+      return false;
+    }
+
+    if (result.status !== 0) {
+      const stderr = (result.stderr ?? "").trim();
+      const classifiedFailure = classifyProbeFailure(result.stderr ?? "", result.stdout ?? "", probedDiagnosis);
+      candidateResults.push({
+        path: candidate.path,
+        diagnosis: classifiedFailure.diagnosis ?? probedDiagnosis,
+        ok: false,
+        summary:
+          classifiedFailure.summary ??
+          (stderr.length > 0 ? `Codex launch probe failed: ${stderr}` : "Codex launch probe exited non-zero."),
+        exitCode: result.status ?? undefined,
+        stderr: result.stderr ?? "",
+        stdout: result.stdout ?? ""
+      });
+      return false;
+    }
+
+    const events = parseCodexProbeEvents(result.stdout ?? "");
+    if (!hasSuccessfulCommandExecution(events)) {
+      const classifiedFailure = classifyProbeFailure(result.stderr ?? "", result.stdout ?? "", probedDiagnosis);
+      candidateResults.push({
+        path: candidate.path,
+        diagnosis: classifiedFailure.diagnosis ?? probedDiagnosis,
+        ok: false,
+        summary:
+          classifiedFailure.summary ?? "Codex launch probe did not complete a shell command successfully.",
+        exitCode: result.status ?? undefined,
+        stderr: result.stderr ?? "",
+        stdout: result.stdout ?? ""
+      });
+      return false;
+    }
+
+    candidateResults.push({
+      path: candidate.path,
+      diagnosis: probedDiagnosis,
+      ok: true,
+      summary: "Codex exec prompt-and-shell probe passed for the current MartinLoop invocation shape.",
       exitCode: result.status ?? undefined,
       stderr: result.stderr ?? "",
       stdout: result.stdout ?? ""
-    };
+    });
+    return true;
+  };
+
+  for (const candidate of probeCandidates) {
+    if (probeCandidatePath(candidate)) {
+      break;
+    }
   }
 
-  return {
-    ok: true,
-    summary: "Codex exec launch probe passed for the current MartinLoop invocation shape.",
-    availability,
-    diagnosis,
-    command: availability.resolvedPath ?? availability.command,
+  const successfulCandidates = candidateResults.filter((candidate) => candidate.ok);
+  const selectedCandidate = successfulCandidates[0];
+  const candidateProbeResults = candidateResults.map((candidate) => ({
+    path: candidate.path,
+    installKind: candidate.diagnosis.installKind,
+    invocationMode: candidate.diagnosis.invocationMode,
+    nativeInstallValid: candidate.diagnosis.nativeInstallValid,
+    sandboxCompatible: candidate.diagnosis.sandboxCompatible,
+    launchReady: candidate.ok,
+    summary: candidate.summary,
+    ...(candidate.diagnosis.remediation ? { remediation: candidate.diagnosis.remediation } : {}),
+    ...(candidate.diagnosis.nativeDependencyStatus
+      ? { nativeDependencyStatus: candidate.diagnosis.nativeDependencyStatus }
+      : {}),
+    ...(candidate.diagnosis.nativeDependencyPackage
+      ? { nativeDependencyPackage: candidate.diagnosis.nativeDependencyPackage }
+      : {})
+  }));
+
+  if (selectedCandidate) {
+    const successResult: CodexLaunchProbeResult = {
+      ok: true,
+      summary: selectedCandidate.summary,
+      availability: {
+        ...availability,
+        resolvedPath: selectedCandidate.path,
+        candidatePaths
+      },
+      diagnosis: {
+        ...selectedCandidate.diagnosis,
+        resolvedPath: selectedCandidate.path
+      },
+      command: selectedCandidate.path,
+      args,
+      exitCode: selectedCandidate.exitCode,
+      stderr: selectedCandidate.stderr,
+      stdout: selectedCandidate.stdout,
+      candidateProbeResults
+    };
+    if (input.spawnSyncImpl === undefined) {
+      codexLaunchProbeCache.set(cacheKey, successResult);
+    }
+    return successResult;
+  }
+
+  const bestFailure =
+    platform === "win32"
+      ? candidateResults.find(
+          (candidate) =>
+            candidate.diagnosis.nativeInstallValid && candidate.diagnosis.installKind === "native"
+        ) ??
+        candidateResults.find((candidate) => candidate.diagnosis.nativeInstallValid) ??
+        candidateResults[0]
+      : candidateResults[0];
+
+  const failureResult: CodexLaunchProbeResult = {
+    ok: false,
+    summary: bestFailure?.summary ?? diagnosis.remediation ?? "Codex launch probe failed.",
+    availability: {
+      ...availability,
+      ...(bestFailure ? { resolvedPath: bestFailure.path } : {}),
+      ...(candidatePaths.length ? { candidatePaths } : {})
+    },
+    diagnosis: bestFailure
+      ? {
+          ...bestFailure.diagnosis,
+          resolvedPath: bestFailure.path
+        }
+      : diagnosis,
+    command: bestFailure?.path ?? availability.resolvedPath ?? availability.command,
     args,
-    exitCode: result.status ?? undefined,
-    stderr: result.stderr ?? "",
-    stdout: result.stdout ?? ""
+    exitCode: bestFailure?.exitCode,
+    stderr: bestFailure?.stderr,
+    stdout: bestFailure?.stdout,
+    candidateProbeResults
   };
+  if (input.spawnSyncImpl === undefined) {
+    codexLaunchProbeCache.set(cacheKey, failureResult);
+  }
+  return failureResult;
 }

--- a/packages/adapters/src/openai-compatible.ts
+++ b/packages/adapters/src/openai-compatible.ts
@@ -247,7 +247,12 @@ export function createOpenAiCompatibleAdapter(
     async execute(request: MartinAdapterRequest): Promise<MartinAdapterResult> {
       const prompt = buildPrompt(request);
       const estimated = estimateCost(model, prompt.length, 2000);
-      const baselineChangedFiles = new Set(await readGitChangedFiles(workingDirectory, 5_000));
+      const hasVerificationSteps =
+        request.context.verificationPlan.length > 0 ||
+        (request.context.verificationStack?.length ?? 0) > 0;
+      const baselineChangedFiles = hasVerificationSteps
+        ? new Set(await readGitChangedFiles(workingDirectory, 5_000))
+        : new Set<string>();
 
       // Preflight: bail if projected cost exceeds remaining budget
       if (
@@ -354,9 +359,11 @@ export function createOpenAiCompatibleAdapter(
       );
 
       const execution = {
-        changedFiles: (await readGitChangedFiles(workingDirectory, 5_000)).filter(
-          (file) => !baselineChangedFiles.has(file)
-        )
+        changedFiles: hasVerificationSteps
+          ? (await readGitChangedFiles(workingDirectory, 5_000)).filter(
+              (file) => !baselineChangedFiles.has(file)
+            )
+          : []
       };
 
       const pricing = KNOWN_MODEL_PRICING[model] ?? {

--- a/packages/adapters/src/verifier-only.ts
+++ b/packages/adapters/src/verifier-only.ts
@@ -1,12 +1,13 @@
 import type { MartinAdapter } from "@martin/core";
 
-import { readGitChangedFiles, runVerification } from "./cli-bridge.js";
+import { readGitChangedFiles, runVerification, type SpawnLike } from "./cli-bridge.js";
 import { createAdapterCapabilities, normalizeUsage } from "./runtime-support.js";
 
 export interface VerifierOnlyAdapterOptions {
   workingDirectory?: string;
   verifyTimeoutMs?: number;
   label?: string;
+  spawnImpl?: SpawnLike;
 }
 
 export function createVerifierOnlyAdapter(
@@ -29,16 +30,24 @@ export function createVerifierOnlyAdapter(
       })
     },
     async execute(request) {
-      const baselineChangedFiles = new Set(await readGitChangedFiles(workingDirectory, 5_000));
+      const hasVerificationSteps =
+        request.context.verificationPlan.length > 0 ||
+        (request.context.verificationStack?.length ?? 0) > 0;
+      const baselineChangedFiles = hasVerificationSteps
+        ? new Set(await readGitChangedFiles(workingDirectory, 5_000))
+        : new Set<string>();
       const verification = await runVerification(
         request.context.verificationPlan,
         workingDirectory,
         verifyTimeoutMs,
-        request.context.verificationStack
+        request.context.verificationStack,
+        options.spawnImpl
       );
-      const changedFiles = (await readGitChangedFiles(workingDirectory, 5_000)).filter(
-        (file) => !baselineChangedFiles.has(file)
-      );
+      const changedFiles = hasVerificationSteps
+        ? (await readGitChangedFiles(workingDirectory, 5_000)).filter(
+            (file) => !baselineChangedFiles.has(file)
+          )
+        : [];
       const execution = { changedFiles };
 
       if (verification.passed) {

--- a/packages/adapters/tests/claude-cli.test.ts
+++ b/packages/adapters/tests/claude-cli.test.ts
@@ -19,7 +19,7 @@ import {
   createVerifierOnlyAdapter,
   type SpawnLike
 } from "../src/index.js";
-import { runSubprocess, splitCommand } from "../src/cli-bridge.js";
+import { readGitChangedFiles, readGitExecutionArtifacts, runSubprocess, splitCommand } from "../src/cli-bridge.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -332,10 +332,10 @@ describe("createAgentCliAdapter", () => {
 describe("splitCommand", () => {
   it("preserves backslashes inside quoted Windows executable paths", () => {
     const command =
-      '"C:\\Users\\ExampleUser\\Projects\\node.exe" -e "process.exit(0)"';
+      '"C:\\Projects\\Example\\node.exe" -e "process.exit(0)"';
 
     expect(splitCommand(command)).toEqual([
-      "C:\\Users\\ExampleUser\\Projects\\node.exe",
+      "C:\\Projects\\Example\\node.exe",
       "-e",
       "process.exit(0)",
     ]);
@@ -349,7 +349,7 @@ describe("createSpawnPlan", () => {
       return;
     }
 
-    const pnpmPath = "C:\\Users\\Example User\\AppData\\Roaming\\npm\\pnpm.cmd";
+    const pnpmPath = "C:\\Tools\\Example Path\\npm\\pnpm.cmd";
     const plan = createSpawnPlan(
       pnpmPath,
       ["verify shared baseline", "--filter", "pkg with spaces"],
@@ -359,11 +359,10 @@ describe("createSpawnPlan", () => {
 
     expect(plan.command.toLowerCase()).toContain("cmd.exe");
     expect(plan.args[0]).toBe("/d");
-    expect(plan.args[1]).toBe("/s");
-    expect(plan.args[2]).toBe("/c");
-    expect(plan.args[3]).toContain('"C:\\Users\\Example User\\AppData\\Roaming\\npm\\pnpm.cmd"');
-    expect(plan.args[3]).toContain('"verify shared baseline"');
-    expect(plan.args[3]).toContain('"pkg with spaces"');
+    expect(plan.args[1]).toBe("/c");
+    expect(plan.args[2]).toBe("C:\\Tools\\Example Path\\npm\\pnpm.cmd");
+    expect(plan.args[3]).toBe("verify shared baseline");
+    expect(plan.args[5]).toBe("pkg with spaces");
   });
 
   it("wraps absolute Windows PowerShell scripts through powershell.exe", () => {
@@ -372,7 +371,7 @@ describe("createSpawnPlan", () => {
       return;
     }
 
-    const scriptPath = "C:\\Users\\ExampleUser\\AppData\\Roaming\\npm\\codex.ps1";
+    const scriptPath = "C:\\Tools\\npm\\codex.ps1";
     const plan = createSpawnPlan(scriptPath, ["--version"], process.cwd(), false);
 
     expect(plan.command.toLowerCase()).toContain("powershell.exe");
@@ -402,8 +401,8 @@ describe("createSpawnPlan", () => {
     expect(plan.args[0]).toBe("/d");
     expect(plan.args[1]).toBe("/c");
     expect(plan.args[2]).toContain("__martin_nonexistent_verifier_cmd__");
-    expect(plan.args[2]).toContain("run");
-    expect(plan.args[2]).toContain("test");
+    expect(plan.args[3]).toBe("run");
+    expect(plan.args[4]).toBe("test");
   });
 
   it("preserves raw command when preserveRawForInjectedSpawn is true regardless of platform", () => {
@@ -453,6 +452,51 @@ describe("runSubprocess", () => {
 });
 
 describe("createVerifierOnlyAdapter", () => {
+  it("short-circuits git inspection outside a repository", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "martin-no-git-"));
+    let spawnCalls = 0;
+    const spawnImpl: SpawnLike = () => {
+      spawnCalls += 1;
+      throw new Error("git subprocess should not run outside a repository");
+    };
+
+    try {
+      await expect(readGitChangedFiles(directory, 1_000, spawnImpl)).resolves.toEqual([]);
+      await expect(readGitExecutionArtifacts(directory, 1_000, spawnImpl)).resolves.toEqual({});
+      expect(spawnCalls).toBe(0);
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("skips baseline diff scans when verify-only has no verification steps", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "martin-verify-empty-"));
+
+    try {
+      const adapter = createVerifierOnlyAdapter({ workingDirectory: directory });
+      const result = await adapter.execute(
+        makeRequest({
+          context: {
+            taskTitle: "verify only",
+            objective: "Run verification only",
+            verificationPlan: [],
+            verificationStack: [],
+            mutationMode: "verify_only",
+            focus: "verify only",
+            remainingBudgetUsd: 8,
+            remainingIterations: 1,
+            remainingTokens: 10_000
+          }
+        })
+      );
+
+      expect(result.status).toBe("completed");
+      expect(result.execution?.changedFiles).toEqual([]);
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
   it("reports verifier-created file changes instead of treating verify-only as clean", { timeout: 15000 }, async () => {
     const directory = await mkdtemp(join(tmpdir(), "martin-verify-only-"));
 
@@ -535,7 +579,7 @@ describe("createClaudeCliAdapter", () => {
     expect(result.failure?.message).toContain("environment_mismatch");
   });
 
-  it("routes no-diff and scope git probes through the injected spawn implementation", async () => {
+  it("skips git probes when repoRoot is outside a repository", async () => {
     const calls: SpawnCall[] = [];
     const adapter = createClaudeCliAdapter({
       spawnImpl: createScriptedSpawn(calls, [
@@ -573,11 +617,8 @@ describe("createClaudeCliAdapter", () => {
     );
 
     expect(result.status).toBe("completed");
-    expect(calls).toHaveLength(5);
+    expect(calls).toHaveLength(1);
     expect(calls[0]?.command).toBe("claude");
-    expect(calls.slice(1).map((call) => call.command)).toEqual(["git", "git", "git", "git"]);
-    expect(calls[1]?.args).toEqual(["diff", "--name-only", "HEAD"]);
-    expect(calls[4]?.args).toEqual(["diff", "--name-only", "HEAD"]);
   });
 });
 
@@ -705,6 +746,37 @@ describe("createCodexCliAdapter", () => {
     expect(result.verification.passed).toBe(true);
     expect(calls[0]?.command).toBe("codex");
     expect(calls[1]?.command).toBe(process.platform === "win32" ? "cmd" : "true");
+  });
+
+  it("fails closed when Codex exits non-zero before emitting structured completion", async () => {
+    const calls: SpawnCall[] = [];
+    const adapter = createCodexCliAdapter({
+      spawnImpl: createScriptedSpawn(calls, [
+        {
+          stdout: "usage: codex exec ...\n",
+          stderr: "launch failed\n",
+          exitCode: 2
+        }
+      ])
+    });
+    const result = await adapter.execute(
+      makeRequest({
+        context: {
+          taskTitle: "test",
+          objective: "patch then verify",
+          verificationPlan: process.platform === "win32" ? ["cmd /c exit 0"] : ["true"],
+          focus: "test",
+          remainingBudgetUsd: 8,
+          remainingIterations: 3,
+          remainingTokens: 10_000
+        }
+      })
+    );
+
+    expect(result.status).toBe("failed");
+    expect(result.summary).toContain("exited before verifier execution");
+    expect(result.verification.passed).toBe(false);
+    expect(calls).toHaveLength(1);
   });
 
   it("settles authoritative Codex usage from JSONL turn.completed output", async () => {

--- a/packages/adapters/tests/codex-launcher.test.ts
+++ b/packages/adapters/tests/codex-launcher.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  buildCodexExecArgs,
   diagnoseCodexHost,
   probeCodexLaunch,
   resolveCliCommandAvailability
@@ -14,9 +15,10 @@ describe("resolveCliCommandAvailability", () => {
   it("captures the resolved path when the locator succeeds", () => {
     const availability = resolveCliCommandAvailability("codex", {
       platform: "win32",
+      env: {},
       spawnSyncImpl: vi.fn(() => ({
         status: 0,
-        stdout: "C:\\Users\\ExampleUser\\AppData\\Roaming\\npm\\codex.cmd\r\n",
+        stdout: "C:\\Tools\\npm\\codex.cmd\r\n",
         stderr: ""
       })) as never
     });
@@ -26,14 +28,15 @@ describe("resolveCliCommandAvailability", () => {
     expect(availability.locator).toBe("where.exe");
   });
 
-  it("prefers a Windows command shim over the bare npm shim", () => {
+  it("preserves Windows candidate discovery order from PATH", () => {
     const availability = resolveCliCommandAvailability("codex", {
       platform: "win32",
+      env: {},
       spawnSyncImpl: vi.fn(() => ({
         status: 0,
         stdout: [
-          "C:\\Users\\ExampleUser\\AppData\\Roaming\\npm\\codex",
-          "C:\\Users\\ExampleUser\\AppData\\Roaming\\npm\\codex.cmd",
+          "C:\\Tools\\npm\\codex",
+          "C:\\Tools\\npm\\codex.cmd",
           "C:\\Program Files\\OpenAI\\Codex\\codex.exe",
           ""
         ].join("\r\n"),
@@ -42,12 +45,18 @@ describe("resolveCliCommandAvailability", () => {
     });
 
     expect(availability.available).toBe(true);
-    expect(availability.resolvedPath).toBe("C:\\Users\\ExampleUser\\AppData\\Roaming\\npm\\codex.cmd");
+    expect(availability.resolvedPath).toBe("C:\\Tools\\npm\\codex");
+    expect(availability.candidatePaths).toEqual([
+      "C:\\Tools\\npm\\codex",
+      "C:\\Tools\\npm\\codex.cmd",
+      "C:\\Program Files\\OpenAI\\Codex\\codex.exe"
+    ]);
   });
 
-  it("preserves where.exe order when equally preferred Windows shims match", () => {
+  it("preserves where.exe order when equally ordered Windows candidates match", () => {
     const availability = resolveCliCommandAvailability("codex", {
       platform: "win32",
+      env: {},
       spawnSyncImpl: vi.fn(() => ({
         status: 0,
         stdout: [
@@ -61,6 +70,10 @@ describe("resolveCliCommandAvailability", () => {
 
     expect(availability.available).toBe(true);
     expect(availability.resolvedPath).toBe("C:\\Zeta Tools\\codex.cmd");
+    expect(availability.candidatePaths).toEqual([
+      "C:\\Zeta Tools\\codex.cmd",
+      "C:\\Alpha Tools\\codex.cmd"
+    ]);
   });
 });
 
@@ -81,13 +94,43 @@ describe("diagnoseCodexHost", () => {
     );
 
     expect(diagnosis.hostPlatform).toBe("wsl");
+    expect(diagnosis.installKind).toBe("windows_mounted_path");
     expect(diagnosis.nativeInstallValid).toBe(false);
+    expect(diagnosis.sandboxCompatible).toBe(false);
     expect(diagnosis.remediation).toContain("Install Codex natively");
   });
 });
 
+describe("buildCodexExecArgs", () => {
+  it("builds the same exec contract used for real runs and launch probes", () => {
+    expect(
+      buildCodexExecArgs({
+        workingDirectory: "/repo/worktree",
+        sandbox: "workspace-write",
+        model: "gpt-5-codex",
+        extraArgs: ["--profile", "ci"],
+        mode: "prompt"
+      })
+    ).toEqual([
+      "exec",
+      "--cd",
+      "/repo/worktree",
+      "--sandbox",
+      "workspace-write",
+      "--json",
+      "--color",
+      "never",
+      "--model",
+      "gpt-5-codex",
+      "--profile",
+      "ci",
+      "-"
+    ]);
+  });
+});
+
 describe("probeCodexLaunch", () => {
-  it("probes the exact MartinLoop Codex exec shape without spending tokens", () => {
+  it("probes the exact MartinLoop Codex exec shape with a no-edit shell command", () => {
     const spawnSyncImpl = vi
       .fn()
       .mockReturnValueOnce({
@@ -97,7 +140,27 @@ describe("probeCodexLaunch", () => {
       })
       .mockReturnValueOnce({
         status: 0,
-        stdout: "usage: codex exec ...\n",
+        stdout: [
+          JSON.stringify({
+            type: "item.completed",
+            item: {
+              id: "item_1",
+              type: "command_execution",
+              command: "git status --short -- .",
+              aggregated_output: "",
+              exit_code: 0,
+              status: "completed"
+            }
+          }),
+          JSON.stringify({
+            type: "item.completed",
+            item: {
+              id: "item_2",
+              type: "agent_message",
+              text: "READY"
+            }
+          })
+        ].join("\n"),
         stderr: ""
       });
 
@@ -118,7 +181,7 @@ describe("probeCodexLaunch", () => {
       "--json",
       "--color",
       "never",
-      "--help"
+      "-"
     ]);
     expect(spawnSyncImpl).toHaveBeenNthCalledWith(
       2,
@@ -126,9 +189,11 @@ describe("probeCodexLaunch", () => {
       result.args,
       expect.objectContaining({
         cwd: process.cwd(),
-        encoding: "utf8"
+        encoding: "utf8",
+        input: expect.stringContaining("git status --short -- .")
       })
     );
+    expect(result.summary).toContain("prompt-and-shell probe passed");
   });
 
   it("fails closed when Codex resolves to a Windows shim in WSL", () => {
@@ -150,6 +215,79 @@ describe("probeCodexLaunch", () => {
     expect(spawnSyncImpl).toHaveBeenCalledTimes(1);
   });
 
+  it("prefers native Windows runtime candidates ahead of shims", () => {
+    const spawnSyncImpl = vi.fn((command: string) => {
+      if (/cmd(.exe)?$/iu.test(command)) {
+        return {
+          status: 0,
+          stdout: [
+            JSON.stringify({
+              type: "item.completed",
+              item: {
+                id: "item_1",
+                type: "command_execution",
+                command: "\"pwsh.exe\" -NoProfile -Command 'git status --short -- .'",
+                aggregated_output:
+                  "execution error: Io(Custom { kind: Other, error: \"windows sandbox: runner error: CreateProcessAsUserW failed: 5\" })",
+                exit_code: -1,
+                status: "failed"
+              }
+            })
+          ].join("\n"),
+          stderr: ""
+        };
+      }
+
+      return {
+        status: 0,
+        stdout: JSON.stringify({
+          type: "item.completed",
+          item: {
+            id: "item_1",
+            type: "command_execution",
+            command: "git status --short -- .",
+            aggregated_output: "",
+            exit_code: 0,
+            status: "completed"
+          }
+        }),
+        stderr: ""
+      };
+    });
+
+    const result = probeCodexLaunch({
+      workingDirectory: process.cwd(),
+      platform: "win32",
+      availability: {
+        command: "codex",
+        available: true,
+        locator: "where.exe",
+        detail: "codex is available on PATH.",
+        resolvedPath: "C:\\Tools\\npm\\codex.cmd",
+        candidatePaths: [
+          "C:\\Tools\\npm\\codex.cmd",
+          "C:\\Users\\ExampleUser\\AppData\\Local\\OpenAI\\Codex\\bin\\abcd1234\\codex.exe"
+        ]
+      },
+      spawnSyncImpl: spawnSyncImpl as never
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.command).toBe(
+      "C:\\Users\\ExampleUser\\AppData\\Local\\OpenAI\\Codex\\bin\\abcd1234\\codex.exe"
+    );
+    expect(result.availability.resolvedPath).toBe(
+      "C:\\Users\\ExampleUser\\AppData\\Local\\OpenAI\\Codex\\bin\\abcd1234\\codex.exe"
+    );
+    expect(result.candidateProbeResults).toEqual([
+      expect.objectContaining({
+        path: "C:\\Users\\ExampleUser\\AppData\\Local\\OpenAI\\Codex\\bin\\abcd1234\\codex.exe",
+        launchReady: true,
+        installKind: "native"
+      })
+    ]);
+  });
+
   it("fails closed when the working directory is not inside a git repository", () => {
     const workingDirectory = mkdtempSync(join(tmpdir(), "martin-codex-nongit-"));
 
@@ -164,7 +302,7 @@ describe("probeCodexLaunch", () => {
           available: true,
           locator: "where.exe",
           detail: "codex is available on PATH.",
-          resolvedPath: "C:\\Users\\ExampleUser\\AppData\\Roaming\\npm\\codex.cmd"
+          resolvedPath: "C:\\Tools\\npm\\codex.cmd"
         },
         spawnSyncImpl: spawnSyncImpl as never
       });
@@ -206,7 +344,17 @@ describe("probeCodexLaunch", () => {
   it("wraps Windows cmd launch probes through cmd.exe", () => {
     const spawnSyncImpl = vi.fn(() => ({
       status: 0,
-      stdout: "usage: codex exec ...\r\n",
+      stdout: JSON.stringify({
+        type: "item.completed",
+        item: {
+          id: "item_1",
+          type: "command_execution",
+          command: "git status --short -- .",
+          aggregated_output: "",
+          exit_code: 0,
+          status: "completed"
+        }
+      }),
       stderr: ""
     }));
 
@@ -218,7 +366,7 @@ describe("probeCodexLaunch", () => {
         available: true,
         locator: "where.exe",
         detail: "codex is available on PATH.",
-        resolvedPath: "C:\\Users\\ExampleUser\\AppData\\Roaming\\npm\\codex.cmd"
+          resolvedPath: "C:\\Tools\\npm\\codex.cmd"
       },
       spawnSyncImpl: spawnSyncImpl as never
     });
@@ -226,11 +374,88 @@ describe("probeCodexLaunch", () => {
     expect(result.ok).toBe(true);
     expect(spawnSyncImpl).toHaveBeenCalledWith(
       expect.stringMatching(/cmd(.exe)?$/i),
-      expect.arrayContaining(["/d", "/c", expect.stringContaining("codex.cmd"), "exec"]),
+      expect.arrayContaining(["/d", "/c", "C:\\Tools\\npm\\codex.cmd", "exec"]),
       expect.objectContaining({
         cwd: process.cwd(),
         encoding: "utf8"
       })
     );
+    expect(result.diagnosis.invocationMode).toBe("cmd_shell");
+  });
+
+  it("fails closed when Codex prompt execution cannot launch shell commands on Windows", () => {
+    const spawnSyncImpl = vi.fn(() => ({
+      status: 0,
+      stdout: [
+        JSON.stringify({
+          type: "item.completed",
+          item: {
+            id: "item_1",
+            type: "command_execution",
+            command: "\"pwsh.exe\" -NoProfile -Command 'git status --short -- .'",
+            aggregated_output:
+              "execution error: Io(Custom { kind: Other, error: \"windows sandbox: runner error: CreateProcessAsUserW failed: 5\" })",
+            exit_code: -1,
+            status: "failed"
+          }
+        }),
+        JSON.stringify({
+          type: "item.completed",
+          item: {
+            id: "item_2",
+            type: "agent_message",
+            text: "Shell execution failed."
+          }
+        })
+      ].join("\n"),
+      stderr: ""
+    }));
+
+    const result = probeCodexLaunch({
+      workingDirectory: process.cwd(),
+      platform: "win32",
+      availability: {
+        command: "codex",
+        available: true,
+        locator: "where.exe",
+        detail: "codex is available on PATH.",
+        resolvedPath: "C:\\Tools\\npm\\codex.cmd"
+      },
+      spawnSyncImpl: spawnSyncImpl as never
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.summary).toContain("workspace-write sandbox");
+    expect(result.diagnosis.sandboxCompatible).toBe(false);
+    expect(result.diagnosis.remediation).toContain("workspace-write");
+  });
+
+  it("classifies missing Linux native Codex dependencies before governed work starts", () => {
+    const spawnSyncImpl = vi
+      .fn()
+      .mockReturnValueOnce({
+        status: 0,
+        stdout: "/usr/local/bin/codex\n",
+        stderr: ""
+      })
+      .mockReturnValueOnce({
+        status: 1,
+        stdout: "",
+        stderr: "Error: Cannot find module '@openai/codex-linux-x64'\n"
+      });
+
+    const result = probeCodexLaunch({
+      workingDirectory: process.cwd(),
+      platform: "linux",
+      env: {},
+      spawnSyncImpl: spawnSyncImpl as never
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.summary).toContain("@openai/codex-linux-x64");
+    expect(result.diagnosis.nativeInstallValid).toBe(false);
+    expect(result.diagnosis.nativeDependencyStatus).toBe("missing");
+    expect(result.diagnosis.nativeDependencyPackage).toBe("@openai/codex-linux-x64");
+    expect(result.diagnosis.remediation).toContain("Reinstall Codex natively");
   });
 });

--- a/packages/adapters/tests/openai-compatible.test.ts
+++ b/packages/adapters/tests/openai-compatible.test.ts
@@ -5,6 +5,9 @@
 
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import type { AddressInfo } from "node:net";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, it, expect, afterEach, vi } from "vitest";
 import { createLoopRecord } from "@martin/contracts";
 import { createOpenAiCompatibleAdapter } from "../src/openai-compatible.js";
@@ -164,6 +167,32 @@ describe("createOpenAiCompatibleAdapter", () => {
 
     expect(result.status).toBe("failed");
     expect(result.failure?.message).toBe("empty_response");
+  });
+
+  it("skips git diff scans when no verification steps are configured", async () => {
+    const { url, close } = await startMockServer(() => ({
+      body: {
+        choices: [{ message: { role: "assistant", content: "No repo required." }, finish_reason: "stop" }],
+        usage: { prompt_tokens: 50, completion_tokens: 10 }
+      }
+    }));
+    mockClose = close;
+    const workingDirectory = await mkdtemp(join(tmpdir(), "martin-openai-no-git-"));
+
+    try {
+      const adapter = createOpenAiCompatibleAdapter({
+        baseUrl: url,
+        model: "test-model",
+        workingDirectory
+      });
+
+      const result = await adapter.execute(makeRequest() as any);
+
+      expect(result.status).toBe("completed");
+      expect(result.execution?.changedFiles).toEqual([]);
+    } finally {
+      await rm(workingDirectory, { recursive: true, force: true });
+    }
   });
 
   it("blocks on budget preflight when projected cost exceeds remaining budget", async () => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -24,7 +24,8 @@ import {
   type MartinOutputMode,
   type MartinRunListFilters,
   type MartinRunSelector,
-  type MutationMode
+  type MutationMode,
+  type ReceiptScope
 } from "@martin/contracts";
 
 import {
@@ -76,9 +77,11 @@ import {
   triagePersistedLoops
 } from "./run-store.js";
 import { CliCommandError, renderCliError, renderCliSuccess } from "./ux.js";
+import { evaluateCliRunGate, recordCliWorkflowStep } from "./workflow-state.js";
 
 const require = createRequire(import.meta.url);
 const packageJson = require("../package.json") as { version: string };
+let runAdapterOverrideForTests: MartinAdapter | undefined;
 
 export type RunCommandRequest = {
   workspaceId: string;
@@ -91,6 +94,7 @@ export type RunCommandRequest = {
   budgetOverrides?: Partial<Record<keyof LoopBudget, true>>;
   configPath?: string;
   cwd?: string;
+  runsDir?: string;
   model?: string;
   engine?: string;
   mutationMode?: MutationMode;
@@ -369,6 +373,10 @@ export async function executeCli(args: string[]): Promise<{
   } catch (error) {
     return renderCliError(outputMode, error);
   }
+}
+
+export function __setRunAdapterOverrideForTests(adapter?: MartinAdapter): void {
+  runAdapterOverrideForTests = adapter;
 }
 
 export function parseCliArguments(args: string[]): ParsedCliArguments {
@@ -699,22 +707,46 @@ async function executeRunCommand(
   };
   const cliEnvironment = resolveCliEnvironment({
     cwd: resolvedRequest.cwd,
+    runsDir: resolvedRequest.runsDir,
     engine: resolvedRequest.engine
   });
-  const adapter = selectAdapter(
-    resolvedRequest.engine,
-    cliEnvironment.workingDirectory,
-    resolvedRequest.model,
-    resolvedRequest.mutationMode
-  );
-
-  let result: Awaited<ReturnType<typeof runMartin>>;
+  const receiptScope = buildCliReceiptScope(cliEnvironment);
   const engineRequired =
     resolvedRequest.mutationMode !== "verify_only" && cliEnvironment.liveMode === "live";
 
+  if (engineRequired) {
+    const gate = await evaluateCliRunGate({
+      runsRoot: cliEnvironment.runsRoot,
+      workingDirectory: cliEnvironment.workingDirectory,
+      objective: resolvedRequest.objective,
+      engine: cliEnvironment.engine,
+      verificationPlan: resolvedRequest.verificationPlan,
+      mutationMode: resolvedRequest.mutationMode,
+      receiptScope,
+      allowedPaths: resolvedRequest.allowedPaths,
+      deniedPaths: resolvedRequest.deniedPaths,
+      budget: resolvedRequest.budget
+    });
+
+    if (!gate.allowed) {
+      throw new CliCommandError("policy_blocked", gate.message, {
+        suggestion: gate.nextCommand,
+        details: {
+          missingSteps: gate.missingSteps,
+          receiptScope
+        }
+      });
+    }
+  }
+
+  let result: Awaited<ReturnType<typeof runMartin>>;
+  let codexCommandOverride: string | undefined;
+
   if (engineRequired && cliEnvironment.engine === "codex") {
+    const codexAvailability = resolveCliCommandAvailability("codex");
     const codexProbe = probeCodexLaunch({
-      workingDirectory: cliEnvironment.workingDirectory
+      workingDirectory: cliEnvironment.workingDirectory,
+      availability: codexAvailability
     });
     if (!codexProbe.ok) {
       throw new CliCommandError("environment", codexProbe.summary, {
@@ -723,20 +755,30 @@ async function executeRunCommand(
           command: codexProbe.command,
           args: codexProbe.args,
           resolvedPath: codexProbe.availability.resolvedPath,
-          hostPlatform: codexProbe.diagnosis.hostPlatform
+          hostPlatform: codexProbe.diagnosis.hostPlatform,
+          invocationMode: codexProbe.diagnosis.invocationMode,
+          installKind: codexProbe.diagnosis.installKind,
+          sandboxCompatible: codexProbe.diagnosis.sandboxCompatible,
+          remediation: codexProbe.diagnosis.remediation
         }
       });
     }
+    codexCommandOverride = codexProbe.command;
   }
+
+  const adapter = selectAdapter(
+    resolvedRequest.engine,
+    cliEnvironment.workingDirectory,
+    resolvedRequest.model,
+    resolvedRequest.mutationMode,
+    codexCommandOverride
+  );
   try {
     result = await runMartin({
       workspaceId: resolvedRequest.workspaceId,
       projectId: resolvedRequest.projectId,
       receiptScope: {
-        invocationRoot: cliEnvironment.invocationRoot,
-        workingDirectory: cliEnvironment.workingDirectory,
-        repoRoot: cliEnvironment.workingDirectory,
-        runsRoot: cliEnvironment.runsRoot
+        ...receiptScope
       },
       task: {
         title: resolvedRequest.title,
@@ -768,10 +810,7 @@ async function executeRunCommand(
       budget: resolvedRequest.budget,
       metadata: resolvedRequest.metadata,
       receiptScope: {
-        invocationRoot: cliEnvironment.invocationRoot,
-        workingDirectory: cliEnvironment.workingDirectory,
-        repoRoot: cliEnvironment.workingDirectory,
-        runsRoot: cliEnvironment.runsRoot
+        ...receiptScope
       },
       status: "exited",
       lifecycleState: "human_escalation"
@@ -818,7 +857,8 @@ async function executeRunCommand(
         runsRoot: cliEnvironment.runsRoot,
         engine: cliEnvironment.engine,
         liveMode: cliEnvironment.liveMode
-      }
+      },
+      receiptScope
     },
     human: [
       `Started Martin Loop run ${result.loop.loopId}`,
@@ -1001,12 +1041,13 @@ async function executeDoctorCommand(
   const geminiAvailability = resolveCliCommandAvailability("gemini");
   const geminiAvailable = geminiAvailability.available;
   const codexProbe =
-    environment.liveMode === "live" && workingDirectoryReady
+    environment.liveMode === "live" && environment.engine === "codex" && workingDirectoryReady
       ? probeCodexLaunch({
           workingDirectory: environment.workingDirectory,
           availability: codexAvailability
         })
       : undefined;
+  const receiptScope = buildCliReceiptScope(environment);
   const warnings: string[] = [];
 
   if (!workingDirectoryReady) {
@@ -1032,11 +1073,9 @@ async function executeDoctorCommand(
     command: "doctor",
     cliVersion: packageJson.version,
     environment,
+    receiptScope,
     scope: {
-      invocationRoot: environment.invocationRoot,
-      workingDirectory: environment.workingDirectory,
-      repoRoot: environment.workingDirectory,
-      runsRoot: environment.runsRoot
+      ...receiptScope
     },
     config: {
       path: configPath,
@@ -1045,16 +1084,7 @@ async function executeDoctorCommand(
     engines: {
       claude: { available: claudeAvailable },
       codex: {
-        available: codexAvailable,
-        ...(codexAvailability.resolvedPath ? { resolvedPath: codexAvailability.resolvedPath } : {}),
-        ...(codexProbe
-          ? {
-              hostPlatform: codexProbe.diagnosis.hostPlatform,
-              nativeInstallValid: codexProbe.diagnosis.nativeInstallValid,
-              launchReady: codexProbe.ok,
-              probeSummary: codexProbe.summary
-            }
-          : {})
+        ...buildCodexEngineDiagnostics(codexAvailability, codexProbe)
       },
       openai: {
         available: true,
@@ -1079,9 +1109,19 @@ async function executeDoctorCommand(
       claudeAvailable,
       codexAvailable,
       geminiAvailable,
-      workingDirectoryReady
+      workingDirectoryReady,
+      codexLaunchReady: codexProbe?.ok,
+      codexRemediation: codexProbe?.diagnosis.remediation
     })
   };
+
+  await recordCliWorkflowStep({
+    runsRoot: environment.runsRoot,
+    step: "doctor",
+    workingDirectory: environment.workingDirectory,
+    engine: environment.engine,
+    receiptScope
+  }).catch(() => {});
 
   return renderCliSuccess(outputMode, {
     data,
@@ -1095,6 +1135,7 @@ async function executeDoctorCommand(
       `Gemini CLI: ${geminiAvailable ? "available" : "missing"}`,
       `OpenAI-compatible: ${resolveOpenAiCompatibleRuntimeConfig().baseUrl} (${resolveOpenAiCompatibleRuntimeConfig().model})`,
       ...(codexProbe ? [`Codex launch probe: ${codexProbe.ok ? "ready" : codexProbe.summary}`] : []),
+      `Receipt scope: repo=${receiptScope.repoRoot} runs=${receiptScope.runsRoot}`,
       `Config: ${configExists ? configPath : `not found at ${configPath}`}`
     ],
     quiet: environment.runsRoot,
@@ -1108,6 +1149,7 @@ async function executeNativePhaseCommand(
 ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
   const snapshot = await createNativePhaseCommandCenterSnapshot({
     rootDir: command.cwd,
+    invocationRoot: resolveInvocationRoot(),
     runsDir: command.runsDir,
     host: command.host,
     runScanLimit: command.runScanLimit
@@ -1125,13 +1167,25 @@ async function executeNativePhaseCommand(
       });
     }
 
-    const request = buildNativePhaseRunRequest(snapshot.contract, command.cwd);
+    const request = buildNativePhaseRunRequest(snapshot.contract, {
+      cwd: command.cwd,
+      runsDir: command.runsDir
+    });
     return command.subcommand === "run"
       ? executeRunCommand(request, outputMode)
       : executePreflightCommand(request, outputMode);
   }
 
   const data = selectNativePhasePayload(snapshot, command.subcommand);
+  if (command.subcommand === "session-start") {
+    await recordCliWorkflowStep({
+      runsRoot: snapshot.receiptScope.runsRoot,
+      step: "session-start",
+      workingDirectory: snapshot.receiptScope.workingDirectory,
+      ...(snapshot.sessionStart.host === "codex" ? { engine: "codex" as const } : {}),
+      receiptScope: snapshot.receiptScope
+    }).catch(() => {});
+  }
   const human =
     command.subcommand === "session-start"
       ? renderNativePhaseHuman(snapshot)
@@ -1161,6 +1215,7 @@ async function executePreflightCommand(
   const resolvedGuardrails = await resolveGuardrails(request);
   const environment = resolveCliEnvironment({
     cwd: request.cwd,
+    runsDir: request.runsDir,
     engine: request.engine
   });
   const warnings: string[] = [];
@@ -1170,6 +1225,7 @@ async function executePreflightCommand(
       ? request.verificationPlan
       : resolvedGuardrails.verifierRules;
   const engineRequired = request.mutationMode !== "verify_only" && environment.liveMode === "live";
+  const receiptScope = buildCliReceiptScope(environment);
 
   const workingDirectoryExists = await stat(environment.workingDirectory).then(() => true).catch(() => false);
   const codexAvailability = resolveCliCommandAvailability("codex");
@@ -1233,26 +1289,13 @@ async function executePreflightCommand(
     blockingIssues,
     warnings,
     environment,
+    receiptScope,
     scope: {
-      invocationRoot: environment.invocationRoot,
-      workingDirectory: environment.workingDirectory,
-      repoRoot: environment.workingDirectory,
-      runsRoot: environment.runsRoot
+      ...receiptScope
     },
     engineProbe:
       environment.engine === "codex"
-        ? {
-            available: codexAvailability.available,
-            ...(codexAvailability.resolvedPath ? { resolvedPath: codexAvailability.resolvedPath } : {}),
-            ...(codexProbe
-              ? {
-                  hostPlatform: codexProbe.diagnosis.hostPlatform,
-                  nativeInstallValid: codexProbe.diagnosis.nativeInstallValid,
-                  launchReady: codexProbe.ok,
-                  summary: codexProbe.summary
-                }
-              : {})
-          }
+        ? buildCodexEngineDiagnostics(codexAvailability, codexProbe)
         : environment.engine === "gemini"
           ? {
               available: geminiAvailability.available,
@@ -1276,6 +1319,21 @@ async function executePreflightCommand(
     }
   };
 
+  if (ready) {
+    await recordCliWorkflowStep({
+      runsRoot: environment.runsRoot,
+      step: "preflight",
+      workingDirectory: environment.workingDirectory,
+      objective: request.objective,
+      engine: environment.engine,
+      verificationPlan,
+      receiptScope,
+      allowedPaths: request.allowedPaths,
+      deniedPaths: request.deniedPaths,
+      budget: resolvedGuardrails.budget
+    }).catch(() => {});
+  }
+
   const corpusLine = corpusRisk.corpusRecords > 0
     ? `Corpus: ${corpusRisk.corpusRecords} records${scopeHotspots.length > 0 ? `, ${scopeHotspots.length} scope hotspot(s)` : ", no scope hotspots"}`
     : `Corpus: no data yet — run Martin to start building prediction intelligence`;
@@ -1287,6 +1345,7 @@ async function executePreflightCommand(
       `Working directory: ${environment.workingDirectory}`,
       `Engine: ${environment.engine} (${environment.liveMode})`,
       `Verification plan: ${verificationPlan.join(", ") || "none"}`,
+      `Receipt scope: repo=${receiptScope.repoRoot} runs=${receiptScope.runsRoot}`,
       corpusLine,
       ...(blockingIssues.length > 0 ? ["Blocking issues:", ...blockingIssues.map((issue) => `- ${issue}`)] : [])
     ],
@@ -1697,6 +1756,10 @@ function parseRunRequest(rest: string[]): RunCommandRequest {
         request.cwd = next;
         index += 1;
         break;
+      case "--runs-dir":
+        request.runsDir = next;
+        index += 1;
+        break;
       case "--verify-only":
         request.mutationMode = "verify_only";
         break;
@@ -1742,6 +1805,7 @@ function parseRunRequest(rest: string[]): RunCommandRequest {
     ...(Object.keys(budgetOverrides).length > 0 ? { budgetOverrides } : {}),
     ...(request.configPath ? { configPath: request.configPath } : {}),
     ...(request.cwd ? { cwd: request.cwd } : {}),
+    ...(request.runsDir ? { runsDir: request.runsDir } : {}),
     ...(request.model ? { model: request.model } : {}),
     ...(request.engine ? { engine: request.engine } : {}),
     ...(request.mutationMode ? { mutationMode: request.mutationMode } : {}),
@@ -2268,8 +2332,13 @@ function selectAdapter(
   engine: string | undefined,
   workingDirectory: string,
   modelOverride?: string,
-  mutationMode?: MutationMode
+  mutationMode?: MutationMode,
+  codexCommandOverride?: string
 ): MartinAdapter {
+  if (runAdapterOverrideForTests) {
+    return runAdapterOverrideForTests;
+  }
+
   if (mutationMode === "verify_only") {
     return createVerifierOnlyAdapter({ workingDirectory });
   }
@@ -2283,7 +2352,11 @@ function selectAdapter(
   }
 
   if (engine === "codex") {
-    return createCodexCliAdapter({ workingDirectory, ...(modelOverride ? { model: modelOverride } : {}) });
+    return createCodexCliAdapter({
+      workingDirectory,
+      ...(modelOverride ? { model: modelOverride } : {}),
+      ...(codexCommandOverride ? { command: codexCommandOverride } : {})
+    });
   }
 
   if (engine === "gemini") {
@@ -2308,6 +2381,8 @@ function buildDoctorRecommendations(input: {
   codexAvailable: boolean;
   geminiAvailable: boolean;
   workingDirectoryReady: boolean;
+  codexLaunchReady?: boolean;
+  codexRemediation?: string;
 }): string[] {
   const recommendations = ["Run `martin preflight` before non-trivial governed coding work."];
 
@@ -2332,12 +2407,63 @@ function buildDoctorRecommendations(input: {
   if (input.liveMode === "live" && input.engine === "codex" && !input.codexAvailable) {
     recommendations.push("Install or expose the Codex CLI on PATH, or set MARTIN_LIVE=false while iterating locally.");
   }
+  if (input.liveMode === "live" && input.engine === "codex" && input.codexAvailable && input.codexLaunchReady === false) {
+    recommendations.push(input.codexRemediation ?? "Run `martin preflight --engine codex` and fix the reported Codex host issue before governed work.");
+  }
 
   if (input.liveMode === "live" && input.engine === "gemini" && !input.geminiAvailable) {
     recommendations.push("Install or expose the Gemini CLI on PATH, or set MARTIN_LIVE=false while iterating locally.");
   }
 
   return recommendations;
+}
+
+function buildCliReceiptScope(environment: {
+  invocationRoot: string;
+  workingDirectory: string;
+  runsRoot: string;
+}): ReceiptScope {
+  return {
+    invocationRoot: environment.invocationRoot,
+    workingDirectory: environment.workingDirectory,
+    repoRoot: environment.workingDirectory,
+    runsRoot: environment.runsRoot
+  };
+}
+
+function buildCodexEngineDiagnostics(
+  availability: ReturnType<typeof resolveCliCommandAvailability>,
+  probe?: ReturnType<typeof probeCodexLaunch>
+): Record<string, unknown> {
+  return {
+    available: availability.available,
+    detail: availability.detail,
+    ...(availability.resolvedPath ? { resolvedPath: availability.resolvedPath } : {}),
+    ...(availability.candidatePaths?.length ? { candidatePaths: availability.candidatePaths } : {}),
+    ...(probe
+      ? {
+          selectedPath: probe.command,
+          hostPlatform: probe.diagnosis.hostPlatform,
+          installKind: probe.diagnosis.installKind,
+          nativeInstallValid: probe.diagnosis.nativeInstallValid,
+          invocationMode: probe.diagnosis.invocationMode,
+          sandboxMode: probe.diagnosis.sandboxMode,
+          sandboxCompatible: probe.diagnosis.sandboxCompatible,
+          launchReady: probe.ok,
+          probeSummary: probe.summary,
+          ...(probe.diagnosis.nativeDependencyStatus
+            ? { nativeDependencyStatus: probe.diagnosis.nativeDependencyStatus }
+            : {}),
+          ...(probe.diagnosis.nativeDependencyPackage
+            ? { nativeDependencyPackage: probe.diagnosis.nativeDependencyPackage }
+            : {}),
+          ...(probe.diagnosis.remediation ? { remediation: probe.diagnosis.remediation } : {}),
+          ...(probe.candidateProbeResults?.length
+            ? { candidateProbeResults: probe.candidateProbeResults }
+            : {})
+        }
+      : {})
+  };
 }
 
 function isCommandAvailable(command: string): boolean {

--- a/packages/cli/src/phase-command-center.ts
+++ b/packages/cli/src/phase-command-center.ts
@@ -1,6 +1,7 @@
 import { readFile, readdir, stat } from "node:fs/promises";
 import { join, resolve } from "node:path";
 
+import { probeCodexLaunch, resolveCliCommandAvailability } from "@martin/adapters";
 import { resolveRunsRoot } from "@martin/core";
 
 const DEFAULT_BLOCKED_PATHS = [
@@ -31,10 +32,18 @@ const DEFAULT_BUDGET = {
 
 const DEFAULT_RUN_SCAN_LIMIT = 40;
 
+type ResolvedReceiptScope = {
+  invocationRoot: string;
+  workingDirectory: string;
+  repoRoot: string;
+  runsRoot: string;
+};
+
 export type NativePhaseSubcommand = "status" | "contract" | "session-start" | "preflight" | "run";
 
 export type NativePhaseCommandOptions = {
   rootDir?: string;
+  invocationRoot?: string;
   runsDir?: string;
   host?: string;
   runScanLimit?: number;
@@ -61,6 +70,7 @@ export type NativePhaseSnapshot = {
   ok: true;
   schemaVersion: "martin.phase-command-center.v1";
   generatedAt: string;
+  receiptScope: ResolvedReceiptScope;
   root: {
     hasPhaseWorkspace: boolean;
     hasSessionHook: boolean;
@@ -92,6 +102,39 @@ export type NativePhaseSnapshot = {
     host: string;
     recommendedNextAction: string;
     commands: string[];
+    receiptScope: ResolvedReceiptScope;
+    hostDiagnostics: {
+      mode: "live" | "proof";
+      engine: string;
+      codex?: {
+        available: boolean;
+        detail: string;
+        resolvedPath?: string;
+        candidatePaths?: string[];
+        selectedPath?: string;
+        hostPlatform?: string;
+        installKind?: string;
+        nativeInstallValid?: boolean;
+        invocationMode?: string;
+        sandboxMode?: string;
+        sandboxCompatible?: boolean;
+        launchReady?: boolean;
+        summary?: string;
+        remediation?: string;
+        candidateProbeResults?: Array<{
+          path: string;
+          installKind: string;
+          invocationMode: string;
+          nativeInstallValid: boolean;
+          sandboxCompatible: boolean;
+          launchReady: boolean;
+          summary: string;
+          remediation?: string;
+          nativeDependencyStatus?: string;
+          nativeDependencyPackage?: string;
+        }>;
+      };
+    };
   };
 };
 
@@ -141,17 +184,26 @@ export async function createNativePhaseCommandCenterSnapshot(
   options: NativePhaseCommandOptions = {}
 ): Promise<NativePhaseSnapshot> {
   const rootDir = resolve(options.rootDir ?? process.cwd());
+  const invocationRoot = resolve(options.invocationRoot ?? process.cwd());
   const runsRoot = resolveRunsRoot({ MARTIN_RUNS_DIR: options.runsDir ?? process.env.MARTIN_RUNS_DIR });
+  const receiptScope: ResolvedReceiptScope = {
+    invocationRoot,
+    workingDirectory: rootDir,
+    repoRoot: rootDir,
+    runsRoot
+  };
   const [phaseWorkspace, runStore] = await Promise.all([
     collectPhaseWorkspaceState(rootDir),
     collectRunStore(runsRoot, { scanLimit: options.runScanLimit ?? DEFAULT_RUN_SCAN_LIMIT })
   ]);
   const contract = await buildPhaseContract(rootDir, phaseWorkspace);
+  const hostDiagnostics = buildSessionStartHostDiagnostics(options.host ?? "claude", receiptScope);
 
   return {
     ok: true,
     schemaVersion: "martin.phase-command-center.v1",
     generatedAt: new Date().toISOString(),
+    receiptScope,
     root: {
       hasPhaseWorkspace: phaseWorkspace.available,
       hasSessionHook: phaseWorkspace.sessionHookAvailable
@@ -172,13 +224,18 @@ export async function createNativePhaseCommandCenterSnapshot(
     contract,
     sessionStart: {
       host: options.host ?? "claude",
-      recommendedNextAction: recommendedNextAction(phaseWorkspace, runStore, contract),
-      commands: DEFAULT_COMMANDS
+      recommendedNextAction: recommendedNextAction(phaseWorkspace, runStore, contract, hostDiagnostics),
+      commands: buildSessionStartCommands(options.host ?? "claude", receiptScope),
+      receiptScope,
+      hostDiagnostics
     }
   };
 }
 
-export function buildNativePhaseRunRequest(contract: NativePhaseContract, cwd?: string) {
+export function buildNativePhaseRunRequest(
+  contract: NativePhaseContract,
+  options: { cwd?: string; runsDir?: string } = {}
+) {
   return {
     workspaceId: "ws_default",
     projectId: "proj_default",
@@ -196,15 +253,26 @@ export function buildNativePhaseRunRequest(contract: NativePhaseContract, cwd?: 
       maxIterations: contract.budget.maxIterations,
       maxTokens: 20_000
     },
-    ...(cwd ? { cwd } : {}),
+    ...(options.cwd ? { cwd: options.cwd } : {}),
+    ...(options.runsDir ? { runsDir: options.runsDir } : {}),
     ...(contract.allowedPaths.length > 0 ? { allowedPaths: contract.allowedPaths } : {}),
     deniedPaths: contract.blockedPaths
   };
 }
 
-export function buildNativePhaseInvocation(command: "preflight" | "run", contract: NativePhaseContract): string[] {
+export function buildNativePhaseInvocation(
+  command: "preflight" | "run",
+  contract: NativePhaseContract,
+  options: { cwd?: string; runsDir?: string } = {}
+): string[] {
   const args = ["martin-loop", command, contract.objective];
 
+  if (options.cwd) {
+    args.push("--cwd", options.cwd);
+  }
+  if (options.runsDir) {
+    args.push("--runs-dir", options.runsDir);
+  }
   for (const verifier of contract.verifiers) {
     args.push("--verify", verifier);
   }
@@ -253,7 +321,10 @@ export function selectNativePhasePayload(
   }
 
   const martinCommand = subcommand === "run" ? "run" : "preflight";
-  const invocation = buildNativePhaseInvocation(martinCommand, snapshot.contract);
+  const invocation = buildNativePhaseInvocation(martinCommand, snapshot.contract, {
+    cwd: snapshot.receiptScope.workingDirectory,
+    runsDir: snapshot.receiptScope.runsRoot
+  });
 
   if (snapshot.contract.requiresApproval) {
     return {
@@ -285,11 +356,17 @@ export function selectNativePhasePayload(
 }
 
 export function renderNativePhaseHuman(snapshot: NativePhaseSnapshot): string[] {
+  const codexDiagnostics = snapshot.sessionStart.hostDiagnostics.codex;
   return [
     "MartinLoop phase command-center session start",
     `Phase workspace: ${snapshot.phaseWorkspace.available ? "detected" : "missing"}`,
     `Active phase: ${snapshot.phaseWorkspace.activePhase ?? "unavailable"}`,
     `Latest run: ${snapshot.runStore.latestRun?.loopId ?? "unavailable"}`,
+    `Receipt scope: repo=${snapshot.receiptScope.repoRoot} runs=${snapshot.receiptScope.runsRoot}`,
+    `Host: ${snapshot.sessionStart.host} (${snapshot.sessionStart.hostDiagnostics.mode})`,
+    ...(codexDiagnostics
+      ? [`Codex host diagnostics: ${codexDiagnostics.launchReady ? "ready" : codexDiagnostics.summary ?? codexDiagnostics.detail}`]
+      : []),
     `Recommended next action: ${snapshot.sessionStart.recommendedNextAction}`,
     "Commands:",
     ...snapshot.sessionStart.commands.map((command) => `- ${command}`)
@@ -479,8 +556,14 @@ async function detectPackageManager(rootDir: string): Promise<"pnpm" | "npm" | "
 function recommendedNextAction(
   phaseWorkspace: PhaseWorkspaceState,
   runStore: NativePhaseSnapshot["runStore"],
-  contract: NativePhaseContract
+  contract: NativePhaseContract,
+  hostDiagnostics: NativePhaseSnapshot["sessionStart"]["hostDiagnostics"]
 ): string {
+  if (hostDiagnostics.engine === "codex" && hostDiagnostics.codex?.launchReady === false) {
+    return hostDiagnostics.codex.remediation ??
+      "Run martin-loop doctor --engine codex, fix the reported host issue, then retry preflight.";
+  }
+
   if (contract.requiresApproval) {
     return "Review the generated phase contract, add allowed paths/verifiers, then run martin-loop phase preflight.";
   }
@@ -494,6 +577,83 @@ function recommendedNextAction(
   }
 
   return "Run martin-loop phase preflight before spending work.";
+}
+
+function buildSessionStartCommands(host: string, receiptScope: ResolvedReceiptScope): string[] {
+  const scopedFlags = [
+    "--cwd",
+    quoteCliArgument(receiptScope.workingDirectory),
+    "--runs-dir",
+    quoteCliArgument(receiptScope.runsRoot)
+  ].join(" ");
+
+  const commands = host === "codex"
+    ? [
+        `martin-loop doctor --engine codex ${scopedFlags}`,
+        ...DEFAULT_COMMANDS.filter((command) => command !== "martin-loop doctor")
+      ]
+    : DEFAULT_COMMANDS;
+
+  return commands.map((command) => {
+    if (command.startsWith("martin-loop doctor")) {
+      return command;
+    }
+    return `${command} ${scopedFlags}`.trim();
+  });
+}
+
+function quoteCliArgument(value: string): string {
+  return /[\s"]/u.test(value) ? `"${value.replace(/"/g, '\\"')}"` : value;
+}
+
+function buildSessionStartHostDiagnostics(
+  host: string,
+  receiptScope: ResolvedReceiptScope
+): NativePhaseSnapshot["sessionStart"]["hostDiagnostics"] {
+  const mode = process.env.MARTIN_LIVE === "false" ? "proof" : "live";
+  if (host !== "codex") {
+    return {
+      mode,
+      engine: host
+    };
+  }
+
+  const availability = resolveCliCommandAvailability("codex");
+  const probe =
+    mode === "live"
+      ? probeCodexLaunch({
+          workingDirectory: receiptScope.workingDirectory,
+          availability
+        })
+      : undefined;
+
+  return {
+    mode,
+    engine: "codex",
+    codex: {
+      available: availability.available,
+      detail: availability.detail,
+      ...(availability.resolvedPath ? { resolvedPath: availability.resolvedPath } : {}),
+      ...(availability.candidatePaths?.length ? { candidatePaths: availability.candidatePaths } : {}),
+      ...(probe
+        ? {
+            selectedPath: probe.command,
+            hostPlatform: probe.diagnosis.hostPlatform,
+            installKind: probe.diagnosis.installKind,
+            nativeInstallValid: probe.diagnosis.nativeInstallValid,
+            invocationMode: probe.diagnosis.invocationMode,
+            sandboxMode: probe.diagnosis.sandboxMode,
+            sandboxCompatible: probe.diagnosis.sandboxCompatible,
+            launchReady: probe.ok,
+            summary: probe.summary,
+            ...(probe.diagnosis.remediation ? { remediation: probe.diagnosis.remediation } : {}),
+            ...(probe.candidateProbeResults?.length
+              ? { candidateProbeResults: probe.candidateProbeResults }
+              : {})
+          }
+        : {})
+    }
+  };
 }
 
 function summarizeLoop(loop: LocalLoopRecord | undefined): NativePhaseRunSummary | null {

--- a/packages/cli/src/workflow-state.ts
+++ b/packages/cli/src/workflow-state.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 
-import type { MutationMode } from "@martin/contracts";
+import type { LoopBudget, MutationMode, ReceiptScope } from "@martin/contracts";
 
 const WORKFLOW_STATE_DIRECTORY = "_martin";
 const WORKFLOW_STATE_FILENAME = "workflow-state.json";
@@ -25,6 +25,9 @@ interface CliWorkflowReceipt {
   objectiveKey?: string;
   engine?: string;
   verificationPlanKey?: string;
+  scopeKey?: string;
+  pathScopeKey?: string;
+  budgetKey?: string;
 }
 
 interface WorkflowState {
@@ -40,6 +43,10 @@ export interface CliWorkflowStepInput {
   objective?: string;
   engine?: string;
   verificationPlan?: string[];
+  receiptScope?: ReceiptScope;
+  allowedPaths?: string[];
+  deniedPaths?: string[];
+  budget?: LoopBudget;
 }
 
 export interface CliRunGateInput {
@@ -49,6 +56,10 @@ export interface CliRunGateInput {
   engine?: string;
   verificationPlan: string[];
   mutationMode?: MutationMode;
+  receiptScope?: ReceiptScope;
+  allowedPaths?: string[];
+  deniedPaths?: string[];
+  budget?: LoopBudget;
 }
 
 export interface CliRunGateResult {
@@ -85,7 +96,12 @@ export async function recordCliWorkflowStep(input: CliWorkflowStepInput): Promis
     workingDirectory: normalizeWorkingDirectory(input.workingDirectory),
     ...(input.objective ? { objectiveKey: normalizeObjective(input.objective) } : {}),
     ...(input.engine ? { engine: input.engine } : {}),
-    ...(input.verificationPlan ? { verificationPlanKey: hashVerificationPlan(input.verificationPlan) } : {})
+    ...(input.verificationPlan ? { verificationPlanKey: hashVerificationPlan(input.verificationPlan) } : {}),
+    ...(input.receiptScope ? { scopeKey: hashReceiptScope(input.receiptScope) } : {}),
+    ...(input.allowedPaths || input.deniedPaths
+      ? { pathScopeKey: hashPathScope(input.allowedPaths ?? [], input.deniedPaths ?? []) }
+      : {}),
+    ...(input.budget ? { budgetKey: hashBudget(input.budget) } : {})
   };
 
   state.cli ??= {};
@@ -109,19 +125,39 @@ export async function evaluateCliRunGate(input: CliRunGateInput): Promise<CliRun
   const objectiveKey = normalizeObjective(input.objective);
   const verificationPlanKey = hashVerificationPlan(input.verificationPlan);
   const engine = input.engine ?? "claude";
+  const scopeKey = hashReceiptScope(
+    input.receiptScope ?? {
+      invocationRoot: input.workingDirectory,
+      workingDirectory: input.workingDirectory,
+      repoRoot: input.workingDirectory,
+      runsRoot: input.runsRoot
+    }
+  );
+  const pathScopeKey = hashPathScope(input.allowedPaths ?? [], input.deniedPaths ?? []);
+  const budgetKey = input.budget ? hashBudget(input.budget) : undefined;
   const missingSteps: CliWorkflowStepName[] = [];
 
   const doctorReady = isFresh(cliState["doctor"], DOCTOR_TTL_MS, (receipt) =>
-    receipt.workingDirectory === workingDirectory
+    receipt.workingDirectory === workingDirectory &&
+    receipt.scopeKey === scopeKey
   );
   if (!doctorReady) {
     missingSteps.push("doctor");
   }
 
   const sessionReady =
-    isFresh(cliState["session-start"], SESSION_TTL_MS, (receipt) => receipt.workingDirectory === workingDirectory) ||
-    isFresh(cliState["start"], SESSION_TTL_MS, (receipt) => receipt.workingDirectory === workingDirectory) ||
-    isFresh(cliState["tour"], SESSION_TTL_MS, (receipt) => receipt.workingDirectory === workingDirectory);
+    isFresh(cliState["session-start"], SESSION_TTL_MS, (receipt) =>
+      receipt.workingDirectory === workingDirectory &&
+      receipt.scopeKey === scopeKey
+    ) ||
+    isFresh(cliState["start"], SESSION_TTL_MS, (receipt) =>
+      receipt.workingDirectory === workingDirectory &&
+      receipt.scopeKey === scopeKey
+    ) ||
+    isFresh(cliState["tour"], SESSION_TTL_MS, (receipt) =>
+      receipt.workingDirectory === workingDirectory &&
+      receipt.scopeKey === scopeKey
+    );
   if (!sessionReady) {
     missingSteps.push("session-start");
   }
@@ -130,7 +166,10 @@ export async function evaluateCliRunGate(input: CliRunGateInput): Promise<CliRun
     receipt.workingDirectory === workingDirectory &&
     receipt.objectiveKey === objectiveKey &&
     receipt.engine === engine &&
-    receipt.verificationPlanKey === verificationPlanKey
+    receipt.verificationPlanKey === verificationPlanKey &&
+    receipt.scopeKey === scopeKey &&
+    receipt.pathScopeKey === pathScopeKey &&
+    (budgetKey === undefined || receipt.budgetKey === budgetKey)
   );
   if (!preflightReady) {
     missingSteps.push("preflight");
@@ -227,5 +266,37 @@ function normalizeObjective(objective: string): string {
 
 function hashVerificationPlan(verificationPlan: string[]): string {
   const normalized = verificationPlan.map((step) => step.trim()).filter(Boolean);
+  return createHash("sha256").update(JSON.stringify(normalized)).digest("hex").slice(0, 12);
+}
+
+function hashReceiptScope(receiptScope: ReceiptScope): string {
+  const normalized = {
+    invocationRoot: normalizeWorkingDirectory(
+      receiptScope.invocationRoot ?? receiptScope.workingDirectory ?? ""
+    ),
+    workingDirectory: normalizeWorkingDirectory(
+      receiptScope.workingDirectory ?? receiptScope.repoRoot ?? ""
+    ),
+    repoRoot: normalizeWorkingDirectory(receiptScope.repoRoot ?? receiptScope.workingDirectory ?? ""),
+    runsRoot: normalizeWorkingDirectory(receiptScope.runsRoot ?? "")
+  };
+  return createHash("sha256").update(JSON.stringify(normalized)).digest("hex").slice(0, 12);
+}
+
+function hashPathScope(allowedPaths: string[], deniedPaths: string[]): string {
+  const normalized = {
+    allowedPaths: [...new Set(allowedPaths.map((entry) => entry.trim()).filter(Boolean))].sort(),
+    deniedPaths: [...new Set(deniedPaths.map((entry) => entry.trim()).filter(Boolean))].sort()
+  };
+  return createHash("sha256").update(JSON.stringify(normalized)).digest("hex").slice(0, 12);
+}
+
+function hashBudget(budget: LoopBudget): string {
+  const normalized = {
+    maxUsd: Number(budget.maxUsd.toFixed(4)),
+    softLimitUsd: Number(budget.softLimitUsd.toFixed(4)),
+    maxIterations: budget.maxIterations,
+    maxTokens: budget.maxTokens
+  };
   return createHash("sha256").update(JSON.stringify(normalized)).digest("hex").slice(0, 12);
 }

--- a/packages/cli/tests/cli-integration.test.ts
+++ b/packages/cli/tests/cli-integration.test.ts
@@ -72,6 +72,8 @@ async function withPathPrefix<T>(dir: string, fn: () => Promise<T>): Promise<T> 
 
 async function withFakeCodexCli<T>(fn: () => Promise<T>): Promise<T> {
   return withTempDir(async (dir) => {
+    const originalLocalAppData = process.env.LOCALAPPDATA;
+    process.env.LOCALAPPDATA = dir;
     const script = process.platform === "win32"
       ? [
           "@echo off",
@@ -80,6 +82,7 @@ async function withFakeCodexCli<T>(fn: () => Promise<T>): Promise<T> {
           "  echo usage: codex exec ...",
           "  exit /b 0",
           ")",
+          "echo {\"type\":\"item.completed\",\"item\":{\"type\":\"command_execution\",\"status\":\"completed\",\"exit_code\":0}}",
           "echo {\"type\":\"item.completed\",\"item\":{\"type\":\"agent_message\",\"text\":\"fake codex completed\"}}",
           "echo {\"type\":\"turn.completed\",\"usage\":{\"input_tokens\":10,\"output_tokens\":5}}",
           "exit /b 0",
@@ -92,6 +95,7 @@ async function withFakeCodexCli<T>(fn: () => Promise<T>): Promise<T> {
           "    echo 'usage: codex exec ...'",
           "    ;;",
           "  *)",
+          "    echo '{\"type\":\"item.completed\",\"item\":{\"type\":\"command_execution\",\"status\":\"completed\",\"exit_code\":0}}'",
           "    echo '{\"type\":\"item.completed\",\"item\":{\"type\":\"agent_message\",\"text\":\"fake codex completed\"}}'",
           "    echo '{\"type\":\"turn.completed\",\"usage\":{\"input_tokens\":10,\"output_tokens\":5}}'",
           "    ;;",
@@ -104,7 +108,15 @@ async function withFakeCodexCli<T>(fn: () => Promise<T>): Promise<T> {
       await chmod(file, 0o755);
     }
 
-    return withPathPrefix(dir, fn);
+    try {
+      return await withPathPrefix(dir, fn);
+    } finally {
+      if (originalLocalAppData === undefined) {
+        delete process.env.LOCALAPPDATA;
+      } else {
+        process.env.LOCALAPPDATA = originalLocalAppData;
+      }
+    }
   });
 }
 
@@ -171,7 +183,7 @@ describe("MARTIN_LIVE=false — stub adapter", () => {
 // ---------------------------------------------------------------------------
 
 describe("--engine flag", () => {
-  it("defaults to claude when no --engine flag is given", async () => {
+  it("defaults to claude when no --engine flag is given", { timeout: 45_000 }, async () => {
     // Use stub mode — we verify no engine flag selects the claude adapter path,
     // not that claude itself runs successfully
     const result = await withEnv("MARTIN_LIVE", "false", () =>
@@ -223,11 +235,10 @@ describe("--engine flag", () => {
     expect(payload.engineProbe.launchReady).toBe(true);
   });
 
-  it("remains graceful in live mode even when the selected CLI is unavailable", { timeout: 15000 }, async () => {
+  it("blocks live run execution before spend when the governed receipt chain is missing", { timeout: 15000 }, async () => {
     const result = await withoutAgentCliOnPath(() =>
       withEnv("MARTIN_LIVE", "true", () =>
         executeCli([
-          "--json",
           "run",
           "--objective",
           "Fix the bug",
@@ -241,10 +252,9 @@ describe("--engine flag", () => {
       )
     );
 
-    expect(result.exitCode).toBe(0);
-    const payload = JSON.parse(result.stdout);
-    expect(payload.command).toBe("run");
-    expect(payload.loop.loopId).toMatch(/^loop_/u);
+    expect(result.exitCode).toBe(8);
+    expect(result.stderr).toContain("Governed run blocked until MartinLoop receipts exist");
+    expect(result.stderr).toContain("martin-loop session-start");
   });
 });
 

--- a/packages/cli/tests/cli.test.ts
+++ b/packages/cli/tests/cli.test.ts
@@ -2,10 +2,38 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { describe, expect, it } from "vitest";
+import { createStubDirectProviderAdapter } from "@martin/adapters";
+import { afterEach, describe, expect, it } from "vitest";
 
 import { createLoopRecord } from "../../contracts/src/index.js";
-import { executeCli, parseCliArguments } from "../src/index.js";
+import { __setRunAdapterOverrideForTests, executeCli, parseCliArguments } from "../src/index.js";
+
+function installFastRunAdapter(): void {
+  __setRunAdapterOverrideForTests(
+    createStubDirectProviderAdapter({
+      providerId: "test",
+      model: "fast",
+      responder: () => ({
+        status: "completed",
+        summary: "Fast test adapter completed.",
+        usage: {
+          actualUsd: 0,
+          tokensIn: 0,
+          tokensOut: 0,
+          provenance: "actual"
+        },
+        verification: {
+          passed: true,
+          summary: "Verification skipped in config-focused CLI tests."
+        }
+      })
+    })
+  );
+}
+
+afterEach(() => {
+  __setRunAdapterOverrideForTests(undefined);
+});
 
 describe("parseCliArguments", () => {
   it("parses a run command into a typed request", () => {
@@ -76,6 +104,7 @@ describe("executeCli", () => {
     const configPath = join(directory, "martin.config.yaml");
 
     try {
+      installFastRunAdapter();
       await writeFile(
         configPath,
         [
@@ -145,11 +174,12 @@ describe("executeCli", () => {
     }
   });
 
-  it("surfaces effective governance policy metadata in run output", async () => {
+  it("surfaces effective governance policy metadata in run output", { timeout: 45_000 }, async () => {
     const directory = await mkdtemp(join(tmpdir(), "martin-cli-policy-"));
     const configPath = join(directory, "martin.config.yaml");
 
     try {
+      installFastRunAdapter();
       await writeFile(
         configPath,
         [
@@ -163,8 +193,8 @@ describe("executeCli", () => {
           "  destructiveActionPolicy: approval",
           "  telemetryDestination: seeded-telemetry",
           "  verifierRules:",
-          "    - pnpm verify:shared-baseline",
-          "    - node scripts/agent-os-release-plan.mjs --verify-truth-lock"
+          process.platform === "win32" ? "    - cmd /c exit 0" : "    - true",
+          process.platform === "win32" ? "    - cmd /c exit 0" : "    - true"
         ].join("\n"),
         "utf8"
       );
@@ -213,8 +243,8 @@ describe("executeCli", () => {
           maxTokens: 20000
         },
         verifierRules: [
-          "pnpm verify:shared-baseline",
-          "node scripts/agent-os-release-plan.mjs --verify-truth-lock"
+          process.platform === "win32" ? "cmd /c exit 0" : "true",
+          process.platform === "win32" ? "cmd /c exit 0" : "true"
         ],
         maxUsd: 8,
         softLimitUsd: 5,
@@ -223,15 +253,15 @@ describe("executeCli", () => {
         telemetryDestination: "control-plane"
       });
       expect(payload.loop.task.verificationPlan).toEqual([
-        "pnpm verify:shared-baseline",
-        "node scripts/agent-os-release-plan.mjs --verify-truth-lock"
+        process.platform === "win32" ? "cmd /c exit 0" : "true",
+        process.platform === "win32" ? "cmd /c exit 0" : "true"
       ]);
     } finally {
       await rm(directory, { force: true, recursive: true });
     }
   });
 
-  it("supports verify-only runs without invoking a coding adapter", async () => {
+  it("supports verify-only runs without invoking a coding adapter", { timeout: 30_000 }, async () => {
     const directory = await mkdtemp(join(tmpdir(), "martin-cli-verify-only-"));
 
     try {
@@ -273,6 +303,7 @@ describe("executeCli", () => {
     const previousMarinLive = process.env.MARTIN_LIVE;
 
     try {
+      installFastRunAdapter();
       await mkdir(packageDirectory, { recursive: true });
       await writeFile(
         configPath,

--- a/packages/cli/tests/operator-commands.test.ts
+++ b/packages/cli/tests/operator-commands.test.ts
@@ -8,6 +8,21 @@ import { describe, expect, it } from "vitest";
 
 import { executeCli } from "../src/index.js";
 
+async function withEnv<T>(key: string, value: string, fn: () => Promise<T>): Promise<T> {
+  const original = process.env[key];
+  process.env[key] = value;
+
+  try {
+    return await fn();
+  } finally {
+    if (original === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = original;
+    }
+  }
+}
+
 function makeLoopRecord(): LoopRecord {
   const loop = createLoopRecord({
     workspaceId: "ws_ops",
@@ -107,7 +122,7 @@ async function withRunsRoot<T>(fn: (runsRoot: string) => Promise<T>): Promise<T>
 
 describe("operator commands", () => {
   it("doctor reports environment readiness and starter MCP tools", async () => {
-    const result = await executeCli(["--json", "doctor"]);
+    const result = await withEnv("MARTIN_LIVE", "false", () => executeCli(["--json", "doctor"]));
     const payload = JSON.parse(result.stdout);
 
     expect(result.exitCode).toBe(0);
@@ -116,6 +131,7 @@ describe("operator commands", () => {
     expect(payload.profiles.minimal).toContain("martin_list_runs");
     expect(payload.starterTools).toContain("martin_doctor");
     expect(payload.environment.runsRoot).toBeTypeOf("string");
+    expect(payload.receiptScope).toEqual(payload.scope);
     expect(payload.scope.invocationRoot).toBeTypeOf("string");
     expect(payload.scope.repoRoot).toBe(payload.environment.workingDirectory);
     expect(payload.scope.runsRoot).toBe(payload.environment.runsRoot);
@@ -144,9 +160,59 @@ describe("operator commands", () => {
     expect(payload.command).toBe("preflight");
     expect(payload.ready).toBe(false);
     expect(payload.blockingIssues).toContain("Working directory does not exist.");
+    expect(payload.receiptScope).toEqual(payload.scope);
     expect(payload.scope.workingDirectory).toBe(missingDirectory);
     expect(payload.scope.repoRoot).toBe(missingDirectory);
     expect(payload.scope.runsRoot).toBeTypeOf("string");
+  });
+
+  it("preserves explicit --runs-dir overrides for preflight commands after the objective token", async () => {
+    await withRunsRoot(async (runsRoot) => {
+      const workingDirectory = await mkdtemp(join(tmpdir(), "martin-cli-preflight-workspace-"));
+      const narrowedRunsRoot = join(runsRoot, "team-a");
+
+      try {
+        const result = await executeCli([
+          "--json",
+          "preflight",
+          "Repair the failing MCP lane",
+          "--cwd",
+          workingDirectory,
+          "--runs-dir",
+          narrowedRunsRoot
+        ]);
+        const payload = JSON.parse(result.stdout);
+
+        expect(result.exitCode).toBe(0);
+        expect(payload.environment.workingDirectory).toBe(workingDirectory);
+        expect(payload.environment.runsRoot).toBe(narrowedRunsRoot);
+        expect(payload.receiptScope.runsRoot).toBe(narrowedRunsRoot);
+      } finally {
+        await rm(workingDirectory, { force: true, recursive: true }).catch(() => {});
+      }
+    });
+  });
+
+  it("blocks live run execution before spend when the governed receipt chain is missing", async () => {
+    await withRunsRoot(async () => {
+      const result = await executeCli([
+        "run",
+        "--objective",
+        "Repair the failing MCP lane",
+        "--engine",
+        "codex",
+        "--verify",
+        "pnpm --filter @martinloop/mcp test",
+        "--budget-usd",
+        "2",
+        "--max-iterations",
+        "1"
+      ]);
+
+      expect(result.exitCode).toBe(8);
+      expect(result.stderr).toContain("Governed run blocked until MartinLoop receipts exist");
+      expect(result.stderr).toContain("martin-loop doctor");
+    });
   });
 
   it("loads persisted runs through dossier, attempt, verify, and triage commands", async () => {

--- a/packages/cli/tests/phase-command-center.test.ts
+++ b/packages/cli/tests/phase-command-center.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -6,6 +6,64 @@ import { describe, expect, it } from "vitest";
 
 import { executeCli, parseCliArguments } from "../src/index.js";
 import { createNativePhaseCommandCenterSnapshot } from "../src/phase-command-center.js";
+import { resolveInvocationRoot } from "../src/run-store.js";
+
+async function withPathPrefix<T>(directory: string, fn: () => Promise<T>): Promise<T> {
+  const pathKey = Object.keys(process.env).find((key) => key.toLowerCase() === "path") ?? "PATH";
+  const original = process.env[pathKey];
+  process.env[pathKey] =
+    original && original.length > 0
+      ? `${directory}${process.platform === "win32" ? ";" : ":"}${original}`
+      : directory;
+
+  try {
+    return await fn();
+  } finally {
+    if (original === undefined) {
+      delete process.env[pathKey];
+    } else {
+      process.env[pathKey] = original;
+    }
+  }
+}
+
+async function withFakeCodexCli<T>(fn: () => Promise<T>): Promise<T> {
+  const directory = await mkdtemp(join(tmpdir(), "martin-phase-codex-"));
+  const originalLocalAppData = process.env.LOCALAPPDATA;
+  process.env.LOCALAPPDATA = directory;
+
+  try {
+    const commandPath = join(directory, process.platform === "win32" ? "codex.cmd" : "codex");
+    const contents =
+      process.platform === "win32"
+        ? [
+            "@echo off",
+            "echo {\"type\":\"item.completed\",\"item\":{\"type\":\"command_execution\",\"status\":\"completed\",\"exit_code\":0}}",
+            "echo {\"type\":\"turn.completed\",\"usage\":{\"input_tokens\":10,\"output_tokens\":5}}",
+            "exit /b 0",
+            ""
+          ].join("\r\n")
+        : [
+            "#!/usr/bin/env sh",
+            "echo '{\"type\":\"item.completed\",\"item\":{\"type\":\"command_execution\",\"status\":\"completed\",\"exit_code\":0}}'",
+            "echo '{\"type\":\"turn.completed\",\"usage\":{\"input_tokens\":10,\"output_tokens\":5}}'",
+            ""
+          ].join("\n");
+    await writeFile(commandPath, contents, "utf8");
+    if (process.platform !== "win32") {
+      await chmod(commandPath, 0o755);
+    }
+
+    return await withPathPrefix(directory, fn);
+  } finally {
+    if (originalLocalAppData === undefined) {
+      delete process.env.LOCALAPPDATA;
+    } else {
+      process.env.LOCALAPPDATA = originalLocalAppData;
+    }
+    await rm(directory, { recursive: true, force: true }).catch(() => {});
+  }
+}
 
 async function createPhaseFixture() {
   const rootDir = await mkdtemp(join(tmpdir(), "martin-phase-cli-"));
@@ -139,6 +197,57 @@ describe("native phase command center", () => {
     }
   });
 
+  it("surfaces receipt scope and Codex host diagnostics in session-start", async () => {
+    const { rootDir, runsDir } = await createPhaseFixture();
+    const previousLive = process.env.MARTIN_LIVE;
+    process.env.MARTIN_LIVE = "true";
+
+    try {
+      await withFakeCodexCli(async () => {
+        await mkdir(join(rootDir, ".git"), { recursive: true });
+        const invocationRoot = resolveInvocationRoot();
+        const result = await executeCli([
+          "--json",
+          "session-start",
+          "--host",
+          "codex",
+          "--cwd",
+          rootDir,
+          "--runs-dir",
+          runsDir
+        ]);
+        const payload = JSON.parse(result.stdout);
+
+        expect(result.exitCode).toBe(0);
+        expect(payload.command).toBe("session_start");
+        expect(payload.receiptScope).toMatchObject({
+          invocationRoot,
+          repoRoot: rootDir,
+          workingDirectory: rootDir,
+          runsRoot: runsDir
+        });
+        expect(payload.sessionStart.receiptScope).toMatchObject({
+          invocationRoot,
+          repoRoot: rootDir,
+          workingDirectory: rootDir,
+          runsRoot: runsDir
+        });
+        expect(payload.sessionStart.hostDiagnostics.engine).toBe("codex");
+        expect(payload.sessionStart.hostDiagnostics.codex.available).toBe(true);
+        expect(payload.sessionStart.hostDiagnostics.codex.launchReady).toBe(true);
+        expect(payload.sessionStart.commands[0]).toContain(`--cwd ${rootDir}`);
+        expect(payload.sessionStart.commands[0]).toContain(`--runs-dir ${runsDir}`);
+      });
+    } finally {
+      if (previousLive === undefined) {
+        delete process.env.MARTIN_LIVE;
+      } else {
+        process.env.MARTIN_LIVE = previousLive;
+      }
+      await rm(rootDir, { recursive: true, force: true });
+    }
+  });
+
   it("emits dry-run preflight and run invocations by default", async () => {
     const { rootDir, runsDir } = await createPhaseFixture();
 
@@ -162,11 +271,15 @@ describe("native phase command center", () => {
 
       expect(preflightPayload.ok).toBe(true);
       expect(preflightPayload.invocation.executed).toBe(false);
-      expect(preflightPayload.invocation.command.slice(0, 3)).toEqual([
+      expect(preflightPayload.invocation.command.slice(0, 5)).toEqual([
         "martin-loop",
         "preflight",
-        "Build the local command center"
+        "Build the local command center",
+        "--cwd",
+        rootDir
       ]);
+      expect(preflightPayload.invocation.command).toContain("--runs-dir");
+      expect(preflightPayload.invocation.command).toContain(runsDir);
       expect(runPayload.ok).toBe(true);
       expect(runPayload.invocation.command.slice(0, 2)).toEqual(["martin-loop", "run"]);
     } finally {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -55,7 +55,7 @@
     "smoke:published": "node ./scripts/smoke-published-package.mjs",
     "smoke:published:pack": "node ./scripts/smoke-published-package.mjs --package-spec=pack",
     "verify:release": "node --test ../../scripts/tests/publish-mcp-workflow.test.mjs ../../scripts/tests/mcp-publish-reliability.test.mjs ../../scripts/tests/mcp-release-docs.test.mjs",
-    "test": "vitest run",
+    "test": "vitest run --maxWorkers=1",
     "lint": "tsc -p tsconfig.json --noEmit",
     "start": "node dist/server.js",
     "inspect:live": "node ./scripts/inspect-live.mjs"

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -23,6 +23,7 @@ import { realpathSync } from "node:fs";
 import path from "node:path";
 
 import { resolveRunsRoot } from "@martin/core";
+import type { LoopBudget, ReceiptScope } from "@martin/contracts";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {
@@ -60,8 +61,9 @@ import { martinTriageRunsTool } from "./tools/triage-runs.js";
 import { runLoopTool } from "./tools/run-loop.js";
 import { createToolErrorResult, createToolSuccessResult } from "./tools/tool-response.js";
 import { MartinToolError, toToolFailure } from "./tools/tool-errors.js";
-import { sanitizeToolErrorMessage, validateToolInput } from "./server-validation.js";
-import { recordMcpWorkflowStep } from "./workflow-state.js";
+import { normalizeLoopBudget } from "./tools/workflow-governance.js";
+import { resolveSafeRepoRoot, sanitizeToolErrorMessage, validateToolInput } from "./server-validation.js";
+import { evaluateMcpRunGate, recordMcpWorkflowStep } from "./workflow-state.js";
 
 const stringArraySchema = {
   type: "array",
@@ -162,6 +164,18 @@ const verificationSchema = {
     warnings: stringArraySchema
   },
   required: ["status", "eventCount", "ledgerEventCount", "warnings"]
+} as const;
+
+const receiptScopeSchema = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    invocationRoot: { type: "string" },
+    workingDirectory: { type: "string" },
+    repoRoot: { type: "string" },
+    runsRoot: { type: "string" }
+  },
+  required: ["invocationRoot", "workingDirectory", "repoRoot", "runsRoot"]
 } as const;
 
 const artifactSummarySchema = {
@@ -421,6 +435,7 @@ const doctorOutputSchema = {
       },
       required: ["workspaceRoot", "workingDirectory", "runsRoot", "mode", "liveMode"]
     },
+    receiptScope: receiptScopeSchema,
     engines: {
       type: "object",
       additionalProperties: true
@@ -438,7 +453,7 @@ const doctorOutputSchema = {
     },
     warnings: stringArraySchema
   },
-  required: ["status", "summary", "server", "environment", "engines", "runStore", "warnings"]
+  required: ["status", "summary", "server", "environment", "receiptScope", "engines", "runStore", "warnings"]
 } as const;
 
 const preflightOutputSchema = {
@@ -448,6 +463,7 @@ const preflightOutputSchema = {
     ok: { type: "boolean" },
     summary: { type: "string" },
     warnings: stringArraySchema,
+    receiptScope: receiptScopeSchema,
     readiness: {
       type: "object",
       additionalProperties: false,
@@ -523,7 +539,7 @@ const preflightOutputSchema = {
       required: ["requestedEngine", "engineAvailability", "runsRoot", "pathScope", "expectedRunLayout"]
     }
   },
-  required: ["ok", "summary", "warnings", "readiness", "normalized", "execution"]
+  required: ["ok", "summary", "warnings", "receiptScope", "readiness", "normalized", "execution"]
 } as const;
 
 const listRunsOutputSchema = {
@@ -1479,6 +1495,36 @@ export function createMartinMcpServer(serverInfo?: {
   try {
     if (name === "martin_run") {
       const input = validateToolInput("martin_run", args) as Parameters<typeof runLoopTool>[0];
+      const runsRoot = resolveRunsRoot(process.env);
+      const workingDirectory = input.workingDirectory ?? resolveSafeRepoRoot();
+      const receiptScope: ReceiptScope = {
+        invocationRoot: resolveSafeRepoRoot(),
+        workingDirectory,
+        repoRoot: workingDirectory,
+        runsRoot
+      };
+      const gate = await evaluateMcpRunGate({
+        runsRoot,
+        workingDirectory,
+        objective: input.objective,
+        engine: input.engine,
+        verificationPlan: input.verificationPlan,
+        receiptScope,
+        allowedPaths: input.allowedPaths,
+        deniedPaths: input.deniedPaths,
+        budget: normalizeRunBudget(input)
+      });
+      if (!gate.allowed) {
+        throw new MartinToolError("policy_blocked", gate.summary, {
+          category: "policy_blocked",
+          suggestion: gate.nextAction,
+          retryable: false,
+          details: {
+            missingSteps: gate.missingSteps,
+            receiptScope
+          }
+        });
+      }
       const output = await runLoopTool(input);
       return createToolSuccessResult(
         output,
@@ -1511,7 +1557,8 @@ export function createMartinMcpServer(serverInfo?: {
         runsRoot: output.environment.runsRoot,
         step: "doctor",
         workingDirectory: output.environment.workingDirectory,
-        engine: input.engine
+        engine: input.engine,
+        receiptScope: output.receiptScope
       }).catch(() => {});
       return createToolSuccessResult(output, output.summary);
     }
@@ -1523,7 +1570,13 @@ export function createMartinMcpServer(serverInfo?: {
         runsRoot: resolveRunsRoot(process.env),
         step: "plan",
         workingDirectory: output.workingDirectory,
-        objective: output.objective
+        objective: output.objective,
+        receiptScope: {
+          invocationRoot: resolveSafeRepoRoot(),
+          workingDirectory: output.workingDirectory,
+          repoRoot: output.workingDirectory,
+          runsRoot: resolveRunsRoot(process.env)
+        }
       }).catch(() => {});
       return createToolSuccessResult(
         output,
@@ -1541,7 +1594,11 @@ export function createMartinMcpServer(serverInfo?: {
           workingDirectory: output.normalized.workingDirectory,
           objective: output.normalized.objective,
           engine: output.normalized.engine,
-          verificationPlan: output.normalized.verificationPlan
+          verificationPlan: output.normalized.verificationPlan,
+          receiptScope: output.receiptScope,
+          allowedPaths: output.normalized.allowedPaths,
+          deniedPaths: output.normalized.deniedPaths,
+          budget: output.normalized.budget
         }).catch(() => {});
       }
       return createToolSuccessResult(output, output.summary);
@@ -1682,6 +1739,14 @@ export function createMartinMcpServer(serverInfo?: {
   });
 
   return server;
+}
+
+function normalizeRunBudget(input: Parameters<typeof runLoopTool>[0]): LoopBudget {
+  return normalizeLoopBudget({
+    maxUsd: input.maxUsd,
+    maxIterations: input.maxIterations,
+    maxTokens: input.maxTokens
+  });
 }
 
 export async function connectMartinMcpStdioServer() {

--- a/packages/mcp/src/tools/doctor.ts
+++ b/packages/mcp/src/tools/doctor.ts
@@ -7,6 +7,7 @@ import { resolveRunsRoot } from "@martin/core";
 
 import { resolveSafeRepoRoot, resolveSafeRunsRootPath } from "../server-validation.js";
 import {
+  createSkippedCliAvailability,
   getEngineAvailability,
   inspectRunsRoot,
   resolveExecutionMode,
@@ -46,16 +47,43 @@ export interface MartinDoctorOutput {
     repoRoot: string;
     runsRoot: string;
   };
+  receiptScope: {
+    invocationRoot: string;
+    workingDirectory: string;
+    repoRoot: string;
+    runsRoot: string;
+  };
   engines: Record<
     MartinEngine,
     {
       available: boolean;
       detail: string;
       resolvedPath?: string;
+      candidatePaths?: string[];
+      selectedPath?: string;
       hostPlatform?: CodexHostPlatform;
+      installKind?: string;
       nativeInstallValid?: boolean;
+      invocationMode?: string;
+      sandboxMode?: string;
+      sandboxCompatible?: boolean;
+      nativeDependencyStatus?: string;
+      nativeDependencyPackage?: string;
       launchReady?: boolean;
       probeSummary?: string;
+      remediation?: string;
+      candidateProbeResults?: Array<{
+        path: string;
+        installKind: string;
+        invocationMode: string;
+        nativeInstallValid: boolean;
+        sandboxCompatible: boolean;
+        launchReady: boolean;
+        summary: string;
+        remediation?: string;
+        nativeDependencyStatus?: string;
+        nativeDependencyPackage?: string;
+      }>;
     }
   >;
   requestedEngine?: MartinEngine;
@@ -73,21 +101,35 @@ export async function martinDoctorTool(input: MartinDoctorInput): Promise<Martin
   const runsRoot = resolveSafeRunsRootPath(input.runsDir, resolveRunsRoot(process.env));
   const workspaceRoot = resolveSafeRepoRoot();
   const executionMode = resolveExecutionMode();
-  const claude = getEngineAvailability("claude");
-  const codex = resolveCliCommandAvailability("codex");
-  const gemini = getEngineAvailability("gemini");
+  const claude = executionMode.liveMode
+    ? getEngineAvailability("claude")
+    : createSkippedCliAvailability("claude");
+  const codex = executionMode.liveMode
+    ? resolveCliCommandAvailability("codex")
+    : createSkippedCliAvailability("codex");
+  const gemini = executionMode.liveMode
+    ? getEngineAvailability("gemini")
+    : createSkippedCliAvailability("gemini");
   const codexProbe =
-    executionMode.liveMode && codex.available
+    executionMode.liveMode && input.engine === "codex" && codex.available
       ? probeCodexLaunch({
           workingDirectory,
           availability: codex
         })
       : undefined;
   const runStore = await inspectRunsRoot(runsRoot);
-  const signals = inspectRepoSignals(workingDirectory);
+  const signals = inspectRepoSignals(workingDirectory, {
+    includeHostAvailability: executionMode.liveMode
+  });
   const readiness = buildReadinessReport(signals, runStore);
 
   const warnings: string[] = [];
+  const receiptScope = {
+    invocationRoot: workspaceRoot,
+    workingDirectory,
+    repoRoot: workingDirectory,
+    runsRoot
+  };
   if (!runStore.exists) {
     warnings.push("Configured Martin runs root does not exist yet.");
   }
@@ -128,11 +170,9 @@ export async function martinDoctorTool(input: MartinDoctorInput): Promise<Martin
       liveMode: executionMode.liveMode
     },
     scope: {
-      invocationRoot: workspaceRoot,
-      workingDirectory,
-      repoRoot: workingDirectory,
-      runsRoot
+      ...receiptScope
     },
+    receiptScope,
     engines: {
       claude: {
         available: claude.available,
@@ -143,12 +183,28 @@ export async function martinDoctorTool(input: MartinDoctorInput): Promise<Martin
         available: codex.available,
         detail: codex.detail,
         ...(codex.resolvedPath ? { resolvedPath: codex.resolvedPath } : {}),
+        ...(codex.candidatePaths?.length ? { candidatePaths: codex.candidatePaths } : {}),
         ...(codexProbe
           ? {
+              selectedPath: codexProbe.command,
               hostPlatform: codexProbe.diagnosis.hostPlatform,
+              installKind: codexProbe.diagnosis.installKind,
               nativeInstallValid: codexProbe.diagnosis.nativeInstallValid,
+              invocationMode: codexProbe.diagnosis.invocationMode,
+              sandboxMode: codexProbe.diagnosis.sandboxMode,
+              sandboxCompatible: codexProbe.diagnosis.sandboxCompatible,
+              ...(codexProbe.diagnosis.nativeDependencyStatus
+                ? { nativeDependencyStatus: codexProbe.diagnosis.nativeDependencyStatus }
+                : {}),
+              ...(codexProbe.diagnosis.nativeDependencyPackage
+                ? { nativeDependencyPackage: codexProbe.diagnosis.nativeDependencyPackage }
+                : {}),
               launchReady: codexProbe.ok,
-              probeSummary: codexProbe.summary
+              probeSummary: codexProbe.summary,
+              ...(codexProbe.diagnosis.remediation ? { remediation: codexProbe.diagnosis.remediation } : {}),
+              ...(codexProbe.candidateProbeResults?.length
+                ? { candidateProbeResults: codexProbe.candidateProbeResults }
+                : {})
             }
           : {})
       },

--- a/packages/mcp/src/tools/plan.ts
+++ b/packages/mcp/src/tools/plan.ts
@@ -1,6 +1,7 @@
 import { resolveSafeRepoRoot } from "../server-validation.js";
 import {
   buildPlanProposal,
+  inspectRepoSignals,
   type MartinPlanProposal,
   type MartinPolicyPack
 } from "./workflow-governance.js";
@@ -27,7 +28,9 @@ export interface MartinPlanOutput extends MartinPlanProposal {
 
 export async function martinPlanTool(input: MartinPlanInput): Promise<MartinPlanOutput> {
   const workingDirectory = resolveSafeRepoRoot(input.workingDirectory);
-  const proposal = buildPlanProposal(workingDirectory, input);
+  const proposal = buildPlanProposal(workingDirectory, input, {
+    signals: inspectRepoSignals(workingDirectory, { includeHostAvailability: false })
+  });
   return {
     workingDirectory,
     ...proposal

--- a/packages/mcp/src/tools/preflight.ts
+++ b/packages/mcp/src/tools/preflight.ts
@@ -3,11 +3,11 @@ import {
   resolveCliCommandAvailability,
   type CodexHostPlatform
 } from "@martin/adapters";
-import { DEFAULT_BUDGET } from "@martin/contracts";
 import { resolveRunsRoot } from "@martin/core";
 
 import { resolveSafeRepoRoot } from "../server-validation.js";
 import {
+  createSkippedCliAvailability,
   formatUsd,
   getEngineAvailability,
   resolveExecutionMode,
@@ -15,6 +15,7 @@ import {
 } from "./tool-support.js";
 import {
   buildPlanProposal,
+  normalizeLoopBudget,
   buildRunContract,
   buildPolicyPackDefinition,
   inspectRepoSignals,
@@ -48,6 +49,12 @@ export interface MartinPreflightOutput {
   ok: boolean;
   summary: string;
   warnings: string[];
+  receiptScope: {
+    invocationRoot: string;
+    workingDirectory: string;
+    repoRoot: string;
+    runsRoot: string;
+  };
   scope: {
     invocationRoot: string;
     workingDirectory: string;
@@ -82,12 +89,33 @@ export interface MartinPreflightOutput {
       available: boolean;
       detail: string;
       resolvedPath?: string;
+      candidatePaths?: string[];
     };
     codexDiagnostics?: {
+      selectedPath?: string;
       hostPlatform: CodexHostPlatform;
+      installKind: string;
       nativeInstallValid: boolean;
+      invocationMode: string;
+      sandboxMode: string;
+      sandboxCompatible: boolean;
+      nativeDependencyStatus?: string;
+      nativeDependencyPackage?: string;
       launchReady: boolean;
       summary: string;
+      remediation?: string;
+      candidateProbeResults?: Array<{
+        path: string;
+        installKind: string;
+        invocationMode: string;
+        nativeInstallValid: boolean;
+        sandboxCompatible: boolean;
+        launchReady: boolean;
+        summary: string;
+        remediation?: string;
+        nativeDependencyStatus?: string;
+        nativeDependencyPackage?: string;
+      }>;
     };
     runsRoot: string;
     pathScope: {
@@ -113,10 +141,16 @@ export async function martinPreflightTool(
   const executionMode = resolveExecutionMode();
   const workspaceRoot = resolveSafeRepoRoot();
   const workingDirectory = resolveSafeRepoRoot(input.workingDirectory);
-  const signals = inspectRepoSignals(workingDirectory);
+  const signals = inspectRepoSignals(workingDirectory, {
+    includeHostAvailability: executionMode.liveMode
+  });
   const engine = input.engine ?? "claude";
   const engineAvailability =
-    engine === "codex" ? resolveCliCommandAvailability("codex") : getEngineAvailability(engine);
+    executionMode.liveMode
+      ? engine === "codex"
+        ? resolveCliCommandAvailability("codex")
+        : getEngineAvailability(engine)
+      : createSkippedCliAvailability(engine);
   const codexProbe =
     executionMode.liveMode && engine === "codex" && engineAvailability.available
       ? probeCodexLaunch({
@@ -129,12 +163,11 @@ export async function martinPreflightTool(
   const deniedPaths = input.deniedPaths ?? [];
   const overlappingScopes = allowedPaths.filter((candidate) => deniedPaths.includes(candidate));
 
-  const budget = {
-    ...DEFAULT_BUDGET,
-    ...(input.maxUsd !== undefined ? { maxUsd: input.maxUsd } : {}),
-    ...(input.maxIterations !== undefined ? { maxIterations: input.maxIterations } : {}),
-    ...(input.maxTokens !== undefined ? { maxTokens: input.maxTokens } : {})
-  };
+  const budget = normalizeLoopBudget({
+    maxUsd: input.maxUsd,
+    maxIterations: input.maxIterations,
+    maxTokens: input.maxTokens
+  });
 
   if (!executionMode.liveMode) {
     warnings.push("Proof mode is active; preflight only proves configuration shape, not live CLI readiness.");
@@ -157,14 +190,20 @@ export async function martinPreflightTool(
     );
   }
 
-  const plan = buildPlanProposal(workingDirectory, input);
-  const runContract = buildRunContract(workingDirectory, input);
+  const plan = buildPlanProposal(workingDirectory, input, { signals });
+  const runContract = buildRunContract(workingDirectory, input, { signals, plan });
   const policy = buildPolicyPackDefinition(input.policyPack, signals);
 
   const engineReady =
     !executionMode.liveMode ||
     (engineAvailability.available && (engine !== "codex" || codexProbe?.ok !== false));
   const ok = engineReady;
+  const receiptScope = {
+    invocationRoot: workspaceRoot,
+    workingDirectory,
+    repoRoot: workingDirectory,
+    runsRoot: resolveRunsRoot(process.env)
+  };
 
   return {
     ok,
@@ -176,11 +215,9 @@ export async function martinPreflightTool(
             : `${engine} is not available for live execution.`
         }`,
     warnings,
+    receiptScope,
     scope: {
-      invocationRoot: workspaceRoot,
-      workingDirectory,
-      repoRoot: workingDirectory,
-      runsRoot: resolveRunsRoot(process.env)
+      ...receiptScope
     },
     readiness: {
       mode: executionMode.mode,
@@ -204,17 +241,33 @@ export async function martinPreflightTool(
       engineAvailability: {
         available: engineAvailability.available,
         detail: engineAvailability.detail,
-        ...(engineAvailability.resolvedPath
-          ? { resolvedPath: engineAvailability.resolvedPath }
+        ...(engineAvailability.resolvedPath ? { resolvedPath: engineAvailability.resolvedPath } : {}),
+        ...(engineAvailability.candidatePaths?.length
+          ? { candidatePaths: engineAvailability.candidatePaths }
           : {})
       },
       ...(codexProbe
         ? {
             codexDiagnostics: {
+              selectedPath: codexProbe.command,
               hostPlatform: codexProbe.diagnosis.hostPlatform,
+              installKind: codexProbe.diagnosis.installKind,
               nativeInstallValid: codexProbe.diagnosis.nativeInstallValid,
+              invocationMode: codexProbe.diagnosis.invocationMode,
+              sandboxMode: codexProbe.diagnosis.sandboxMode,
+              sandboxCompatible: codexProbe.diagnosis.sandboxCompatible,
+              ...(codexProbe.diagnosis.nativeDependencyStatus
+                ? { nativeDependencyStatus: codexProbe.diagnosis.nativeDependencyStatus }
+                : {}),
+              ...(codexProbe.diagnosis.nativeDependencyPackage
+                ? { nativeDependencyPackage: codexProbe.diagnosis.nativeDependencyPackage }
+                : {}),
               launchReady: codexProbe.ok,
-              summary: codexProbe.summary
+              summary: codexProbe.summary,
+              ...(codexProbe.diagnosis.remediation ? { remediation: codexProbe.diagnosis.remediation } : {}),
+              ...(codexProbe.candidateProbeResults?.length
+                ? { candidateProbeResults: codexProbe.candidateProbeResults }
+                : {})
             }
           }
         : {}),

--- a/packages/mcp/src/tools/run-loop.ts
+++ b/packages/mcp/src/tools/run-loop.ts
@@ -4,11 +4,12 @@ import {
   createGeminiCliAdapter,
   probeCodexLaunch,
   resolveCliCommandAvailability,
-  createVerifierOnlyAdapter
+  createVerifierOnlyAdapter,
+  type SpawnLike
 } from "@martin/adapters";
 
 import { createFileRunStore, evaluateCostGovernor, resolveRunsRoot, runMartin } from "@martin/core";
-import { DEFAULT_BUDGET, type LoopBudget, type ReceiptScope } from "@martin/contracts";
+import type { LoopBudget, ReceiptScope } from "@martin/contracts";
 
 import { normalizeSafePathPatterns, resolveSafeRepoRoot } from "../server-validation.js";
 import { MartinToolError } from "./tool-errors.js";
@@ -21,6 +22,7 @@ import {
   resolveExecutionMode,
   type MartinEngine
 } from "./tool-support.js";
+import { normalizeLoopBudget } from "./workflow-governance.js";
 
 export interface RunLoopInput {
   objective: string;
@@ -65,6 +67,12 @@ export interface RunLoopOutput {
   };
 }
 
+let proofModeVerifierSpawnImpl: SpawnLike | undefined;
+
+export function __setProofModeVerifierSpawnImplForTests(spawnImpl?: SpawnLike): void {
+  proofModeVerifierSpawnImpl = spawnImpl;
+}
+
 export async function runLoopTool(input: RunLoopInput): Promise<RunLoopOutput> {
   const workingDirectory = resolveSafeRepoRoot(input.workingDirectory);
   const engine = input.engine ?? "claude";
@@ -80,6 +88,7 @@ export async function runLoopTool(input: RunLoopInput): Promise<RunLoopOutput> {
     repoRoot: workingDirectory,
     runsRoot
   };
+  let codexCommandOverride: string | undefined;
   if (executionMode.liveMode) {
     if (engine === "codex") {
       const engineAvailability = resolveCliCommandAvailability("codex");
@@ -102,6 +111,7 @@ export async function runLoopTool(input: RunLoopInput): Promise<RunLoopOutput> {
           retryable: false
         });
       }
+      codexCommandOverride = codexProbe.command;
     } else {
       const engineAvailability = getEngineAvailability(engine);
       if (!engineAvailability.available) {
@@ -118,10 +128,15 @@ export async function runLoopTool(input: RunLoopInput): Promise<RunLoopOutput> {
     !executionMode.liveMode
       ? createVerifierOnlyAdapter({
           workingDirectory,
-          label: "Proof mode adapter (MARTIN_LIVE=false)"
+          label: "Proof mode adapter (MARTIN_LIVE=false)",
+          ...(proofModeVerifierSpawnImpl ? { spawnImpl: proofModeVerifierSpawnImpl } : {})
         })
       : engine === "codex"
-        ? createCodexCliAdapter({ workingDirectory, ...(model ? { model } : {}) })
+        ? createCodexCliAdapter({
+            workingDirectory,
+            ...(model ? { model } : {}),
+            ...(codexCommandOverride ? { command: codexCommandOverride } : {})
+          })
         : engine === "gemini"
           ? createGeminiCliAdapter({ workingDirectory, ...(model ? { model } : {}) })
         : createClaudeCliAdapter({ workingDirectory, ...(model ? { model } : {}) });
@@ -137,10 +152,7 @@ export async function runLoopTool(input: RunLoopInput): Promise<RunLoopOutput> {
     partialBudget.maxTokens = input.maxTokens;
   }
 
-  const budget: LoopBudget = {
-    ...DEFAULT_BUDGET,
-    ...partialBudget
-  };
+  const budget: LoopBudget = normalizeLoopBudget(partialBudget);
 
   const result = await runMartin({
     workspaceId: input.workspaceId ?? "ws_mcp",

--- a/packages/mcp/src/tools/tool-support.ts
+++ b/packages/mcp/src/tools/tool-support.ts
@@ -129,6 +129,7 @@ export interface CliAvailability {
   locator: string;
   detail: string;
   resolvedPath?: string;
+  candidatePaths?: string[];
 }
 
 export interface ExecutionMode {
@@ -221,6 +222,18 @@ export function detectCliAvailability(command: string): CliAvailability {
 
 export function getEngineAvailability(engine: MartinEngine): CliAvailability {
   return detectCliAvailability(engine);
+}
+
+export function createSkippedCliAvailability(
+  command: string,
+  detail = "Proof mode skipped live CLI availability detection."
+): CliAvailability {
+  return {
+    command,
+    available: false,
+    locator: "skipped",
+    detail
+  };
 }
 
 export function formatUsd(value: number): string {

--- a/packages/mcp/src/tools/workflow-governance.ts
+++ b/packages/mcp/src/tools/workflow-governance.ts
@@ -2,9 +2,10 @@ import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 
-import { DEFAULT_BUDGET } from "@martin/contracts";
+import { DEFAULT_BUDGET, type LoopBudget } from "@martin/contracts";
 
 import {
+  createSkippedCliAvailability,
   detectCliAvailability,
   type MartinEngine,
   type RunStoreInspection
@@ -41,6 +42,7 @@ export interface RepoSignals {
   packageScripts: Record<string, string>;
   git: RepoGitState;
   sensitivePaths: string[];
+  hostAvailabilityChecked: boolean;
   availableHosts: Record<
     "claude" | "codex" | "cursor" | "gemini",
     {
@@ -139,12 +141,28 @@ interface ContractOverrides {
   maxCommands?: number;
 }
 
+interface LoopBudgetOverrides {
+  maxUsd?: number;
+  softLimitUsd?: number;
+  maxIterations?: number;
+  maxTokens?: number;
+}
+
 const HOST_COMMANDS = {
   claude: "claude",
   codex: "codex",
   cursor: "cursor",
   gemini: "gemini"
 } as const;
+
+const REPO_SIGNALS_CACHE_TTL_MS = 5_000;
+const repoSignalsCache = new Map<
+  string,
+  {
+    expiresAt: number;
+    value: RepoSignals;
+  }
+>();
 
 const POLICY_PACKS: Record<MartinPolicyPack, Omit<MartinPolicyPackDefinition, "defaultVerifiers">> = {
   "solo-founder": {
@@ -248,14 +266,24 @@ const POLICY_PACKS: Record<MartinPolicyPack, Omit<MartinPolicyPackDefinition, "d
   }
 };
 
-export function inspectRepoSignals(workingDirectory: string): RepoSignals {
+export function inspectRepoSignals(
+  workingDirectory: string,
+  options: { includeHostAvailability?: boolean } = {}
+): RepoSignals {
+  const includeHostAvailability = options.includeHostAvailability ?? true;
+  const cacheKey = `${workingDirectory}::hosts=${includeHostAvailability ? "live" : "skipped"}`;
+  const cached = repoSignalsCache.get(cacheKey);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.value;
+  }
+
   const packageScripts = readPackageScripts(workingDirectory);
   const packageManager = detectPackageManager(workingDirectory);
   const frameworks = detectFrameworks(workingDirectory, packageScripts);
   const languages = detectLanguages(workingDirectory, frameworks);
   const verifiers = detectVerifierCommands(packageScripts, packageManager);
 
-  return {
+  const signals: RepoSignals = {
     workingDirectory,
     packageManager,
     languages,
@@ -264,13 +292,29 @@ export function inspectRepoSignals(workingDirectory: string): RepoSignals {
     packageScripts,
     git: detectGitState(workingDirectory),
     sensitivePaths: detectSensitivePaths(workingDirectory),
+    hostAvailabilityChecked: includeHostAvailability,
     availableHosts: {
-      claude: detectCliAvailability(HOST_COMMANDS.claude),
-      codex: detectCliAvailability(HOST_COMMANDS.codex),
-      cursor: detectCliAvailability(HOST_COMMANDS.cursor),
-      gemini: detectCliAvailability(HOST_COMMANDS.gemini)
+      claude: includeHostAvailability
+        ? detectCliAvailability(HOST_COMMANDS.claude)
+        : createSkippedCliAvailability(HOST_COMMANDS.claude),
+      codex: includeHostAvailability
+        ? detectCliAvailability(HOST_COMMANDS.codex)
+        : createSkippedCliAvailability(HOST_COMMANDS.codex),
+      cursor: includeHostAvailability
+        ? detectCliAvailability(HOST_COMMANDS.cursor)
+        : createSkippedCliAvailability(HOST_COMMANDS.cursor),
+      gemini: includeHostAvailability
+        ? detectCliAvailability(HOST_COMMANDS.gemini)
+        : createSkippedCliAvailability(HOST_COMMANDS.gemini)
     }
   };
+
+  repoSignalsCache.set(cacheKey, {
+    expiresAt: Date.now() + REPO_SIGNALS_CACHE_TTL_MS,
+    value: signals
+  });
+
+  return signals;
 }
 
 export function buildReadinessReport(
@@ -300,7 +344,11 @@ export function buildReadinessReport(
   if (signals.frameworks.length === 0) {
     score -= 8;
   }
-  if (!signals.availableHosts.claude.available && !signals.availableHosts.codex.available) {
+  if (
+    signals.hostAvailabilityChecked &&
+    !signals.availableHosts.claude.available &&
+    !signals.availableHosts.codex.available
+  ) {
     score -= 18;
   }
   score = Math.max(0, Math.min(100, score));
@@ -344,9 +392,10 @@ export function buildPolicyPackDefinition(
 
 export function buildPlanProposal(
   workingDirectory: string,
-  overrides: ContractOverrides
+  overrides: ContractOverrides,
+  options: { signals?: RepoSignals } = {}
 ): MartinPlanProposal {
-  const signals = inspectRepoSignals(workingDirectory);
+  const signals = options.signals ?? inspectRepoSignals(workingDirectory);
   const policy = buildPolicyPackDefinition(overrides.policyPack, signals);
   const scope = inferScopeFromObjective(overrides.objective, policy, overrides);
   const estimatedBudget = buildBudget(overrides, signals);
@@ -385,9 +434,10 @@ export function buildPlanProposal(
 
 export function buildRunContract(
   workingDirectory: string,
-  overrides: ContractOverrides
+  overrides: ContractOverrides,
+  options: { signals?: RepoSignals; plan?: MartinPlanProposal } = {}
 ): MartinRunContract {
-  const plan = buildPlanProposal(workingDirectory, overrides);
+  const plan = options.plan ?? buildPlanProposal(workingDirectory, overrides, options);
   return {
     objective: overrides.objective,
     ...(overrides.context ? { context: overrides.context } : {}),
@@ -400,6 +450,21 @@ export function buildRunContract(
     requiresApproval:
       plan.approvalRecommendation === "required" ||
       shouldRequireApproval(plan.policyPack.requireApprovalAtOrAbove, plan.risk.level)
+  };
+}
+
+export function normalizeLoopBudget(overrides: LoopBudgetOverrides = {}): LoopBudget {
+  const maxUsd = overrides.maxUsd ?? DEFAULT_BUDGET.maxUsd;
+  const softLimitUsd = Math.min(
+    overrides.softLimitUsd ?? DEFAULT_BUDGET.softLimitUsd,
+    maxUsd
+  );
+
+  return {
+    maxUsd,
+    softLimitUsd,
+    maxIterations: overrides.maxIterations ?? DEFAULT_BUDGET.maxIterations,
+    maxTokens: overrides.maxTokens ?? DEFAULT_BUDGET.maxTokens
   };
 }
 
@@ -639,34 +704,52 @@ function detectGitState(workingDirectory: string): RepoGitState {
     };
   }
 
-  const branch = spawnSync("git", ["branch", "--show-current"], {
-    cwd: workingDirectory,
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"]
-  }).stdout.trim();
-  const status = spawnSync("git", ["status", "--porcelain", "--branch"], {
-    cwd: workingDirectory,
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"]
-  });
+  const status = spawnSync(
+    "git",
+    ["status", "--porcelain=v2", "--branch", "--untracked-files=normal", "--ignored=no", "--", "."],
+    {
+      cwd: workingDirectory,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"]
+    }
+  );
   const statusLines = (status.stdout ?? "")
     .split(/\r?\n/u)
     .map((line) => line.trim())
     .filter(Boolean);
-  const dirty = statusLines.some((line) => !line.startsWith("##"));
-  const header = statusLines.find((line) => line.startsWith("##"));
-  const upstream = header?.match(/\.\.\.([^\s[]+)/u)?.[1];
-  const ahead = parseCount(header, /ahead (\d+)/u);
-  const behind = parseCount(header, /behind (\d+)/u);
+  const dirty = statusLines.some((line) => !line.startsWith("#"));
+  const branch = statusLines
+    .find((line) => line.startsWith("# branch.head "))
+    ?.replace("# branch.head ", "")
+    .trim();
+  const upstream = statusLines
+    .find((line) => line.startsWith("# branch.upstream "))
+    ?.replace("# branch.upstream ", "")
+    .trim();
+  const aheadBehind = statusLines
+    .find((line) => line.startsWith("# branch.ab "))
+    ?.replace("# branch.ab ", "")
+    .trim()
+    .split(/\s+/u);
+  const aheadToken = aheadBehind?.find((token) => token.startsWith("+"));
+  const behindToken = aheadBehind?.find((token) => token.startsWith("-"));
+  const ahead =
+    aheadToken && aheadToken.length > 1
+      ? Number.parseInt(aheadToken.slice(1), 10)
+      : undefined;
+  const behind =
+    behindToken && behindToken.length > 1
+      ? Number.parseInt(behindToken.slice(1), 10)
+      : undefined;
 
   return {
     available: true,
     isRepo: true,
     clean: !dirty,
-    ...(branch ? { branch } : {}),
+    ...(branch && branch !== "(detached)" ? { branch } : {}),
     ...(upstream ? { upstream } : {}),
-    ...(ahead !== undefined ? { ahead } : {}),
-    ...(behind !== undefined ? { behind } : {})
+    ...(Number.isFinite(ahead) ? { ahead } : {}),
+    ...(Number.isFinite(behind) ? { behind } : {})
   };
 }
 
@@ -744,14 +827,9 @@ function inferScopeFromObjective(
 
 function buildBudget(overrides: ContractOverrides, signals: RepoSignals): MartinPlanBudget {
   const defaultCommands = signals.verifiers.defaultPlan.length > 0 ? 12 : 8;
+  const normalizedBudget = normalizeLoopBudget(overrides);
   return {
-    maxUsd: overrides.maxUsd ?? DEFAULT_BUDGET.maxUsd,
-    softLimitUsd: Math.min(
-      overrides.maxUsd ?? DEFAULT_BUDGET.maxUsd,
-      DEFAULT_BUDGET.softLimitUsd
-    ),
-    maxIterations: overrides.maxIterations ?? DEFAULT_BUDGET.maxIterations,
-    maxTokens: overrides.maxTokens ?? DEFAULT_BUDGET.maxTokens,
+    ...normalizedBudget,
     maxMinutes: overrides.maxMinutes ?? 20,
     maxFilesChanged: overrides.maxFilesChanged ?? 8,
     maxCommands: overrides.maxCommands ?? defaultCommands
@@ -809,13 +887,4 @@ function shouldRequireApproval(
 ): boolean {
   const ordering = ["low", "medium", "high"] as const;
   return ordering.indexOf(level) >= ordering.indexOf(threshold);
-}
-
-function parseCount(value: string | undefined, pattern: RegExp): number | undefined {
-  const match = value?.match(pattern)?.[1];
-  if (!match) {
-    return undefined;
-  }
-  const parsed = Number.parseInt(match, 10);
-  return Number.isFinite(parsed) ? parsed : undefined;
 }

--- a/packages/mcp/src/workflow-state.ts
+++ b/packages/mcp/src/workflow-state.ts
@@ -2,6 +2,8 @@ import { createHash } from "node:crypto";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 
+import type { LoopBudget, ReceiptScope } from "@martin/contracts";
+
 const WORKFLOW_STATE_DIRECTORY = "_martin";
 const WORKFLOW_STATE_FILENAME = "workflow-state.json";
 const DOCTOR_TTL_MS = 24 * 60 * 60 * 1000;
@@ -17,6 +19,9 @@ interface McpWorkflowReceipt {
   objectiveKey?: string;
   engine?: string;
   verificationPlanKey?: string;
+  scopeKey?: string;
+  pathScopeKey?: string;
+  budgetKey?: string;
 }
 
 interface WorkflowState {
@@ -31,6 +36,10 @@ export interface RecordMcpWorkflowStepInput {
   objective?: string;
   engine?: string;
   verificationPlan?: string[];
+  receiptScope?: ReceiptScope;
+  allowedPaths?: string[];
+  deniedPaths?: string[];
+  budget?: LoopBudget;
 }
 
 export interface EvaluateMcpRunGateInput {
@@ -39,6 +48,10 @@ export interface EvaluateMcpRunGateInput {
   objective: string;
   engine?: string;
   verificationPlan?: string[];
+  receiptScope?: ReceiptScope;
+  allowedPaths?: string[];
+  deniedPaths?: string[];
+  budget?: LoopBudget;
 }
 
 export interface McpRunGateResult {
@@ -57,7 +70,12 @@ export async function recordMcpWorkflowStep(input: RecordMcpWorkflowStepInput): 
     workingDirectory: normalizeWorkingDirectory(input.workingDirectory),
     ...(input.objective ? { objectiveKey: normalizeObjective(input.objective) } : {}),
     ...(input.engine ? { engine: input.engine } : {}),
-    ...(input.verificationPlan ? { verificationPlanKey: hashVerificationPlan(input.verificationPlan) } : {})
+    ...(input.verificationPlan ? { verificationPlanKey: hashVerificationPlan(input.verificationPlan) } : {}),
+    ...(input.receiptScope ? { scopeKey: hashReceiptScope(input.receiptScope) } : {}),
+    ...(input.allowedPaths || input.deniedPaths
+      ? { pathScopeKey: hashPathScope(input.allowedPaths ?? [], input.deniedPaths ?? []) }
+      : {}),
+    ...(input.budget ? { budgetKey: hashBudget(input.budget) } : {})
   };
   await writeWorkflowState(input.runsRoot, state);
 }
@@ -69,14 +87,28 @@ export async function evaluateMcpRunGate(input: EvaluateMcpRunGateInput): Promis
   const objectiveKey = normalizeObjective(input.objective);
   const engine = input.engine ?? "claude";
   const verificationPlanKey = hashVerificationPlan(input.verificationPlan ?? []);
+  const scopeKey = hashReceiptScope(
+    input.receiptScope ?? {
+      invocationRoot: input.workingDirectory,
+      workingDirectory: input.workingDirectory,
+      repoRoot: input.workingDirectory,
+      runsRoot: input.runsRoot
+    }
+  );
+  const pathScopeKey = hashPathScope(input.allowedPaths ?? [], input.deniedPaths ?? []);
+  const budgetKey = input.budget ? hashBudget(input.budget) : undefined;
   const missingSteps: McpWorkflowStepName[] = [];
 
-  if (!isFresh(mcpState["doctor"], DOCTOR_TTL_MS, (receipt) => receipt.workingDirectory === workingDirectory)) {
+  if (!isFresh(mcpState["doctor"], DOCTOR_TTL_MS, (receipt) =>
+    receipt.workingDirectory === workingDirectory &&
+    receipt.scopeKey === scopeKey
+  )) {
     missingSteps.push("doctor");
   }
 
   if (!isFresh(mcpState["plan"], PLAN_TTL_MS, (receipt) =>
     receipt.workingDirectory === workingDirectory &&
+    receipt.scopeKey === scopeKey &&
     receipt.objectiveKey === objectiveKey
   )) {
     missingSteps.push("plan");
@@ -86,7 +118,10 @@ export async function evaluateMcpRunGate(input: EvaluateMcpRunGateInput): Promis
     receipt.workingDirectory === workingDirectory &&
     receipt.objectiveKey === objectiveKey &&
     receipt.engine === engine &&
-    receipt.verificationPlanKey === verificationPlanKey
+    receipt.verificationPlanKey === verificationPlanKey &&
+    receipt.scopeKey === scopeKey &&
+    receipt.pathScopeKey === pathScopeKey &&
+    (budgetKey === undefined || receipt.budgetKey === budgetKey)
   )) {
     missingSteps.push("preflight");
   }
@@ -164,5 +199,37 @@ function normalizeObjective(objective: string): string {
 
 function hashVerificationPlan(verificationPlan: string[]): string {
   const normalized = verificationPlan.map((step) => step.trim()).filter(Boolean);
+  return createHash("sha256").update(JSON.stringify(normalized)).digest("hex").slice(0, 12);
+}
+
+function hashReceiptScope(receiptScope: ReceiptScope): string {
+  const normalized = {
+    invocationRoot: normalizeWorkingDirectory(
+      receiptScope.invocationRoot ?? receiptScope.workingDirectory ?? ""
+    ),
+    workingDirectory: normalizeWorkingDirectory(
+      receiptScope.workingDirectory ?? receiptScope.repoRoot ?? ""
+    ),
+    repoRoot: normalizeWorkingDirectory(receiptScope.repoRoot ?? receiptScope.workingDirectory ?? ""),
+    runsRoot: normalizeWorkingDirectory(receiptScope.runsRoot ?? "")
+  };
+  return createHash("sha256").update(JSON.stringify(normalized)).digest("hex").slice(0, 12);
+}
+
+function hashPathScope(allowedPaths: string[], deniedPaths: string[]): string {
+  const normalized = {
+    allowedPaths: [...new Set(allowedPaths.map((entry) => entry.trim()).filter(Boolean))].sort(),
+    deniedPaths: [...new Set(deniedPaths.map((entry) => entry.trim()).filter(Boolean))].sort()
+  };
+  return createHash("sha256").update(JSON.stringify(normalized)).digest("hex").slice(0, 12);
+}
+
+function hashBudget(budget: LoopBudget): string {
+  const normalized = {
+    maxUsd: Number(budget.maxUsd.toFixed(4)),
+    softLimitUsd: Number(budget.softLimitUsd.toFixed(4)),
+    maxIterations: budget.maxIterations,
+    maxTokens: budget.maxTokens
+  };
   return createHash("sha256").update(JSON.stringify(normalized)).digest("hex").slice(0, 12);
 }

--- a/packages/mcp/tests/mcp-discovery.test.ts
+++ b/packages/mcp/tests/mcp-discovery.test.ts
@@ -16,6 +16,21 @@ import {
   readMartinResource
 } from "../src/resources.js";
 
+async function withEnv<T>(key: string, value: string, fn: () => Promise<T>): Promise<T> {
+  const original = process.env[key];
+  process.env[key] = value;
+
+  try {
+    return await fn();
+  } finally {
+    if (original === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = original;
+    }
+  }
+}
+
 function makeLoopRecord() {
   const base = createLoopRecord({
     workspaceId: "ws_test",
@@ -186,18 +201,20 @@ describe("Martin MCP discovery resources", () => {
     });
   });
 
-  it("degrades server health when an explicit runsDir is missing", async () => {
-    await withRunsRoot(async (runsRoot) => {
-      const missingRunsRoot = join(runsRoot, "missing");
-      const health = await readMartinResource({
-        uri: MARTIN_STATIC_RESOURCE_URIS.serverHealth,
-        runsDir: missingRunsRoot
-      });
+  it("degrades server health when an explicit runsDir is missing", { timeout: 20_000 }, async () => {
+    await withEnv("MARTIN_LIVE", "false", () =>
+      withRunsRoot(async (runsRoot) => {
+        const missingRunsRoot = join(runsRoot, "missing");
+        const health = await readMartinResource({
+          uri: MARTIN_STATIC_RESOURCE_URIS.serverHealth,
+          runsDir: missingRunsRoot
+        });
 
-      expect(health.contents[0]?.text).toContain("\"status\": \"degraded\"");
-      expect(health.contents[0]?.text).toContain("\"exists\": false");
-      expect(health.contents[0]?.text).toContain("Configured Martin runs root does not exist yet.");
-    });
+        expect(health.contents[0]?.text).toContain("\"status\": \"degraded\"");
+        expect(health.contents[0]?.text).toContain("\"exists\": false");
+        expect(health.contents[0]?.text).toContain("Configured Martin runs root does not exist yet.");
+      })
+    );
   });
 
   it("reads loop, attempt, and verification resources from persisted loop records", async () => {

--- a/packages/mcp/tests/mcp-tools.test.ts
+++ b/packages/mcp/tests/mcp-tools.test.ts
@@ -1,10 +1,14 @@
+import { EventEmitter } from "node:events";
+import type { ChildProcess, SpawnOptions } from "node:child_process";
+import { PassThrough } from "node:stream";
 import { chmod, mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { writeReceiptIntegrityMaterial } from "@martin/core";
 import { createLoopRecord } from "@martin/contracts";
-import { describe, expect, it, vi } from "vitest";
+import type { SpawnLike } from "@martin/adapters";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { getStatusTool } from "../src/tools/get-status.js";
 import { martinGetRunTool } from "../src/tools/get-run.js";
@@ -14,7 +18,7 @@ import { martinGetVerificationResultsTool } from "../src/tools/get-verification-
 import { martinListRunsTool } from "../src/tools/list-runs.js";
 import { martinPreflightTool } from "../src/tools/preflight.js";
 import { martinRunDossierTool } from "../src/tools/run-dossier.js";
-import { runLoopTool } from "../src/tools/run-loop.js";
+import { __setProofModeVerifierSpawnImplForTests, runLoopTool } from "../src/tools/run-loop.js";
 import { martinTriageRunsTool } from "../src/tools/triage-runs.js";
 
 // ---------------------------------------------------------------------------
@@ -98,6 +102,27 @@ async function installFakeCliProbe(directory: string, command: string, markerPat
   );
   await chmod(commandPath, 0o755);
 }
+
+function createImmediateSpawn(calls: Array<{ command: string; args: readonly string[]; options?: SpawnOptions }>): SpawnLike {
+  return (command, args = [], options) => {
+    calls.push({ command, args, options });
+    const child = new EventEmitter() as Partial<ChildProcess> & {
+      stdout: PassThrough;
+      stderr: PassThrough;
+      stdin: PassThrough;
+    };
+    child.stdout = new PassThrough();
+    child.stderr = new PassThrough();
+    child.stdin = new PassThrough();
+    child.kill = () => true;
+    process.nextTick(() => child.emit("close", 0));
+    return child as ChildProcess;
+  };
+}
+
+afterEach(() => {
+  __setProofModeVerifierSpawnImplForTests(undefined);
+});
 
 // ---------------------------------------------------------------------------
 // martin_status
@@ -385,6 +410,7 @@ describe("martinDoctorTool", () => {
         expect(result.runStore.loopCount).toBe(1);
         expect(result.runStore.latestRun?.loopId).toBe(loop.loopId);
         expect(result.requestedEngine).toBe("codex");
+        expect(result.receiptScope).toEqual(result.scope);
         expect(result.scope.repoRoot).toBe(result.environment.workingDirectory);
         expect(result.scope.runsRoot).toBe(runsRoot);
       } finally {
@@ -471,8 +497,10 @@ describe("martinPreflightTool", () => {
       expect(result.readiness.mode).toBe("proof");
       expect(result.normalized.engine).toBe("codex");
       expect(result.normalized.budget.maxUsd).toBe(3);
+      expect(result.normalized.budget.softLimitUsd).toBe(3);
       expect(result.normalized.budget.maxIterations).toBe(2);
       expect(result.normalized.allowedPaths).toEqual(["src/**", "tests/**"]);
+      expect(result.receiptScope).toEqual(result.scope);
       expect(result.scope.repoRoot).toBe(result.normalized.workingDirectory);
       expect(result.scope.runsRoot).toBe(result.execution.runsRoot);
       expect(result.execution.expectedRunLayout.loopRecordPathPattern).toBe(
@@ -1151,6 +1179,35 @@ describe("martinTriageRunsTool", () => {
 // ---------------------------------------------------------------------------
 
 describe("runLoopTool", () => {
+  it("uses the injected proof-mode verifier spawn for verification-only contract tests", async () => {
+    await withRunsRoot(async () => {
+      const originalEnv = process.env.MARTIN_LIVE;
+      process.env.MARTIN_LIVE = "false";
+      const calls: Array<{ command: string; args: readonly string[]; options?: SpawnOptions }> = [];
+      __setProofModeVerifierSpawnImplForTests(createImmediateSpawn(calls));
+
+      try {
+        const result = await runLoopTool({
+          objective: "Validate proof-mode verifier seams",
+          verificationPlan: ["node --version"],
+          maxIterations: 1,
+          maxUsd: 1
+        });
+
+        expect(result.loopId).toMatch(/^loop_/u);
+        expect(calls).toHaveLength(1);
+        expect(calls[0]?.command).toBe("node");
+        expect(calls[0]?.args).toEqual(["--version"]);
+      } finally {
+        if (originalEnv === undefined) {
+          delete process.env.MARTIN_LIVE;
+        } else {
+          process.env.MARTIN_LIVE = originalEnv;
+        }
+      }
+    });
+  });
+
   it("returns a loop outcome in stub mode (MARTIN_LIVE=false)", async () => {
     // Set stub mode so the adapter doesn't try to spawn claude
     const originalEnv = process.env.MARTIN_LIVE;
@@ -1166,12 +1223,13 @@ describe("runLoopTool", () => {
         maxUsd: 5
       });
 
-      // Stub adapter returns failed, so loop exits with budget_exit or diminishing_returns
-      expect(result.loopId).toMatch(/^loop_/u);
-      expect(typeof result.attempts).toBe("number");
-      expect(typeof result.costUsd).toBe("number");
-      expect(["completed", "exited", "failed"]).toContain(result.status);
-    } finally {
+        // Stub adapter returns failed, so loop exits with budget_exit or diminishing_returns
+        expect(result.loopId).toMatch(/^loop_/u);
+        expect(typeof result.attempts).toBe("number");
+        expect(typeof result.costUsd).toBe("number");
+        expect(result.budget.softLimitUsd).toBe(5);
+        expect(["completed", "exited", "failed"]).toContain(result.status);
+      } finally {
       if (originalEnv === undefined) {
         delete process.env.MARTIN_LIVE;
       } else {

--- a/packages/mcp/tests/run-dossier.test.ts
+++ b/packages/mcp/tests/run-dossier.test.ts
@@ -38,7 +38,7 @@ async function withRunsAndWorkspace<T>(
 }
 
 describe("martinRunDossierTool", () => {
-  it("uses the trusted workspace root when a run record omits repoRoot", async () => {
+  it("uses the trusted workspace root when a run record omits repoRoot", { timeout: 20_000 }, async () => {
     await withRunsAndWorkspace(async ({ runsRoot, workspaceRoot }) => {
       const loop = createLoopRecord({
         loopId: "loop_workspace_fallback",

--- a/packages/mcp/tests/server-validation.test.ts
+++ b/packages/mcp/tests/server-validation.test.ts
@@ -1,9 +1,13 @@
+import { EventEmitter } from "node:events";
+import type { ChildProcess, SpawnOptions } from "node:child_process";
+import { PassThrough } from "node:stream";
 import { symlink, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { describe, expect, it } from "vitest";
+import type { SpawnLike } from "@martin/adapters";
+import { afterEach, describe, expect, it } from "vitest";
 
 import {
   MARTIN_PROMPT_NAMES,
@@ -17,12 +21,42 @@ import {
   resolveTrustedLoopRepoRoot,
   validateToolInput
 } from "../src/server-validation.js";
+import { __setProofModeVerifierSpawnImplForTests } from "../src/tools/run-loop.js";
 import { createMartinMcpServer } from "../src/server.js";
 
 type ServerRequestHandler = (request: unknown, extra: unknown) => Promise<unknown>;
 type ServerWithRequestHandlers = {
   _requestHandlers: Map<string, ServerRequestHandler>;
 };
+
+function createImmediateSpawn(calls: Array<{ command: string; args: readonly string[]; options?: SpawnOptions }>): SpawnLike {
+  return (command, args = [], options) => {
+    calls.push({ command, args, options });
+    const child = new EventEmitter() as Partial<ChildProcess> & {
+      stdout: PassThrough;
+      stderr: PassThrough;
+      stdin: PassThrough;
+    };
+    child.stdout = new PassThrough();
+    child.stderr = new PassThrough();
+    child.stdin = new PassThrough();
+    child.kill = () => true;
+    process.nextTick(() => child.emit("close", 0));
+    return child as ChildProcess;
+  };
+}
+
+afterEach(() => {
+  __setProofModeVerifierSpawnImplForTests(undefined);
+});
+
+function readToolText(result: unknown): string {
+  const content = (result as { content?: Array<{ type?: string; text?: string }> })?.content;
+  if (!Array.isArray(content) || content.length === 0 || content[0]?.type !== "text") {
+    throw new Error("Expected text content from MCP tool result.");
+  }
+  return content[0].text ?? "";
+}
 
 async function withValidationRunsRoot<T>(fn: (runsRoot: string) => Promise<T>): Promise<T> {
   const previousRunsRoot = process.env.MARTIN_RUNS_DIR;
@@ -442,5 +476,149 @@ describe("server validation", () => {
 
     expect(normalizedServerSource).toContain('name: "martin_get_attempt"');
     expect(normalizedServerSource).toMatch(/attemptIndex:\s*\{\s*type:\s*"integer",\s*minimum:\s*1,/m);
+  });
+
+  it("blocks martin_run before spend when the MCP receipt chain is missing", async () => {
+    await withValidationRunsRoot(async () => {
+      await withValidationWorkspaceRoot(async () => {
+        const server = createMartinMcpServer() as unknown as ServerWithRequestHandlers;
+        const callTool = server._requestHandlers.get("tools/call");
+
+        const result = await callTool?.(
+          {
+            method: "tools/call",
+            params: {
+              name: "martin_run",
+              arguments: {
+                objective: "Repair the failing MCP lane",
+                engine: "codex",
+                verificationPlan: ["pnpm --filter @martinloop/mcp test"],
+                maxUsd: 2,
+                maxIterations: 1
+              }
+            }
+          },
+          {}
+        );
+
+        expect(result).toMatchObject({
+          isError: true,
+          _meta: {
+            "martinloop/errorCode": "policy_blocked",
+            "martinloop/errorCategory": "policy_blocked"
+          }
+        });
+      });
+    });
+  });
+
+  it("accepts a matching doctor-plan-preflight receipt chain for martin_run when maxUsd is below the default soft limit", async () => {
+    await withValidationRunsRoot(async () => {
+      await withValidationWorkspaceRoot(async (workspaceRoot) => {
+        const previousLive = process.env.MARTIN_LIVE;
+        process.env.MARTIN_LIVE = "false";
+        const verifierCalls: Array<{ command: string; args: readonly string[]; options?: SpawnOptions }> = [];
+        __setProofModeVerifierSpawnImplForTests(createImmediateSpawn(verifierCalls));
+
+        try {
+          const server = createMartinMcpServer() as unknown as ServerWithRequestHandlers;
+          const callTool = server._requestHandlers.get("tools/call");
+          if (!callTool) {
+            throw new Error("Expected tools/call request handler.");
+          }
+
+          const doctorResult = await callTool(
+            {
+              method: "tools/call",
+              params: {
+                name: "martin_doctor",
+                arguments: {
+                  workingDirectory: workspaceRoot,
+                  engine: "claude"
+                }
+              }
+            },
+            {}
+          );
+          expect((doctorResult as { isError?: boolean }).isError).not.toBe(true);
+
+          const planResult = await callTool(
+            {
+              method: "tools/call",
+              params: {
+                name: "martin_plan",
+                arguments: {
+                  objective: "Summarize the current runtime state",
+                  workingDirectory: workspaceRoot
+                }
+              }
+            },
+            {}
+          );
+          expect((planResult as { isError?: boolean }).isError).not.toBe(true);
+
+          const preflightResult = await callTool(
+            {
+              method: "tools/call",
+              params: {
+                name: "martin_preflight",
+                arguments: {
+                  objective: "Summarize the current runtime state",
+                  workingDirectory: workspaceRoot,
+                  engine: "claude",
+                  verificationPlan: ["node --version"],
+                  maxUsd: 1,
+                  maxIterations: 1,
+                  allowedPaths: ["src/**"],
+                  deniedPaths: ["docs/**"]
+                }
+              }
+            },
+            {}
+          );
+
+          expect((preflightResult as { isError?: boolean }).isError).not.toBe(true);
+          expect(JSON.parse(readToolText(preflightResult)).normalized.budget.softLimitUsd).toBe(1);
+
+          const runResult = await callTool(
+            {
+              method: "tools/call",
+              params: {
+                name: "martin_run",
+                arguments: {
+                  objective: "Summarize the current runtime state",
+                  workingDirectory: workspaceRoot,
+                  engine: "claude",
+                  verificationPlan: ["node --version"],
+                  maxUsd: 1,
+                  maxIterations: 1,
+                  allowedPaths: ["src/**"],
+                  deniedPaths: ["docs/**"]
+                }
+              }
+            },
+            {}
+          );
+
+          expect((runResult as { isError?: boolean }).isError).not.toBe(true);
+          expect(JSON.parse(readToolText(runResult))).toMatchObject({
+            budget: {
+              maxUsd: 1,
+              softLimitUsd: 1,
+              maxIterations: 1
+            }
+          });
+          expect(verifierCalls).toHaveLength(1);
+          expect(verifierCalls[0]?.command).toBe("node");
+          expect(verifierCalls[0]?.args).toEqual(["--version"]);
+        } finally {
+          if (previousLive === undefined) {
+            delete process.env.MARTIN_LIVE;
+          } else {
+            process.env.MARTIN_LIVE = previousLive;
+          }
+        }
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary
- improve Codex launcher selection so Windows can choose a working native runtime instead of getting stuck on shims
- surface explicit receipt scope and host diagnostics across CLI and MCP proof surfaces
- keep WSL/Linux fail-closed when Codex resolves to a Windows-hosted install

## What changed
- refactor the Codex launcher to order candidates intentionally and stop probing once a working runtime is found
- thread the selected Codex command through CLI and MCP run paths so the proven runtime is the one that executes
- limit deep Codex launch probing in generic health checks to cases where Codex is the requested engine
- harden CLI and MCP tests around launch diagnostics, receipt scope, and tamper-aware persisted run reads

## Validation
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm public:copy-scan`
- `pnpm public:git-surface`
- `pnpm oss:validate`
- `pnpm public:smoke`
- `pnpm release:matrix:local`

## Live proof
- Windows: verified `doctor`, `session-start`, and `preflight` select a working native Codex runtime; completed a real governed one-file fix and verified the repo test passes after the run
- WSL: verified `doctor` and `preflight` fail closed before spend when Codex resolves to a Windows-mounted install and return native-install remediation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Receipt-scope propagation across doctor, preflight, run and CLI sessions; richer run gating with scope/path/budget constraints.
  * Expanded Codex diagnostics and command probing with candidate discovery, probe summaries, and command override support.

* **Bug Fixes**
  * More reliable CLI adapter behavior for structured completions and clearer failure paths.
  * Fixed Windows subprocess invocation/argument handling.

* **Improvements**
  * Skip unnecessary git reads when no verification steps; richer doctor/preflight engine diagnostics and outputs.

* **Tests**
  * Broadened test coverage and new integration cases for governance, Codex probing, and verifier injection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->