### PR TITLE
fix(release): stage MCP 0.3.1 and harden npx version parity

### DIFF
--- a/docs/oss/MCP-FOR-AI-AGENTS.md
+++ b/docs/oss/MCP-FOR-AI-AGENTS.md
@@ -1,6 +1,6 @@
 # MCP For AI Agents
 
-`@martinloop/mcp@0.3.0` is the current public standalone MCP baseline for MartinLoop.
+`@martinloop/mcp@0.3.0` is the live public standalone MCP baseline for MartinLoop. `0.3.1` is staged as the next standalone release line.
 
 It is built for hosts that need a governed local-first workflow, not a vague bag of tools.
 
@@ -62,8 +62,8 @@ claude mcp add --transport stdio --scope user martin-loop -- cmd /c npx -y @mart
 
 ## What comes next in the train
 
-- `0.3.0` focuses on adoption and host onboarding.
-- `0.3.1` focuses on review and handoff.
-- `0.3.2` focuses on opt-in execution controls.
+- `0.3.0` is the live adoption and host-onboarding baseline.
+- `0.3.1` is the staged review-and-handoff follow-up.
+- `0.3.2` stays planned for opt-in execution controls.
 
 None of those slices should imply hosted transport, tenant features, or billing surfaces.

--- a/docs/release/MCP-0.3.1-RELEASE-NOTES.md
+++ b/docs/release/MCP-0.3.1-RELEASE-NOTES.md
@@ -1,12 +1,12 @@
 # @martinloop/mcp 0.3.1
 
-`0.3.1` is the review and handoff release for the standalone MartinLoop MCP server.
+`0.3.1` is the staged review and handoff release for the standalone MartinLoop MCP server.
 
 ## Release story
 
 Make post-run review feel crisp instead of forensic.
 
-## Planned scope
+## Scope in this cut
 
 - stronger dossier and eval guidance
 - clearer triage and publish-readiness prompts
@@ -20,6 +20,6 @@ Make post-run review feel crisp instead of forensic.
 - org policy
 - fleet controls
 
-## Release gate
+## Release gate for ship
 
 A human reviewer or AI host should be able to understand a governed run without reconstructing MartinLoop from raw receipts.

--- a/docs/release/MCP-COMPATIBILITY.md
+++ b/docs/release/MCP-COMPATIBILITY.md
@@ -1,10 +1,10 @@
 # MCP Compatibility
 
-This document describes the compatibility posture for the public standalone MCP line after `@martinloop/mcp@0.3.0`.
+This document describes the compatibility posture for the public standalone MCP line after the live `@martinloop/mcp@0.3.0` baseline and through the staged `0.3.1` follow-up.
 
 ## Current baseline
 
-`0.3.0` is the current public baseline.
+`0.3.0` is the current public baseline. `0.3.1` is the staged review-and-handoff follow-up.
 
 It keeps the standalone server local-first and stdio-first, and it assumes a governed MartinLoop workflow:
 

--- a/docs/release/MCP-DELIVERY-SLICE-MAP.md
+++ b/docs/release/MCP-DELIVERY-SLICE-MAP.md
@@ -1,12 +1,13 @@
 # Martin MCP Release Map
 
-This map defines the next public standalone MCP releases after the live `0.3.0` baseline. The point is to keep each release narrow, legible, and easy to validate.
+This map defines the staged standalone MCP releases after the live `0.3.0` baseline. The point is to keep each release narrow, legible, and easy to validate.
 
 ## Live baseline
 
 - public npm baseline: `0.3.0`
 - public GitHub release baseline: `mcp-v0.3.0`
-- next release to prepare: `0.3.1`
+- in-repo release candidate: `0.3.1`
+- next release to prepare after this cut: `0.3.2`
 
 ## `0.3.1` — Review And Handoff Controls
 

--- a/docs/release/MCP-PUBLISHING.md
+++ b/docs/release/MCP-PUBLISHING.md
@@ -5,7 +5,8 @@ The standalone MCP line is published as its own package. Treat it like a product
 ## Current public truth
 
 - live public standalone release: `@martinloop/mcp@0.3.0`
-- next planned standalone release: `0.3.1`
+- current in-repo standalone release line: `0.3.1`
+- next planned standalone release after this cut: `0.3.2`
 - publish authority: GitHub Actions trusted publishing / OIDC
 
 ## Before publish

