### PR TITLE
Fix benchmark repro reliability and clarify trust boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ Release notes for the current root package: [MartinLoop 0.3.0](./docs/release/OS
 | Safety and verification | Scope checks, verifier command checks, prompt integrity, and grounding decide whether work can continue. |
 | Persistence | JSONL run records, evidence summaries, and repo-backed artifacts make every run inspectable later. Each loop record is locally signed (HMAC, per-runs-root key) and `dossier`/`runs get`/`runs verify`/`challenge`/`badge` report an `integrity` verdict (`verified` / `tamper_detected` / `unsigned`) so post-hoc edits to a record are detectable, not just inspectable. |
 
+## Trust Boundaries
+
+- Cost and token outputs always include provenance (`actual`, `estimated`, or `unavailable`).
+- For Codex specifically, MartinLoop reports authoritative usage only when the host exposes it; otherwise MartinLoop labels usage as estimated and avoids presenting it as settled accounting.
+- Receipt integrity must be `verified` before a run is treated as trustworthy evidence for external review.
+
 ## CLI
 
 ```text
@@ -98,6 +104,14 @@ From a clean public clone:
 
 ```sh
 pnpm install --frozen-lockfile
+pnpm bench:build
+pnpm bench:eval
+pnpm bench:report:ralphy
+```
+
+Equivalent workspace-filter commands:
+
+```sh
 pnpm --filter @martin/benchmarks build
 pnpm --filter @martin/benchmarks test
 pnpm --filter @martin/benchmarks eval

--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -9,9 +9,11 @@
     "build": "tsc -p tsconfig.build.json",
     "test": "vitest run",
     "lint": "tsc -p tsconfig.json --noEmit",
-    "eval": "tsx src/eval.ts --suite under-3-challenge",
-    "eval:phase12": "tsx src/eval.ts --suite under-3-challenge",
-    "report:ralphy": "tsx src/eval.ts --suite ralphy-engineering-50"
+    "preeval": "pnpm build",
+    "eval": "node dist/eval.js --suite under-3-challenge",
+    "eval:phase12": "node dist/eval.js --suite under-3-challenge",
+    "prereport:ralphy": "pnpm build",
+    "report:ralphy": "node dist/eval.js --suite ralphy-engineering-50"
   },
   "dependencies": {
     "@martin/contracts": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,10 @@
   },
   "scripts": {
     "build": "pnpm --filter @martin/contracts build && pnpm --filter @martin/core build && pnpm --filter @martin/adapters build && pnpm --filter @martin/benchmarks build && pnpm --filter @martin/cli build && pnpm --filter @martinloop/mcp build && node ./scripts/build-public-facade.mjs",
+    "bench:build": "pnpm --filter @martin/benchmarks build",
+    "bench:test": "pnpm --filter @martin/benchmarks test",
+    "bench:eval": "pnpm --filter @martin/benchmarks eval",
+    "bench:report:ralphy": "pnpm --filter @martin/benchmarks report:ralphy",
     "prepack": "pnpm build && node ./scripts/root-release-guard.mjs --pack",
     "test": "pnpm -r --workspace-concurrency=1 test && node --test scripts/tests/*.mjs",
     "lint": "pnpm -r lint",

--- a/scripts/tests/benchmarks-workspace.test.mjs
+++ b/scripts/tests/benchmarks-workspace.test.mjs
@@ -82,6 +82,14 @@ test("benchmark workspace cold-builds from a fresh dependency state", async () =
   await access(path.join(ROOT_DIR, "benchmarks", "dist", "index.js"));
 });
 
+test("benchmark eval and report commands run through public workspace commands", async () => {
+  const evalResult = await run("pnpm", ["--filter", "@martin/benchmarks", "eval"]);
+  const reportResult = await run("pnpm", ["--filter", "@martin/benchmarks", "report:ralphy"]);
+
+  assert.match(evalResult.stdout, /Under-\$3 Challenge/u);
+  assert.match(reportResult.stdout, /Ralph Loop Stress Report/u);
+});
+
 test("public benchmark docs align to the shipped benchmark commands", async () => {
   const readme = await readFile(path.join(ROOT_DIR, "README.md"), "utf8");
   const cliReference = await readFile(path.join(ROOT_DIR, "docs", "reference", "cli.md"), "utf8");


### PR DESCRIPTION
Summary:
- make benchmark workspace eval and report commands deterministic by running built JS from dist
- add pre-hooks so benchmark commands self-build dependencies before execution
- add root benchmark scripts for clean-clone reruns: bench:build, bench:test, bench:eval, bench:report:ralphy
- add regression coverage to execute public workspace benchmark commands end-to-end
- document trust boundaries for usage provenance and receipt-integrity gating in the public README

Verification:
- pnpm bench:eval
- pnpm bench:report:ralphy
- node --test scripts/tests/benchmarks-workspace.test.mjs
- node --test scripts/tests/readme-public-surface.test.mjs
- node --test scripts/tests/public-copy-scan.test.mjs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation with Trust Boundaries subsection covering cost/token provenance reporting and receipt verification requirements.
  * Expanded Benchmarks section with explicit script instructions and workspace command examples.

* **Chores**
  * Updated benchmark scripts to execute built output for improved performance.
  * Added benchmark workspace commands to root-level scripts.
  * Added verification tests for benchmark workflow execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->