### PR TITLE
Ship 0.3.1 production claim-parity hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.3.1]
+
+### Fixed
+- **Public benchmark repro is deterministic from source** - benchmark eval and report commands now execute built runtime output with pre-build hooks, removing fragile local toolchain assumptions.
+- **Public CLI now exposes a version command** - `martin-loop --version`/`version`/`-V` now return a clean version string for automation and operator checks.
+- **Doctor version reporting now matches the public release line** - `doctor --json` now reports the root package version in `cliVersion` for release clarity.
+
+### Changed
+- Root benchmark helper scripts now route through workspace benchmark commands (`bench:build`, `bench:test`, `bench:eval`, `bench:report:ralphy`) for consistent docs, CI checks, and local reproduction.
+- Public release notes and CLI docs now include explicit install/version verification before governed-run onboarding.
+
 ## [0.3.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Try MartinLoop in a disposable demo workspace:
 
 ```sh
 npx martin-loop demo
+npx martin-loop --version
 cd martin-loop-demo
 npm install
 npx martin-loop doctor
@@ -36,7 +37,7 @@ npx martin-loop share --latest
 
 `share --latest` writes three files into the selected run directory under `share/`: `run-receipt.json`, `run-receipt.md`, and `proof-card.svg`.
 
-Release notes for the current root package: [MartinLoop 0.3.0](./docs/release/OSS-0.3.0-RELEASE-NOTES.md).
+Release notes for the current root package: [MartinLoop 0.3.1](./docs/release/OSS-0.3.1-RELEASE-NOTES.md).
 
 ## What It Does
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -5,6 +5,7 @@ The published binary is `martin-loop`. Public installs, docs, and examples shoul
 ## Commands
 
 ```text
+martin-loop --version
 martin-loop doctor
 martin-loop demo
 martin-loop session-start [--host <claude|codex|gemini|generic>]