--- a/docs/release/VERSION-LEDGER.md
+++ b/docs/release/VERSION-LEDGER.md
@@ -4,16 +4,16 @@ This file is the release source of truth for package/version mapping in this rep
 
 ## Root package: `martin-loop`
 
-- live npm dist-tag `latest`: `0.3.0`
-- live public GitHub release: `v0.3.0`
-- live public baseline in this train: `0.3.0`
-- root public baseline: `0.3.0`
+- live npm dist-tag `latest`: `0.3.1`
+- live public GitHub release: `v0.3.1`
+- live public baseline in this train: `0.3.1`
+- root public baseline: `0.3.1`
 - releases consumed since the original `0.2.8` launch:
   - `0.2.9` fixed proof-run classification, Windows `.cmd` resolution, and public provider defaults
   - `0.2.10` tightened verifier evidence, `--runs-dir` consistency, and public help output
   - `0.2.11` fixed `runs verify --latest` selector parity in the public CLI
 - current in-repo root release line: `0.3.1` for production claim parity hardening and CLI/public benchmark reliability
-- next planned root follow-on: `0.3.2`
+- next planned root follow-on: `0.3.2` for npx invocation parity hardening
 
 ## Standalone package: `@martinloop/mcp`
 
@@ -21,9 +21,10 @@ This file is the release source of truth for package/version mapping in this rep
 - live public GitHub release: `mcp-v0.3.0`
 - live public baseline in this train: `0.3.0`
 - standalone MCP public baseline: `0.3.0`
-- next planned standalone release: `0.3.1` for review and handoff controls
+- current in-repo standalone release line: `0.3.1` for review and handoff controls
+- next planned standalone release: `0.3.2` for opt-in execution controls
 - next planned follow-ons:
