### PR TITLE
Make public benchmarks reproducible

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ martin-loop session-start [--host <claude|codex|gemini|generic>]
 martin-loop phase status|contract|session-start|preflight|run [--execute]
 martin-loop preflight <objective> [options]
 martin-loop run <objective> [options]
+martin-loop bench --suite <suiteId>
 martin-loop triage
 martin-loop dossier (--latest | --loop-id <id> | --file <path>)
 martin-loop runs list|get|attempt|verify ...
@@ -81,6 +82,29 @@ Examples below use `npx martin-loop` so they work without a global install. If y
 Use `martin-loop share --latest` after `dossier` when you want a redacted bundle you can hand to another person without sending raw run-store files.
 
 More detail: [CLI reference](./docs/reference/cli.md) and [configuration reference](./docs/reference/config.md).
+
+## Benchmarks
+
+MartinLoop ships a public deterministic benchmark workspace in `benchmarks/` plus the installed-package `bench` command.
+
+From an installed package:
+
+```sh
+npx martin-loop bench --suite under-3-challenge
+npx martin-loop bench --suite ralphy-engineering-50
+```
+
+From a clean public clone:
+
+```sh
+pnpm install --frozen-lockfile
+pnpm --filter @martin/benchmarks build
+pnpm --filter @martin/benchmarks test
+pnpm --filter @martin/benchmarks eval
+pnpm --filter @martin/benchmarks report:ralphy
+```
+
+The installed-package command reads the shipped public fixtures. The repo-clone workflow runs the public benchmark workspace directly.
 
 ## MCP
 