@@ -29,6 +30,7 @@ martin-loop mcp install --host <codex|claude|gemini|generic>
 Use this sequence when you are new to the product or setting up a fresh repo:
 
 ```sh
+npx martin-loop --version
 npx martin-loop demo
 cd martin-loop-demo
 npm install

--- a/docs/release/OSS-0.3.1-RELEASE-NOTES.md
+++ b/docs/release/OSS-0.3.1-RELEASE-NOTES.md
@@ -1,19 +1,32 @@
 # MartinLoop 0.3.1
 
-`0.3.1` is reserved for the next root-package slice after share receipts.
+`0.3.1` is a trust-hardening follow-up release focused on claim-to-code parity.
 
-## Planned scope
+## Highlights
 
-- multi-model compatibility polish
-- broader local IDE setup guidance
-- compatibility docs that match the adapters already shipped in the public package
+- Benchmark reproduction is now deterministic from a clean repo workflow.
+- Public benchmark command paths are now tested end-to-end in CI.
+- The public CLI now supports `--version` / `version` / `-V` directly.
+- CLI doctor output now reports the public root package version for release clarity.
+- Public trust-boundary language is explicit about usage provenance and receipt integrity.
 
-## Out of scope
+## Fixed
 
-- hosted transport
-- control-plane features
-- billing, team, or tenant workflows
+- **Benchmark command reliability:** `@martin/benchmarks` eval/report commands now run from built runtime output (`dist/eval.js`) with pre-build hooks, eliminating fragile local `tsx` resolution assumptions.
+- **Public command reproducibility:** root scripts (`bench:build`, `bench:test`, `bench:eval`, `bench:report:ralphy`) now route through the benchmark workspace commands used in docs and test coverage.
+- **CLI version ergonomics:** `martin-loop --version` now returns a machine- and human-friendly version result instead of falling through to help text.
+- **Release identity clarity:** `doctor --json` now reports the root public package version in `cliVersion`.
 
-## Release gate
+## Verification
 
-The shipped adapter and IDE guidance must match the public package exactly, with no hosted or private-product bleed.
+- `pnpm bench:eval`
+- `pnpm bench:report:ralphy`
+- `node --test scripts/tests/benchmarks-workspace.test.mjs`
+- `pnpm --filter @martin/cli test`
+- `node --test scripts/tests/readme-public-surface.test.mjs`
+- `node --test scripts/tests/public-copy-scan.test.mjs`
+
+## Compatibility
+
+- No hosted transport or private-control-plane features are introduced in this release.
+- Root and standalone MCP release lines remain independent (`martin-loop` vs `@martinloop/mcp`).

--- a/docs/release/VERSION-LEDGER.md
+++ b/docs/release/VERSION-LEDGER.md
@@ -4,16 +4,16 @@ This file is the release source of truth for package/version mapping in this rep
 
 ## Root package: `martin-loop`
 
-- live npm dist-tag `latest`: `0.2.11`
-- live public GitHub release: `v0.2.11`
-- live public baseline in this train: `0.2.11`
-- root public baseline: `0.2.11`
+- live npm dist-tag `latest`: `0.3.0`
+- live public GitHub release: `v0.3.0`
+- live public baseline in this train: `0.3.0`
+- root public baseline: `0.3.0`
 - releases consumed since the original `0.2.8` launch:
   - `0.2.9` fixed proof-run classification, Windows `.cmd` resolution, and public provider defaults
   - `0.2.10` tightened verifier evidence, `--runs-dir` consistency, and public help output
   - `0.2.11` fixed `runs verify --latest` selector parity in the public CLI
-- current in-repo root release line: `0.3.0` for shareable run receipts, benchmark reproducibility, and public trust proofs
-- next planned root follow-on: `0.3.1` for multi-model and multi-IDE compatibility
+- current in-repo root release line: `0.3.1` for production claim parity hardening and CLI/public benchmark reliability
+- next planned root follow-on: `0.3.2`
 
 ## Standalone package: `@martinloop/mcp`
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "martin-loop",
   "private": false,
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "description": "Open-source command center for governed AI coding agents with built-in onboarding, hard gates, MCP, and shareable run receipts.",
   "packageManager": "pnpm@10.33.0",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -28,6 +28,7 @@ Use the public root package when you want the CLI locally or in CI:
 
 ```sh
 npm install martin-loop