-  - `0.3.2` opt-in execution controls
+  - `0.3.3` reserved for additional host-coverage follow-ups
 
 ## Release rules
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,4 +1,5 @@
 import { cp, mkdir, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, isAbsolute, join, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
@@ -85,13 +86,44 @@ import { evaluateCliRunGate, recordCliWorkflowStep } from "./workflow-state.js";
 
 const require = createRequire(import.meta.url);
 const packageJson = require("../package.json") as { version: string };
-const rootPackageVersion = (() => {
+type PackageManifest = {
+  name?: string;
+  version?: string;
+};
+
+function readPackageManifest(path: string): PackageManifest | undefined {
   try {
-    return (require("../../../package.json") as { version?: string }).version ?? packageJson.version;
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as PackageManifest;
+    return parsed;
   } catch {
-    return packageJson.version;
+    return undefined;
   }
-})();
+}
+
+function resolveRootPackageVersion(): string {
+  let cursor = dirname(fileURLToPath(import.meta.url));
+  for (let depth = 0; depth < 10; depth += 1) {
+    const manifest = readPackageManifest(join(cursor, "package.json"));
+    if (manifest?.name === "martin-loop" && typeof manifest.version === "string" && manifest.version.length > 0) {
+      return manifest.version;
+    }
+
+    const parent = dirname(cursor);
+    if (parent === cursor) {
+      break;
+    }
+    cursor = parent;
+  }
+
+  const envVersion = process.env["npm_package_name"] === "martin-loop" ? process.env["npm_package_version"] : undefined;
+  if (typeof envVersion === "string" && envVersion.length > 0) {
+    return envVersion;
+  }
+
+  return packageJson.version;
+}
+
+const rootPackageVersion = resolveRootPackageVersion();
 let runAdapterOverrideForTests: MartinAdapter | undefined;
 
 export type RunCommandRequest = {

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -2,16 +2,16 @@
 
 Governed MCP server for AI coding agents over local stdio.
 
-`@martinloop/mcp@0.3.0` is the current public baseline. It gives hosts one bounded execution entrypoint, strong read-only inspection, clear next-step guidance, and a safer default MartinLoop workflow.
+`@martinloop/mcp@0.3.0` is the live public baseline today. `0.3.1` is the current in-repo release candidate for the next public cut.
 
 This package stays local-first and stdio-first in the public OSS lane.
 
 ## Public release train
 
 - `0.2.7` made the guided MCP workflow easier to adopt and harder to misuse.
-- `0.3.0` is the adoption release that makes host setup and onboarding clearer.
-- `0.3.1` is planned for review and handoff controls.
-- `0.3.2` is planned for opt-in execution controls.
+- `0.3.0` is the live adoption baseline that made host setup and onboarding clearer.
+- `0.3.1` is the review and handoff release candidate currently staged in-repo.
+- `0.3.2` remains the planned follow-on for opt-in execution controls.
 
 ## What ships today
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@martinloop/mcp",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "mcpName": "io.github.Keesan12/martin-loop",
   "private": false,
   "type": "module",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/Keesan12/martin-loop",
     "source": "github"
   },
-  "version": "0.3.0",
+  "version": "0.3.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@martinloop/mcp",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "transport": {
         "type": "stdio"
       }

--- a/packages/mcp/src/package-version.ts
+++ b/packages/mcp/src/package-version.ts
@@ -1,3 +1,3 @@
 // Keep this aligned with packages/mcp/package.json during version bumps so the
 // runtime does not depend on package.json being present in every hosted bundle.
-export const MARTIN_MCP_PACKAGE_VERSION = "0.3.0";
+export const MARTIN_MCP_PACKAGE_VERSION = "0.3.1";

--- a/scripts/tests/mcp-release-docs.test.mjs
+++ b/scripts/tests/mcp-release-docs.test.mjs
@@ -19,7 +19,7 @@ function escapeRegex(input) {
 }
 
 test("current MCP metadata stays aligned for the release cut", async () => {
-  assert.equal(packageJson.version, "0.3.0");
+  assert.equal(packageJson.version, "0.3.1");
   assert.equal(packageJson.version, serverJson.version);
 
   const releaseNotesPath = path.join(ROOT_DIR, "docs", "release", `MCP-${packageJson.version}-RELEASE-NOTES.md`);
@@ -31,9 +31,14 @@ test("version ledger records live public truth and the next release train", asyn
   const ledger = await readRepoFile(path.join("docs", "release", "VERSION-LEDGER.md"));
 
   assert.match(ledger, /root public baseline: `\d+\.\d+\.\d+`/);
+  assert.match(ledger, /live public GitHub release: `v0\.3\.1`/);
   assert.match(
     ledger,
-    new RegExp(escapeRegex(`standalone MCP public baseline: \`${packageJson.version}\``))
+    new RegExp(escapeRegex("standalone MCP public baseline: `0.3.0`"))
+  );
+  assert.match(
+    ledger,
+    new RegExp(escapeRegex(`current in-repo standalone release line: \`${packageJson.version}\``))
   );
   assert.match(
     ledger,
@@ -41,7 +46,7 @@ test("version ledger records live public truth and the next release train", asyn
   );
   assert.match(ledger, /next planned root follow-on: `\d+\.\d+\.\d+`/);
   assert.match(ledger, /next planned standalone release: `\d+\.\d+\.\d+`/);
-  assert.match(ledger, /`0\.3\.2` opt-in execution controls/);
+  assert.match(ledger, /`0\.3\.3` reserved for additional host-coverage follow-ups/);
 });
 
 test("MCP slice map defines the 0.3.x train without private-hosted bleed", async () => {
@@ -68,6 +73,7 @@ test("public MCP docs describe the current baseline and the next train in human-
 
   for (const contents of [packageReadme, aiGuide]) {
     assert.match(contents, /0\.3\.0/);
+    assert.match(contents, /0\.3\.1/);
     assert.match(contents, /local-first/i);
     assert.match(contents, /martin_doctor/);
     assert.match(contents, /martin_plan/);


### PR DESCRIPTION
## Summary
- harden CLI version resolution so npx invocation reports the martin-loop package version consistently
- stage standalone MCP 0.3.1 metadata (package.json, server.json, runtime package version constant)
- refresh MCP public docs/release ledger wording for live-vs-staged truth and keep release-doc tests aligned

## Verification
- pnpm --filter @martin/cli test
- pnpm --filter @martinloop/mcp lint
- pnpm --filter @martinloop/mcp test
- pnpm --filter @martinloop/mcp build
- pnpm --filter @martinloop/mcp smoke:pack
- pnpm --filter @martinloop/mcp verify:release
- pnpm release:validate-local

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified MCP package release roadmap: `0.3.0` as live adoption baseline, `0.3.1` as staged review/handoff release, `0.3.2` for opt-in execution controls

* **Chores**
  * Bumped MCP package version to `0.3.1`
  * Updated release documentation and version ledger to reflect new versioning
  * Improved CLI version resolution to support environment fallbacks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->