--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "description": "Public deterministic benchmark harness for MartinLoop OSS claims.",
   "scripts": {
+    "prebuild": "pnpm --filter @martin/contracts build && pnpm --filter @martin/core build",
     "build": "tsc -p tsconfig.build.json",
     "test": "vitest run",
     "lint": "tsc -p tsconfig.json --noEmit",

--- a/docs/concepts/under-3-challenge.md
+++ b/docs/concepts/under-3-challenge.md
@@ -28,10 +28,12 @@ That makes a coding-agent result easier to trust, replay, compare, and audit.
 
 ## Try The Demo
 
+Canonical public benchmark inputs live at `benchmarks/fixtures/under-3-challenge.json`.
+
 ```sh
-npx martin-loop demo
-cd martin-loop-demo
-npm install
-npx martin-loop run "Summarize the demo workspace and confirm the verifier is green" --proof --verify "npm test"
-npx martin-loop dossier --latest
+npx martin-loop bench --suite under-3-challenge
+pnpm install --frozen-lockfile
+pnpm --filter @martin/benchmarks build
+pnpm --filter @martin/benchmarks test
+pnpm --filter @martin/benchmarks eval
 ```

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -11,6 +11,7 @@ martin-loop session-start [--host <claude|codex|gemini|generic>]
 martin-loop phase status|contract|session-start|preflight|run [--execute]
 martin-loop preflight <objective> [options]
 martin-loop run <objective> [options]
+martin-loop bench --suite <suiteId>
 martin-loop triage
 martin-loop dossier (--latest | --loop-id <id> | --file <path>)
 martin-loop inspect --file <path>
@@ -62,6 +63,25 @@ npx martin-loop share --latest
 --workspace <id>        Workspace ID for the run record
 --project <id>          Project ID for the run record
 --metadata <key=value>  Attach metadata to the run record; repeatable
+```
+
+## Benchmark Reproduction
+
+Use `bench` when you want the shipped public benchmark summary from an installed package:
+
+```sh
+npx martin-loop bench --suite under-3-challenge
+npx martin-loop bench --suite ralphy-engineering-50
+```
+
+Use the public benchmark workspace when you want clean-clone repro from the repository:
+
+```sh
+pnpm install --frozen-lockfile
+pnpm --filter @martin/benchmarks build
+pnpm --filter @martin/benchmarks test
+pnpm --filter @martin/benchmarks eval
+pnpm --filter @martin/benchmarks report:ralphy
 ```
 
 ## Shared persisted-run options

--- a/docs/release/OSS-0.2.10-RELEASE-NOTES.md
+++ b/docs/release/OSS-0.2.10-RELEASE-NOTES.md
@@ -9,7 +9,7 @@ MartinLoop `0.2.10` is the public trust hotfix for the root package. It closes t
 - If adapter output says a tool or verifier failed before execution but MartinLoop’s own verifier passed, MartinLoop now records that contradiction as a warning instead of presenting a silent clean pass.
 - `doctor`, `session-start`, `preflight`, `run`, `dossier`, and `badge` now honor the same explicit `--runs-dir` target.
 - `run --help` and `preflight --help` now exit cleanly before governed-flow checks.
-- Public help/version output now reports the published root `martin-loop` version, and `bench` is not part of the public `0.2.10` CLI surface while the portable harness is being prepared.
+- Public help/version output now reports the published root `martin-loop` version, without changing the `0.2.10` hotfix scope.
 - `--unsafe-allow-unguarded-run` remains available as an explicit local override when an operator intentionally needs to bypass the guarded flow for one run.
 - The public root tarball still excludes the vendored CLI bin manifest, and the same `root-release-guard` remains in the release gate.
 

--- a/docs/release/VERSION-LEDGER.md
+++ b/docs/release/VERSION-LEDGER.md
@@ -12,7 +12,7 @@ This file is the release source of truth for package/version mapping in this rep
   - `0.2.9` fixed proof-run classification, Windows `.cmd` resolution, and public provider defaults
   - `0.2.10` tightened verifier evidence, `--runs-dir` consistency, and public help output
   - `0.2.11` fixed `runs verify --latest` selector parity in the public CLI
-- next planned root release: `0.3.0` for shareable run receipts
+- current in-repo root release line: `0.3.0` for shareable run receipts, benchmark reproducibility, and public trust proofs
 - next planned root follow-on: `0.3.1` for multi-model and multi-IDE compatibility
 
 ## Standalone package: `@martinloop/mcp`

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -11,8 +11,10 @@ The CLI now treats execution, diagnosis, persisted-run inspection, and MCP host 
 - `martin phase status|contract|preflight|run`
 - `martin preflight`
 - `martin run`
+- `martin bench`
 - `martin triage`
 - `martin dossier`
+- `martin challenge`
 - `martin share`
 - `martin runs list|get|attempt|verify`
 - `martin mcp print-config`
@@ -62,6 +64,25 @@ martin mcp print-config --host codex --profile minimal
 `martin session-start` and `martin phase` are local-first command-center helpers. They read local phase state and local MartinLoop run receipts, then produce an explicit run contract before any work is executed. Existing `.gsd` workspaces are imported as a compatibility format when present. `martin phase preflight` and `martin phase run` are dry-run by default; add `--execute` only after the generated contract has the right verifier, budget, allowed paths, and blocked paths.
 
 `martin share --latest` is the handoff step. It writes a redacted JSON receipt, a Markdown summary, and a proof-card SVG for the selected run.
+
+## Benchmarks
+
+Use the installed CLI for the shipped public summaries:
+
+```sh
+npx martin-loop bench --suite under-3-challenge
+npx martin-loop bench --suite ralphy-engineering-50
+```
+
+Use the repo workspace when you want deterministic repro from source:
+
+```sh
+pnpm install --frozen-lockfile
+pnpm --filter @martin/benchmarks build
+pnpm --filter @martin/benchmarks test
+pnpm --filter @martin/benchmarks eval
+pnpm --filter @martin/benchmarks report:ralphy
+```
 
 ## Compatibility aliases
 

--- a/packages/mcp/src/tools/run-loop.ts
+++ b/packages/mcp/src/tools/run-loop.ts
@@ -8,7 +8,13 @@ import {
   type SpawnLike
 } from "@martin/adapters";
 
-import { createFileRunStore, evaluateCostGovernor, resolveRunsRoot, runMartin } from "@martin/core";
+import {
+  createFileRunStore,
+  evaluateCostGovernor,
+  resolveRunsRoot,
+  runMartin,
+  type RunStore
+} from "@martin/core";
 import type { LoopBudget, ReceiptScope } from "@martin/contracts";
 
 import { normalizeSafePathPatterns, resolveSafeRepoRoot } from "../server-validation.js";
@@ -68,9 +74,14 @@ export interface RunLoopOutput {
 }
 
 let proofModeVerifierSpawnImpl: SpawnLike | undefined;
+let runStoreOverrideForTests: RunStore | undefined;
 
 export function __setProofModeVerifierSpawnImplForTests(spawnImpl?: SpawnLike): void {
   proofModeVerifierSpawnImpl = spawnImpl;
+}
+
+export function __setRunStoreOverrideForTests(store?: RunStore): void {
+  runStoreOverrideForTests = store;
 }
 
 export async function runLoopTool(input: RunLoopInput): Promise<RunLoopOutput> {
@@ -157,7 +168,7 @@ export async function runLoopTool(input: RunLoopInput): Promise<RunLoopOutput> {
   const result = await runMartin({
     workspaceId: input.workspaceId ?? "ws_mcp",
     projectId: input.projectId ?? "proj_mcp",
-    store: createFileRunStore({ runsRoot }),
+    store: runStoreOverrideForTests ?? createFileRunStore({ runsRoot }),
     receiptScope,
     task: {
       title: input.objective.slice(0, 100),

--- a/packages/mcp/tests/mcp-tools.test.ts
+++ b/packages/mcp/tests/mcp-tools.test.ts
@@ -5,7 +5,7 @@ import { chmod, mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile } from "n
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { writeReceiptIntegrityMaterial } from "@martin/core";
+import { writeReceiptIntegrityMaterial, type RunStore } from "@martin/core";
 import { createLoopRecord } from "@martin/contracts";
 import type { SpawnLike } from "@martin/adapters";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -18,7 +18,11 @@ import { martinGetVerificationResultsTool } from "../src/tools/get-verification-
 import { martinListRunsTool } from "../src/tools/list-runs.js";
 import { martinPreflightTool } from "../src/tools/preflight.js";
 import { martinRunDossierTool } from "../src/tools/run-dossier.js";
-import { __setProofModeVerifierSpawnImplForTests, runLoopTool } from "../src/tools/run-loop.js";
+import {
+  __setProofModeVerifierSpawnImplForTests,
+  __setRunStoreOverrideForTests,
+  runLoopTool
+} from "../src/tools/run-loop.js";
 import { martinTriageRunsTool } from "../src/tools/triage-runs.js";
 
 // ---------------------------------------------------------------------------
@@ -64,6 +68,16 @@ async function withRunsRoot<T>(fn: (runsRoot: string) => Promise<T>): Promise<T>
       process.env.MARTIN_RUNS_DIR = previousRunsRoot;
     }
 
+    await rm(runsRoot, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+async function withMemoryRunStore<T>(fn: (store: RunStore) => Promise<T>): Promise<T> {
+  const runsRoot = await mkdtemp(join(tmpdir(), "martin-mcp-memory-runs-"));
+
+  try {
+    return await fn(createMemoryRunStore(runsRoot));
+  } finally {
     await rm(runsRoot, { recursive: true, force: true }).catch(() => {});
   }
 }
@@ -122,7 +136,19 @@ function createImmediateSpawn(calls: Array<{ command: string; args: readonly str
 
 afterEach(() => {
   __setProofModeVerifierSpawnImplForTests(undefined);
+  __setRunStoreOverrideForTests(undefined);
 });
+
+function createMemoryRunStore(runsRoot: string): RunStore {
+  return {
+    runsRoot,
+    async initRun() {},
+    async updateState() {},
+    async appendLedger() {},
+    async writeAttemptArtifacts() {},
+    async writeLoopRecord() {}
+  };
+}
 
 // ---------------------------------------------------------------------------
 // martin_status
@@ -1187,17 +1213,21 @@ describe("runLoopTool", () => {
       __setProofModeVerifierSpawnImplForTests(createImmediateSpawn(calls));
 
       try {
-        const result = await runLoopTool({
-          objective: "Validate proof-mode verifier seams",
-          verificationPlan: ["node --version"],
-          maxIterations: 1,
-          maxUsd: 1
-        });
+        await withMemoryRunStore(async (store) => {
+          __setRunStoreOverrideForTests(store);
 
-        expect(result.loopId).toMatch(/^loop_/u);
-        expect(calls).toHaveLength(1);
-        expect(calls[0]?.command).toBe("node");
-        expect(calls[0]?.args).toEqual(["--version"]);
+          const result = await runLoopTool({
+            objective: "Validate proof-mode verifier seams",
+            verificationPlan: ["node --version"],
+            maxIterations: 1,
+            maxUsd: 1
+          });
+
+          expect(result.loopId).toMatch(/^loop_/u);
+          expect(calls).toHaveLength(1);
+          expect(calls[0]?.command).toBe("node");
+          expect(calls[0]?.args).toEqual(["--version"]);
+        });
       } finally {
         if (originalEnv === undefined) {
           delete process.env.MARTIN_LIVE;
@@ -1244,14 +1274,18 @@ describe("runLoopTool", () => {
     process.env.MARTIN_LIVE = "false";
 
     try {
-      const result = await runLoopTool({
-        objective: "Fix the bug",
-        workspaceId: "ws_custom",
-        projectId: "proj_custom",
-        maxIterations: 1
-      });
+      await withMemoryRunStore(async (store) => {
+        __setRunStoreOverrideForTests(store);
 
-      expect(result.loopId).toBeTruthy();
+        const result = await runLoopTool({
+          objective: "Fix the bug",
+          workspaceId: "ws_custom",
+          projectId: "proj_custom",
+          maxIterations: 1
+        });
+
+        expect(result.loopId).toBeTruthy();
+      });
     } finally {
       if (originalEnv === undefined) {
         delete process.env.MARTIN_LIVE;

--- a/packages/mcp/tests/server-validation.test.ts
+++ b/packages/mcp/tests/server-validation.test.ts
@@ -21,7 +21,10 @@ import {
   resolveTrustedLoopRepoRoot,
   validateToolInput
 } from "../src/server-validation.js";
-import { __setProofModeVerifierSpawnImplForTests } from "../src/tools/run-loop.js";
+import {
+  __setProofModeVerifierSpawnImplForTests,
+  __setRunStoreOverrideForTests
+} from "../src/tools/run-loop.js";
 import { createMartinMcpServer } from "../src/server.js";
 
 type ServerRequestHandler = (request: unknown, extra: unknown) => Promise<unknown>;
@@ -48,7 +51,29 @@ function createImmediateSpawn(calls: Array<{ command: string; args: readonly str
 
 afterEach(() => {
   __setProofModeVerifierSpawnImplForTests(undefined);
+  __setRunStoreOverrideForTests(undefined);
 });
+
+function createMemoryRunStore(runsRoot: string) {
+  return {
+    runsRoot,
+    async initRun() {},
+    async updateState() {},
+    async appendLedger() {},
+    async writeAttemptArtifacts() {},
+    async writeLoopRecord() {}
+  };
+}
+
+async function withMemoryRunStore<T>(fn: (runsRoot: string) => Promise<T>): Promise<T> {
+  const runsRoot = await mkdtemp(join(tmpdir(), "martin-mcp-memory-runs-"));
+
+  try {
+    return await fn(runsRoot);
+  } finally {
+    await rm(runsRoot, { recursive: true, force: true }).catch(() => {});
+  }
+}
 
 function readToolText(result: unknown): string {
   const content = (result as { content?: Array<{ type?: string; text?: string }> })?.content;
@@ -521,96 +546,100 @@ describe("server validation", () => {
         __setProofModeVerifierSpawnImplForTests(createImmediateSpawn(verifierCalls));
 
         try {
-          const server = createMartinMcpServer() as unknown as ServerWithRequestHandlers;
-          const callTool = server._requestHandlers.get("tools/call");
-          if (!callTool) {
-            throw new Error("Expected tools/call request handler.");
-          }
+          await withMemoryRunStore(async (memoryRunsRoot) => {
+            __setRunStoreOverrideForTests(createMemoryRunStore(memoryRunsRoot));
 
-          const doctorResult = await callTool(
-            {
-              method: "tools/call",
-              params: {
-                name: "martin_doctor",
-                arguments: {
-                  workingDirectory: workspaceRoot,
-                  engine: "claude"
-                }
-              }
-            },
-            {}
-          );
-          expect((doctorResult as { isError?: boolean }).isError).not.toBe(true);
-
-          const planResult = await callTool(
-            {
-              method: "tools/call",
-              params: {
-                name: "martin_plan",
-                arguments: {
-                  objective: "Summarize the current runtime state",
-                  workingDirectory: workspaceRoot
-                }
-              }
-            },
-            {}
-          );
-          expect((planResult as { isError?: boolean }).isError).not.toBe(true);
-
-          const preflightResult = await callTool(
-            {
-              method: "tools/call",
-              params: {
-                name: "martin_preflight",
-                arguments: {
-                  objective: "Summarize the current runtime state",
-                  workingDirectory: workspaceRoot,
-                  engine: "claude",
-                  verificationPlan: ["node --version"],
-                  maxUsd: 1,
-                  maxIterations: 1,
-                  allowedPaths: ["src/**"],
-                  deniedPaths: ["docs/**"]
-                }
-              }
-            },
-            {}
-          );
-
-          expect((preflightResult as { isError?: boolean }).isError).not.toBe(true);
-          expect(JSON.parse(readToolText(preflightResult)).normalized.budget.softLimitUsd).toBe(1);
-
-          const runResult = await callTool(
-            {
-              method: "tools/call",
-              params: {
-                name: "martin_run",
-                arguments: {
-                  objective: "Summarize the current runtime state",
-                  workingDirectory: workspaceRoot,
-                  engine: "claude",
-                  verificationPlan: ["node --version"],
-                  maxUsd: 1,
-                  maxIterations: 1,
-                  allowedPaths: ["src/**"],
-                  deniedPaths: ["docs/**"]
-                }
-              }
-            },
-            {}
-          );
-
-          expect((runResult as { isError?: boolean }).isError).not.toBe(true);
-          expect(JSON.parse(readToolText(runResult))).toMatchObject({
-            budget: {
-              maxUsd: 1,
-              softLimitUsd: 1,
-              maxIterations: 1
+            const server = createMartinMcpServer() as unknown as ServerWithRequestHandlers;
+            const callTool = server._requestHandlers.get("tools/call");
+            if (!callTool) {
+              throw new Error("Expected tools/call request handler.");
             }
+
+            const doctorResult = await callTool(
+              {
+                method: "tools/call",
+                params: {
+                  name: "martin_doctor",
+                  arguments: {
+                    workingDirectory: workspaceRoot,
+                    engine: "claude"
+                  }
+                }
+              },
+              {}
+            );
+            expect((doctorResult as { isError?: boolean }).isError).not.toBe(true);
+
+            const planResult = await callTool(
+              {
+                method: "tools/call",
+                params: {
+                  name: "martin_plan",
+                  arguments: {
+                    objective: "Summarize the current runtime state",
+                    workingDirectory: workspaceRoot
+                  }
+                }
+              },
+              {}
+            );
+            expect((planResult as { isError?: boolean }).isError).not.toBe(true);
+
+            const preflightResult = await callTool(
+              {
+                method: "tools/call",
+                params: {
+                  name: "martin_preflight",
+                  arguments: {
+                    objective: "Summarize the current runtime state",
+                    workingDirectory: workspaceRoot,
+                    engine: "claude",
+                    verificationPlan: ["node --version"],
+                    maxUsd: 1,
+                    maxIterations: 1,
+                    allowedPaths: ["src/**"],
+                    deniedPaths: ["docs/**"]
+                  }
+                }
+              },
+              {}
+            );
+
+            expect((preflightResult as { isError?: boolean }).isError).not.toBe(true);
+            expect(JSON.parse(readToolText(preflightResult)).normalized.budget.softLimitUsd).toBe(1);
+
+            const runResult = await callTool(
+              {
+                method: "tools/call",
+                params: {
+                  name: "martin_run",
+                  arguments: {
+                    objective: "Summarize the current runtime state",
+                    workingDirectory: workspaceRoot,
+                    engine: "claude",
+                    verificationPlan: ["node --version"],
+                    maxUsd: 1,
+                    maxIterations: 1,
+                    allowedPaths: ["src/**"],
+                    deniedPaths: ["docs/**"]
+                  }
+                }
+              },
+              {}
+            );
+
+            expect((runResult as { isError?: boolean }).isError).not.toBe(true);
+            expect(JSON.parse(readToolText(runResult))).toMatchObject({
+              budget: {
+                maxUsd: 1,
+                softLimitUsd: 1,
+                maxIterations: 1
+              }
+            });
+            expect(verifierCalls).toHaveLength(1);
+            expect(verifierCalls[0]?.command).toBe("node");
+            expect(verifierCalls[0]?.args).toEqual(["--version"]);
           });
-          expect(verifierCalls).toHaveLength(1);
-          expect(verifierCalls[0]?.command).toBe("node");
-          expect(verifierCalls[0]?.args).toEqual(["--version"]);
         } finally {
           if (previousLive === undefined) {
             delete process.env.MARTIN_LIVE;

--- a/scripts/tests/benchmarks-workspace.test.mjs
+++ b/scripts/tests/benchmarks-workspace.test.mjs
@@ -1,0 +1,104 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile, rm, access } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawn } from "node:child_process";
+
+const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+function run(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const spawnPlan =
+      process.platform === "win32"
+        ? {
+            command: process.env.ComSpec ?? "cmd.exe",
+            args: ["/d", "/s", "/c", [command, ...args].map(quoteForCmd).join(" ")],
+          }
+        : {
+            command,
+            args,
+          };
+
+    const child = spawn(spawnPlan.command, spawnPlan.args, {
+      cwd: ROOT_DIR,
+      stdio: ["ignore", "pipe", "pipe"],
+      shell: false,
+      env: {
+        ...process.env,
+        CI: "true",
+        ...(options.env ?? {}),
+      },
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve({ stdout, stderr });
+        return;
+      }
+
+      reject(
+        new Error(
+          `${command} ${args.join(" ")} failed with exit code ${String(code)}\nstdout:\n${stdout}\nstderr:\n${stderr}`
+        )
+      );
+    });
+  });
+}
+
+function quoteForCmd(value) {
+  if (!/[\s"]/u.test(value)) {
+    return value;
+  }
+
+  return `"${value.replace(/"/g, '""')}"`;
+}
+
+test("benchmark workspace cold-builds from a fresh dependency state", async () => {
+  const pathsToReset = [
+    path.join(ROOT_DIR, "packages", "contracts", "dist"),
+    path.join(ROOT_DIR, "packages", "core", "dist"),
+    path.join(ROOT_DIR, "benchmarks", "dist"),
+  ];
+
+  for (const target of pathsToReset) {
+    await rm(target, { recursive: true, force: true });
+  }
+
+  await run("pnpm", ["--filter", "@martin/benchmarks", "build"]);
+
+  await access(path.join(ROOT_DIR, "packages", "contracts", "dist", "index.d.ts"));
+  await access(path.join(ROOT_DIR, "packages", "core", "dist", "index.d.ts"));
+  await access(path.join(ROOT_DIR, "benchmarks", "dist", "index.js"));
+});
+
+test("public benchmark docs align to the shipped benchmark commands", async () => {
+  const readme = await readFile(path.join(ROOT_DIR, "README.md"), "utf8");
+  const cliReference = await readFile(path.join(ROOT_DIR, "docs", "reference", "cli.md"), "utf8");
+  const cliReadme = await readFile(path.join(ROOT_DIR, "packages", "cli", "README.md"), "utf8");
+  const challengeDoc = await readFile(path.join(ROOT_DIR, "docs", "concepts", "under-3-challenge.md"), "utf8");
+
+  for (const contents of [readme, cliReference, cliReadme, challengeDoc]) {
+    assert.match(contents, /under-3-challenge/);
+  }
+
+  assert.match(readme, /npx martin-loop bench --suite under-3-challenge/);
+  assert.match(readme, /pnpm install --frozen-lockfile/);
+  assert.match(readme, /pnpm --filter @martin\/benchmarks build/);
+  assert.match(cliReference, /martin-loop bench --suite <suiteId>/);
+  assert.match(cliReference, /pnpm install --frozen-lockfile/);
+  assert.match(cliReadme, /npx martin-loop bench --suite ralphy-engineering-50/);
+  assert.match(cliReadme, /pnpm install --frozen-lockfile/);
+  assert.match(challengeDoc, /pnpm install --frozen-lockfile/);
+  assert.match(challengeDoc, /benchmarks\/fixtures\/under-3-challenge\.json/);
+});