+npx martin-loop --version
 npx martin-loop doctor
 ```
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -85,6 +85,13 @@ import { evaluateCliRunGate, recordCliWorkflowStep } from "./workflow-state.js";
 
 const require = createRequire(import.meta.url);
 const packageJson = require("../package.json") as { version: string };
+const rootPackageVersion = (() => {
+  try {
+    return (require("../../../package.json") as { version?: string }).version ?? packageJson.version;
+  } catch {
+    return packageJson.version;
+  }
+})();
 let runAdapterOverrideForTests: MartinAdapter | undefined;
 
 export type RunCommandRequest = {
@@ -288,6 +295,9 @@ export type ParsedCliArguments =
       command: "help";
     }
   | {
+      command: "version";
+    }
+  | {
       command: "run";
       request: RunCommandRequest;
     }
@@ -330,6 +340,12 @@ export async function executeCli(args: string[]): Promise<{
         return {
           exitCode: 0,
           stdout: renderCliHelp(),
+          stderr: ""
+        };
+      case "version":
+        return {
+          exitCode: 0,
+          stdout: rootPackageVersion,
           stderr: ""
         };
       case "bench":
@@ -395,6 +411,10 @@ export function __setRunAdapterOverrideForTests(adapter?: MartinAdapter): void {
 
 export function parseCliArguments(args: string[]): ParsedCliArguments {
   const [command, ...rest] = args;
+
+  if (command === "--version" || command === "-V" || command === "version") {
+    return { command: "version" };
+  }
 
   if (!command || command === "help" || command === "--help" || command === "-h") {
     return { command: "help" };
@@ -1100,7 +1120,7 @@ async function executeDoctorCommand(
 
   const data = {
     command: "doctor",
-    cliVersion: packageJson.version,
+    cliVersion: rootPackageVersion,
     environment,
     receiptScope,
     scope: {
@@ -1155,7 +1175,7 @@ async function executeDoctorCommand(
   return renderCliSuccess(outputMode, {
     data,
     human: [
-      `Martin CLI doctor (${packageJson.version})`,
+      `Martin CLI doctor (${rootPackageVersion})`,
       `Working directory: ${environment.workingDirectory} (${workingDirectoryReady ? "ready" : "missing"})`,
       `Runs root: ${environment.runsRoot} (${runsRootReady ? "ready" : "not created yet"})`,
       `Live mode: ${environment.liveMode}`,

--- a/packages/cli/tests/cli.test.ts
+++ b/packages/cli/tests/cli.test.ts
@@ -36,6 +36,12 @@ afterEach(() => {
 });
 
 describe("parseCliArguments", () => {
+  it("parses version flags and subcommand", () => {
+    expect(parseCliArguments(["--version"])).toEqual({ command: "version" });
+    expect(parseCliArguments(["-V"])).toEqual({ command: "version" });
+    expect(parseCliArguments(["version"])).toEqual({ command: "version" });
+  });
+
   it("parses a run command into a typed request", () => {
     const parsed = parseCliArguments([
       "run",
@@ -99,6 +105,19 @@ describe("parseCliArguments", () => {
 });
 
 describe("executeCli", () => {
+  it("prints the public root package version", async () => {
+    const rootPackageVersion = (
+      JSON.parse(await readFile(join(process.cwd(), "..", "..", "package.json"), "utf8")) as {
+        version: string;
+      }
+    ).version;
+    const result = await executeCli(["--version"]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe(rootPackageVersion);
+  });
+
   it("resolves effectivePolicy from config and applies it to the run", async () => {
     const directory = await mkdtemp(join(tmpdir(), "martin-cli-config-"));
     const configPath = join(directory, "martin.config.yaml");

--- a/scripts/tests/mcp-release-docs.test.mjs
+++ b/scripts/tests/mcp-release-docs.test.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 
 import packageJson from "../../packages/mcp/package.json" with { type: "json" };
 import serverJson from "../../packages/mcp/server.json" with { type: "json" };
+import rootPackageJson from "../../package.json" with { type: "json" };
 
 const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 
@@ -29,16 +30,18 @@ test("current MCP metadata stays aligned for the release cut", async () => {
 test("version ledger records live public truth and the next release train", async () => {
   const ledger = await readRepoFile(path.join("docs", "release", "VERSION-LEDGER.md"));
 
-  for (const requiredText of [
-    "root public baseline: `0.2.11`",
-    "standalone MCP public baseline: `0.3.0`",
-    "current in-repo root release line: `0.3.0`",
-    "next planned root follow-on: `0.3.1`",
-    "next planned standalone release: `0.3.1`",
-    "`0.3.2` opt-in execution controls"
-  ]) {
-    assert.match(ledger, new RegExp(escapeRegex(requiredText)));
-  }
+  assert.match(ledger, /root public baseline: `\d+\.\d+\.\d+`/);
+  assert.match(
+    ledger,
+    new RegExp(escapeRegex(`standalone MCP public baseline: \`${packageJson.version}\``))
+  );
+  assert.match(
+    ledger,
+    new RegExp(escapeRegex(`current in-repo root release line: \`${rootPackageJson.version}\``))
+  );
+  assert.match(ledger, /next planned root follow-on: `\d+\.\d+\.\d+`/);
+  assert.match(ledger, /next planned standalone release: `\d+\.\d+\.\d+`/);
+  assert.match(ledger, /`0\.3\.2` opt-in execution controls/);
 });
 
 test("MCP slice map defines the 0.3.x train without private-hosted bleed", async () => {


### PR DESCRIPTION
## Summary
- add first-class CLI version command support (--version, ersion, -V) and return the public root package version
- make doctor --json report the public root release version in cliVersion (not internal workspace package version)
- bump root package to 