--- a/scripts/tests/mcp-release-docs.test.mjs
+++ b/scripts/tests/mcp-release-docs.test.mjs
@@ -32,7 +32,7 @@ test("version ledger records live public truth and the next release train", asyn
   for (const requiredText of [
     "root public baseline: `0.2.11`",
     "standalone MCP public baseline: `0.3.0`",
-    "next planned root release: `0.3.0`",
+    "current in-repo root release line: `0.3.0`",
     "next planned root follow-on: `0.3.1`",
     "next planned standalone release: `0.3.1`",
     "`0.3.2` opt-in execution controls"

--- a/scripts/tests/readme-public-surface.test.mjs
+++ b/scripts/tests/readme-public-surface.test.mjs
@@ -104,6 +104,7 @@ test("root README is a public product entry point", async () => {
     "## What It Does",
     "## How It Works",
     "## CLI",
+    "## Benchmarks",
     "## MCP",
     "## SDK",
     "## Examples",
@@ -124,6 +125,9 @@ test("root README is a public product entry point", async () => {
   assert.match(readme, /npx martin-loop demo/);
   assert.match(readme, /npx martin-loop run .* --proof --verify "npm test"/);
   assert.match(readme, /npx martin-loop dossier --latest/);
+  assert.match(readme, /npx martin-loop bench --suite under-3-challenge/);
+  assert.match(readme, /pnpm --filter @martin\/benchmarks build/);
+  assert.match(readme, /pnpm --filter @martin\/benchmarks eval/);
   assert.match(readme, /npx -y @martinloop\/mcp/);
   assert.match(readme, /import \{ MartinLoop, createClaudeCliAdapter \} from "martin-loop"/);
   assert.match(readme, new RegExp(`docs/release/OSS-${manifest.version.replace(/\./g, "\\.")}-RELEASE-NOTES\\.md`));


### PR DESCRIPTION
## Summary
- make the public benchmark workspace cold-buildable from a clean clone by building its contract/core deps before benchmark build
- align README, CLI docs, challenge docs, and release/version docs to the shipped public benchmark and root release surface
- harden MCP proof-mode contract tests with an isolated run-store seam so the public release gates stay green without repo pollution

## Validation
- pnpm lint
- pnpm test
- pnpm build
- pnpm public:copy-scan
- pnpm public:git-surface
- pnpm oss:validate
- pnpm public:smoke
- pnpm release:matrix:local
- clean-clone proof from temp repo copy:
  - pnpm install --frozen-lockfile
  - pnpm --filter @martin/benchmarks build
  - pnpm --filter @martin/benchmarks test
  - pnpm --filter @martin/benchmarks eval
  - pnpm --filter @martin/benchmarks report:ralphy
  - pnpm build
  - pnpm exec node .\\dist\\bin\\martin-loop.js bench --suite under-3-challenge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added benchmark functionality via `martin-loop bench --suite` command for deterministic performance testing.
  * Introduced "under-3-challenge" benchmark suite for reproducible evaluation.

* **Documentation**
  * Updated CLI reference and README with benchmark command documentation.
  * Added benchmarks section with instructions for installed and repository-based workflows.

* **Chores**
  * Updated root package version to 0.3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->