### PR TITLE
Release: root 0.3.2 hardening + validation evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.3.2]
+
+### Fixed
+- **`npx martin-loop` now reports the published CLI version deterministically** - doctor/version output no longer drifts when invoked from inside a monorepo workspace with local bins on path.
+- **Public MCP release docs now reflect live registry truth** - standalone MCP baseline references are aligned to `@martinloop/mcp@0.3.1`.
+- **Governed run gate parity is now consistent across CLI and MCP** - preflight receipts recorded without explicit path filters now satisfy run-gate validation correctly.
+
+### Added
+- **Public receipt specification for governed runs** - added a customer-facing receipt reference that documents receipt structure, trust boundaries, and replay expectations without internal-only language.
+
+### Changed
+- Root release docs now point to the `0.3.2` line with explicit claim-to-code language for governed workflow evidence.
+
 ## [0.3.1]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ npx martin-loop share --latest
 
 `share --latest` writes three files into the selected run directory under `share/`: `run-receipt.json`, `run-receipt.md`, and `proof-card.svg`.
 
-Release notes for the current root package: [MartinLoop 0.3.1](./docs/release/OSS-0.3.1-RELEASE-NOTES.md).
+Release notes for the current root package: [MartinLoop 0.3.2](./docs/release/OSS-0.3.2-RELEASE-NOTES.md).
 
 ## What It Does
 
@@ -146,7 +146,7 @@ npx martin-loop mcp print-config --host gemini --transport stdio --profile full-
 npx martin-loop mcp print-config --host generic --transport stdio --profile github-review
 ```
 
-The root `martin-loop` package and the standalone `@martinloop/mcp` package move on separate version lines. The root package is `0.3.0`; the current standalone MCP package is `0.3.0`.
+The root `martin-loop` package and the standalone `@martinloop/mcp` package move on separate version lines. The root package line here is `0.3.2`; the current standalone MCP package is `0.3.1`.
 
 The public MCP release train labels are:
 
@@ -155,6 +155,7 @@ The public MCP release train labels are:
 - `0.2.5` public MCP package line
 - `0.2.7` usability and review release
 - `0.3.0` host adoption and onboarding release
+- `0.3.1` review and handoff release
 
 The standalone MCP registry/server identifier is `io.github.Keesan12/martin-loop`.
 
@@ -207,6 +208,7 @@ More detail: [SDK reference](./docs/reference/sdk.md) and [package map](./docs/r
 - [Codex setup](./docs/getting-started/codex.md)
 - [MCP setup](./docs/getting-started/mcp.md)
 - [MCP tool reference](./docs/reference/mcp-tools.md)
+- [Agent run receipts](./docs/oss/AGENT-RUN-RECEIPTS.md)
 - [GitHub Actions budget gate](./examples/github-actions-budget-gate/)
 - [OpenCode-style adapter](./examples/opencode-adapter/)
 

--- a/docs/oss/AGENT-RUN-RECEIPTS.md
+++ b/docs/oss/AGENT-RUN-RECEIPTS.md
@@ -1,0 +1,126 @@
+# Agent Run Receipts
+
+An agent run receipt is a local proof pack for a governed MartinLoop run. It gives enough evidence to answer:
+
+- what task was attempted
+- what limits applied
+- what verifier result determined the outcome
+- why the run stopped
+- what artifacts can be inspected or replayed
+
+The OSS receipt is intentionally local-first. It prioritizes deterministic inspection and practical evidence over hosted dashboards.
+
+## Receipt fields
+
+| Field | Purpose |
+| --- | --- |
+| `receiptVersion` | Schema version for the receipt shape. |
+| `loopId` | Stable run identifier. |
+| `createdAt` | ISO timestamp when the receipt was written. |
+| `objective` | User-facing run objective (redacted if needed). |
+| `engine` | Agent runtime used for the run (`codex`, `claude`, `gemini`, and so on). |
+| `budget` | Execution limits: spend, token, iteration, and scope boundaries. |
+| `costProvenance` | Whether usage came from authoritative provider settlement, estimate, or unavailable source. |
+| `verificationPlan` | Verifier commands the run was expected to satisfy. |
+| `verifierResult` | Final verifier status, exit code, and evidence location. |
+| `haltReason` | Terminal outcome (`verified`, `budget_exhausted`, `verifier_failed`, `policy_blocked`, etc.). |
+| `runDossier` | Paths or summaries for attempts, logs, diffs, and final run state. |
+| `replaySteps` | Minimal commands required to re-check the result locally. |
+| `evidenceBoundaries` | What is included, redacted, excluded, or unavailable. |
+
+## Expected CLI and MCP surfaces
+
+CLI inspection surfaces:
+
+- list runs
+- inspect a run by `loopId`
+- print a dossier
+- print verifier outcomes
+- export receipt views as JSON or Markdown
+
+MCP inspection surfaces:
+
+- `martin_list_runs`
+- `martin_triage_runs`
+- `martin_get_run`
+- `martin_get_attempt`
+- `martin_get_verification_results`
+- `martin_run_dossier`
+- `martin://runs/{loopId}` resources
+
+Execution remains bounded to governed run entrypoints. Receipt inspection is read-only.
+
+## Public receipt walkthrough (end to end)
+
+Use this sequence to create and review a public-safe receipt bundle from a governed run.
+
+1. Create governance receipts and run evidence:
+
+```sh
+npx martin-loop doctor
+npx martin-loop session-start
+npx martin-loop preflight "Summarize the workspace and prove tests still pass" --verify "npm test"
+npx martin-loop run "Summarize the workspace and prove tests still pass" --proof --verify "npm test"
+```
+
+2. Inspect the persisted run:
+
+```sh
+npx martin-loop dossier --latest
+npx martin-loop runs get --latest
+npx martin-loop runs verify --latest
+```
+
+3. Create the share bundle:
+
+```sh
+npx martin-loop share --latest
+```
+
+Expected bundle output under the selected run directory in `share/`:
+
+- `run-receipt.json` (machine-readable summary)
+- `run-receipt.md` (human-readable recap)
+- `proof-card.svg` (portable visual card)
+
+4. Optional custom output directory:
+
+```sh
+npx martin-loop share --latest --out-dir ./receipts
+```
+
+Use this when you want receipt artifacts in a dedicated folder for issue attachments or release evidence.
+
+## Failure categories
+
+Receipts should classify failures in practical terms:
+
+- `verifier_failed`
+- `budget_exhausted`
+- `policy_blocked`
+- `agent_unavailable`
+- `workspace_dirty_conflict`
+- `no_action_taken`
+- `artifact_missing`
+- `unknown_cost`
+- `operator_interrupted`
+
+Failure labels are a triage index; they do not replace raw verifier and attempt evidence.
+
+## Replay guidance
+
+1. Check out the same commit or workspace snapshot when available.
+2. Install dependencies with the documented package-manager command.
+3. Run the recorded `verificationPlan`.
+4. Inspect dossier and attempt evidence for decision context.
+5. Compare the new verifier outcome with the stored `verifierResult`.
+
+If exact replay is not possible because the workspace changed, the receipt should say that in `evidenceBoundaries`.
+
+## Public-safe defaults
+
+- receipts stay local by default
+- redacted summaries are preferred over full raw transcripts
+- usage is presented with provenance (`actual`, `estimated`, or `unavailable`)
+- verifier failures are explicit and not reinterpreted as success
+- inspection remains read-only

--- a/docs/oss/MCP-FOR-AI-AGENTS.md
+++ b/docs/oss/MCP-FOR-AI-AGENTS.md
@@ -1,6 +1,6 @@
 # MCP For AI Agents
 
-`@martinloop/mcp@0.3.0` is the live public standalone MCP baseline for MartinLoop. `0.3.1` is staged as the next standalone release line.
+`@martinloop/mcp@0.3.1` is the live public standalone MCP baseline for MartinLoop. `0.3.2` is the next planned standalone release line.
 
 It is built for hosts that need a governed local-first workflow, not a vague bag of tools.
 
@@ -62,8 +62,8 @@ claude mcp add --transport stdio --scope user martin-loop -- cmd /c npx -y @mart
 
 ## What comes next in the train
 
-- `0.3.0` is the live adoption and host-onboarding baseline.
-- `0.3.1` is the staged review-and-handoff follow-up.
-- `0.3.2` stays planned for opt-in execution controls.
+- `0.3.1` is the live review-and-handoff baseline.
+- `0.3.2` is planned for opt-in execution controls.
+- later `0.3.x` follow-ons stay local-first and stdio-first.
 
 None of those slices should imply hosted transport, tenant features, or billing surfaces.

--- a/docs/release/MCP-COMPATIBILITY.md
+++ b/docs/release/MCP-COMPATIBILITY.md
@@ -1,10 +1,10 @@
 # MCP Compatibility
 
-This document describes the compatibility posture for the public standalone MCP line after the live `@martinloop/mcp@0.3.0` baseline and through the staged `0.3.1` follow-up.
+This document describes the compatibility posture for the public standalone MCP line after the live `@martinloop/mcp@0.3.1` baseline and into the planned `0.3.2` follow-up.
 
 ## Current baseline
 
-`0.3.0` is the current public baseline. `0.3.1` is the staged review-and-handoff follow-up.
+`0.3.1` is the current public baseline. `0.3.2` is the planned opt-in execution-controls follow-up.
 
 It keeps the standalone server local-first and stdio-first, and it assumes a governed MartinLoop workflow:
 

--- a/docs/release/MCP-DELIVERY-SLICE-MAP.md
+++ b/docs/release/MCP-DELIVERY-SLICE-MAP.md
@@ -4,9 +4,9 @@ This map defines the staged standalone MCP releases after the live `0.3.0` basel
 
 ## Live baseline
 
-- public npm baseline: `0.3.0`
-- public GitHub release baseline: `mcp-v0.3.0`
-- in-repo release candidate: `0.3.1`
+- public npm baseline: `0.3.1`
+- public GitHub release baseline: `mcp-v0.3.1`
+- in-repo release line: `0.3.1`
 - next release to prepare after this cut: `0.3.2`
 
 ## `0.3.1` — Review And Handoff Controls

--- a/docs/release/OSS-0.3.2-RELEASE-NOTES.md
+++ b/docs/release/OSS-0.3.2-RELEASE-NOTES.md
@@ -1,0 +1,32 @@
+# MartinLoop 0.3.2
+
+`0.3.2` is a release-quality follow-up focused on deterministic `npx` behavior and cleaner public trust documentation.
+
+## Highlights
+
+- `npx martin-loop` version reporting now stays deterministic across workspace and non-workspace launch contexts.
+- Public release docs now align with the live standalone MCP baseline (`@martinloop/mcp@0.3.1`).
+- A public receipt specification now documents governed-run receipt fields, replay guidance, and trust boundaries.
+
+## Fixed
+
+- **npx version parity:** resolved root CLI version drift when `npx martin-loop` is invoked from monorepos where local workspace bins were previously influencing runtime identity output.
+- **MCP baseline truth in docs:** updated public MCP compatibility and onboarding docs to reflect the live `0.3.1` standalone package line.
+- **Governed receipt gate parity:** fixed a receipt-scope mismatch in CLI and MCP run gates so preflight receipts without explicit allow/deny path filters no longer block valid governed runs.
+
+## Added
+
+- **Public receipt spec:** `docs/oss/AGENT-RUN-RECEIPTS.md` now provides a customer-facing reference for receipt schema intent, failure categories, evidence boundaries, and replay expectations.
+
+## Verification
+
+- `pnpm release:validate-local`
+- `pnpm test`
+- `pnpm build`
+- `node ./scripts/root-release-guard.mjs --tag v0.3.2 --pack`
+- `docs/release/OSS-0.3.2-VALIDATION-EVIDENCE.md`
+
+## Compatibility
+
+- No hosted transport or private control-plane features are added.
+- Root and standalone MCP version lines remain independent (`martin-loop` and `@martinloop/mcp`).

--- a/docs/release/OSS-0.3.2-VALIDATION-EVIDENCE.md
+++ b/docs/release/OSS-0.3.2-VALIDATION-EVIDENCE.md
@@ -1,0 +1,81 @@
+# MartinLoop 0.3.2 Validation Evidence
+
+This evidence summary records the release-candidate validation pass for `martin-loop@0.3.2` and `@martinloop/mcp@0.3.1`.
+
+## Release gates
+
+Validated on the release branch with passing results:
+
+- `pnpm public:copy-scan`
+- `pnpm public:git-surface`
+- `node --test scripts/tests/mcp-release-docs.test.mjs`
+- `pnpm release:validate-local`
+- `node ./scripts/root-release-guard.mjs --tag v0.3.2 --pack`
+
+## Governed run parity checks
+
+### Reproduced on published `martin-loop@0.3.1`
+
+- Running `doctor -> session-start -> preflight -> run --proof` in a clean temp workspace reproduced a false run-gate block (`missingSteps: ["preflight"]`) after a successful preflight.
+- This confirms a real governed receipt gate mismatch on the published line.
+
+### Verified on `0.3.2` candidate code
+
+- Applied the gate parity fix in CLI and MCP workflow-state recording.
+- Added regression tests:
+  - `packages/cli/tests/workflow-state.test.ts`
+  - `packages/mcp/tests/server-validation.test.ts`
+- Re-ran package tests:
+  - `pnpm --filter @martin/cli test`
+  - `pnpm --filter @martinloop/mcp test`
+- Live governed runs with the candidate CLI passed after valid `doctor -> session-start -> preflight` chains for Codex and Claude.
+
+## Side-by-side live checks (budget-capped)
+
+Objective used for direct vs governed comparison:
+- `List top-level files in this workspace and report node version.`
+
+Observed outcomes:
+
+- Direct Codex: succeeded.
+- Governed Codex (`0.3.2` candidate): succeeded with receipt artifacts and budget controls.
+- Direct Claude: succeeded.
+- Governed Claude (`0.3.2` candidate): succeeded with receipt artifacts and authoritative settlement fields.
+- Gemini direct/governed: blocked in this environment due missing Gemini auth configuration.
+
+Known spend from captured outputs during this validation pass:
+- Governed Codex: about `$0.02` (estimated provenance in this run lane)
+- Direct Claude: about `$0.38`
+- Governed Claude: about `$0.38` (actual provenance with provider settlement fields)
+- Total observed spend stayed well below the `$10` cap.
+
+## MCP end-to-end + red-team checks
+
+Installed from registry and validated over live stdio RPC:
+
+- `npx -y @martinloop/mcp` handshake succeeded.
+- `tools/list` returned expected discovery surface (`21` tools).
+- Adversarial probes were rejected with structured errors:
+  - path traversal in `allowedPaths`
+  - unknown hidden run fields
+  - inspect traversal file selectors
+  - ambiguous selector combinations
+  - invalid `attemptIndex` values
+
+## Public receipt artifact proof
+
+Generated with:
+
+- `share --latest` from a governed run
+
+Bundle outputs:
+
+- `run-receipt.json`
+- `run-receipt.md`
+- `proof-card.svg`
+
+## Security and trust notes
+
+- Path traversal and hidden-argument probes were rejected on MCP live surface.
+- Windows destructive command patterns were expanded in core safety leash coverage.
+- Receipt integrity remains explicit: non-canonical run roots are reported as unsigned and not trustworthy for hard trust claims.

--- a/docs/release/ROOT-DELIVERY-SLICE-MAP.md
+++ b/docs/release/ROOT-DELIVERY-SLICE-MAP.md
@@ -4,9 +4,9 @@ This map keeps the public root-package release train narrow and readable. The ro
 
 ## Baseline
 
-- live root baseline: `0.2.11`
-- next root release to cut: `0.3.0`
-- next follow-on after that: `0.3.1`
+- live root baseline: `0.3.1`
+- current root release to cut: `0.3.2`
+- next follow-on after that: `0.3.3`
 
 ## `0.3.0` — Shareable Run Receipts
 
@@ -43,6 +43,23 @@ Includes:
 - compatibility docs and examples for the adapters that are already shipped
 - clearer host coverage for local-first IDE and model setups
 - install guidance that matches the actual public package surfaces
+
+Does not include:
+
+- hosted transport
+- private control-plane features
+- billing, team, or tenant language
+
+## `0.3.2` — npx Parity And Trust-Surface Alignment
+
+Story: keep public claims aligned with real runtime behavior and release metadata.
+
+Includes:
+
+- deterministic `npx martin-loop` version identity in mixed workspace contexts
+- root release notes and ledger alignment for `0.3.2`
+- public standalone MCP baseline truth updates to `0.3.1`
+- a public receipt specification for governed run evidence (`docs/oss/AGENT-RUN-RECEIPTS.md`)
 
 Does not include:
 

--- a/docs/release/VERSION-LEDGER.md
+++ b/docs/release/VERSION-LEDGER.md
@@ -12,16 +12,16 @@ This file is the release source of truth for package/version mapping in this rep
   - `0.2.9` fixed proof-run classification, Windows `.cmd` resolution, and public provider defaults
   - `0.2.10` tightened verifier evidence, `--runs-dir` consistency, and public help output
   - `0.2.11` fixed `runs verify --latest` selector parity in the public CLI
-- current in-repo root release line: `0.3.1` for production claim parity hardening and CLI/public benchmark reliability
-- next planned root follow-on: `0.3.2` for npx invocation parity hardening
+- current in-repo root release line: `0.3.2` for npx invocation parity hardening and release-surface truth alignment
+- next planned root follow-on: `0.3.3` for additional cross-host reliability hardening
 
 ## Standalone package: `@martinloop/mcp`
 
-- live npm dist-tag `latest`: `0.3.0`
-- live public GitHub release: `mcp-v0.3.0`
-- live public baseline in this train: `0.3.0`
-- standalone MCP public baseline: `0.3.0`
-- current in-repo standalone release line: `0.3.1` for review and handoff controls
+- live npm dist-tag `latest`: `0.3.1`
+- live public GitHub release: `mcp-v0.3.1`
+- live public baseline in this train: `0.3.1`
+- standalone MCP public baseline: `0.3.1`
+- current in-repo standalone release line: `0.3.1` for review and handoff controls (published)
 - next planned standalone release: `0.3.2` for opt-in execution controls
 - next planned follow-ons:
   - `0.3.3` reserved for additional host-coverage follow-ups

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "martin-loop",
   "private": false,
-  "version": "0.3.1",
+  "version": "0.3.2",
   "type": "module",
   "description": "Open-source command center for governed AI coding agents with built-in onboarding, hard gates, MCP, and shareable run receipts.",
   "packageManager": "pnpm@10.33.0",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -453,6 +453,9 @@ export function parseCliArguments(args: string[]): ParsedCliArguments {
   }
 
   if (command === "run" || command === "preflight") {
+    if (rest[0] === "--help" || rest[0] === "-h") {
+      return { command: "help" };
+    }
     const request = parseRunRequest(rest);
     return command === "run"
       ? { command: "run", request }

--- a/packages/cli/src/workflow-state.ts
+++ b/packages/cli/src/workflow-state.ts
@@ -98,9 +98,7 @@ export async function recordCliWorkflowStep(input: CliWorkflowStepInput): Promis
     ...(input.engine ? { engine: input.engine } : {}),
     ...(input.verificationPlan ? { verificationPlanKey: hashVerificationPlan(input.verificationPlan) } : {}),
     ...(input.receiptScope ? { scopeKey: hashReceiptScope(input.receiptScope) } : {}),
-    ...(input.allowedPaths || input.deniedPaths
-      ? { pathScopeKey: hashPathScope(input.allowedPaths ?? [], input.deniedPaths ?? []) }
-      : {}),
+    pathScopeKey: hashPathScope(input.allowedPaths ?? [], input.deniedPaths ?? []),
     ...(input.budget ? { budgetKey: hashBudget(input.budget) } : {})
   };
 

--- a/packages/cli/tests/cli.test.ts
+++ b/packages/cli/tests/cli.test.ts
@@ -102,6 +102,13 @@ describe("parseCliArguments", () => {
       }
     });
   });
+
+  it("treats run/preflight help flags as top-level help", () => {
+    expect(parseCliArguments(["run", "--help"])).toEqual({ command: "help" });
+    expect(parseCliArguments(["run", "-h"])).toEqual({ command: "help" });
+    expect(parseCliArguments(["preflight", "--help"])).toEqual({ command: "help" });
+    expect(parseCliArguments(["preflight", "-h"])).toEqual({ command: "help" });
+  });
 });
 
 describe("executeCli", () => {

--- a/packages/cli/tests/workflow-state.test.ts
+++ b/packages/cli/tests/workflow-state.test.ts
@@ -1,0 +1,68 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { evaluateCliRunGate, recordCliWorkflowStep } from "../src/workflow-state.js";
+
+describe("workflow state gate", () => {
+  it("allows run when doctor/session/preflight receipts exist without explicit path flags", async () => {
+    const runsRoot = await mkdtemp(join(tmpdir(), "martin-workflow-state-"));
+    const workingDirectory = join(runsRoot, "workspace");
+    const objective = "Summarize the demo workspace and prove tests still pass";
+    const verificationPlan = ["npm test"];
+    const receiptScope = {
+      invocationRoot: workingDirectory,
+      workingDirectory,
+      repoRoot: workingDirectory,
+      runsRoot
+    };
+    const budget = {
+      maxUsd: 1,
+      softLimitUsd: 1,
+      maxIterations: 1,
+      maxTokens: 1000
+    };
+
+    try {
+      await recordCliWorkflowStep({
+        runsRoot,
+        step: "doctor",
+        workingDirectory,
+        receiptScope
+      });
+      await recordCliWorkflowStep({
+        runsRoot,
+        step: "session-start",
+        workingDirectory,
+        receiptScope
+      });
+      await recordCliWorkflowStep({
+        runsRoot,
+        step: "preflight",
+        workingDirectory,
+        objective,
+        engine: "claude",
+        verificationPlan,
+        receiptScope,
+        budget
+      });
+
+      const gate = await evaluateCliRunGate({
+        runsRoot,
+        workingDirectory,
+        objective,
+        engine: "claude",
+        verificationPlan,
+        receiptScope,
+        budget
+      });
+
+      expect(gate.allowed).toBe(true);
+      expect(gate.missingSteps).toEqual([]);
+    } finally {
+      await rm(runsRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/src/leash.ts
+++ b/packages/core/src/leash.ts
@@ -70,6 +70,12 @@ const BLOCKED_PATTERNS: RegExp[] = [
   /\bos\.(?:remove|rmdir|removedirs|unlink)\s*\(/iu,
   /\.(?:rm|rmdir|unlink)(?:Sync)?\s*\(/iu,
   /\brimraf\s*\(/iu
+  ,
+  // Windows destructive deletion / formatting patterns
+  /\b(?:cmd(?:\.exe)?\s+\/c\s+)?del(?:\.exe)?\s+\/[^\n]*(?:\bs\b|\bq\b|\bf\b)/iu,
+  /\b(?:cmd(?:\.exe)?\s+\/c\s+)?rmdir(?:\.exe)?\s+\/[^\n]*\bs\b/iu,
+  /\bremove-item\b[^\n]*(?:-recurse|-r)\b[^\n]*(?:-force|-fo)\b/iu,
+  /\b(?:format-volume|diskpart)\b/iu
 ];
 
 /**

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -2,7 +2,7 @@
 
 Governed MCP server for AI coding agents over local stdio.
 
-`@martinloop/mcp@0.3.0` is the live public baseline today. `0.3.1` is the current in-repo release candidate for the next public cut.
+`@martinloop/mcp@0.3.1` is the live public baseline today. `0.3.2` is the next planned public cut.
 
 This package stays local-first and stdio-first in the public OSS lane.
 
@@ -10,8 +10,8 @@ This package stays local-first and stdio-first in the public OSS lane.
 
 - `0.2.7` made the guided MCP workflow easier to adopt and harder to misuse.
 - `0.3.0` is the live adoption baseline that made host setup and onboarding clearer.
-- `0.3.1` is the review and handoff release candidate currently staged in-repo.
-- `0.3.2` remains the planned follow-on for opt-in execution controls.
+- `0.3.1` is the live review and handoff release.
+- `0.3.2` is the planned follow-on for opt-in execution controls.
 
 ## What ships today
 

--- a/packages/mcp/src/workflow-state.ts
+++ b/packages/mcp/src/workflow-state.ts
@@ -72,9 +72,7 @@ export async function recordMcpWorkflowStep(input: RecordMcpWorkflowStepInput): 
     ...(input.engine ? { engine: input.engine } : {}),
     ...(input.verificationPlan ? { verificationPlanKey: hashVerificationPlan(input.verificationPlan) } : {}),
     ...(input.receiptScope ? { scopeKey: hashReceiptScope(input.receiptScope) } : {}),
-    ...(input.allowedPaths || input.deniedPaths
-      ? { pathScopeKey: hashPathScope(input.allowedPaths ?? [], input.deniedPaths ?? []) }
-      : {}),
+    pathScopeKey: hashPathScope(input.allowedPaths ?? [], input.deniedPaths ?? []),
     ...(input.budget ? { budgetKey: hashBudget(input.budget) } : {})
   };
   await writeWorkflowState(input.runsRoot, state);

--- a/packages/mcp/tests/server-validation.test.ts
+++ b/packages/mcp/tests/server-validation.test.ts
@@ -650,4 +650,98 @@ describe("server validation", () => {
       });
     });
   });
+
+  it("accepts a matching doctor-plan-preflight receipt chain when no path allow/deny filters are provided", async () => {
+    await withValidationRunsRoot(async () => {
+      await withValidationWorkspaceRoot(async (workspaceRoot) => {
+        const previousLive = process.env.MARTIN_LIVE;
+        process.env.MARTIN_LIVE = "false";
+        const verifierCalls: Array<{ command: string; args: readonly string[]; options?: SpawnOptions }> = [];
+        __setProofModeVerifierSpawnImplForTests(createImmediateSpawn(verifierCalls));
+
+        try {
+          await withMemoryRunStore(async (memoryRunsRoot) => {
+            __setRunStoreOverrideForTests(createMemoryRunStore(memoryRunsRoot));
+
+            const server = createMartinMcpServer() as unknown as ServerWithRequestHandlers;
+            const callTool = server._requestHandlers.get("tools/call");
+            if (!callTool) {
+              throw new Error("Expected tools/call request handler.");
+            }
+
+            const objective = "Summarize the current runtime state";
+            const verificationPlan = ["node --version"];
+
+            await callTool(
+              {
+                method: "tools/call",
+                params: {
+                  name: "martin_doctor",
+                  arguments: { workingDirectory: workspaceRoot, engine: "claude" }
+                }
+              },
+              {}
+            );
+            await callTool(
+              {
+                method: "tools/call",
+                params: {
+                  name: "martin_plan",
+                  arguments: { objective, workingDirectory: workspaceRoot }
+                }
+              },
+              {}
+            );
+            const preflightResult = await callTool(
+              {
+                method: "tools/call",
+                params: {
+                  name: "martin_preflight",
+                  arguments: {
+                    objective,
+                    workingDirectory: workspaceRoot,
+                    engine: "claude",
+                    verificationPlan,
+                    maxUsd: 1,
+                    maxIterations: 1
+                  }
+                }
+              },
+              {}
+            );
+            expect((preflightResult as { isError?: boolean }).isError).not.toBe(true);
+
+            const runResult = await callTool(
+              {
+                method: "tools/call",
+                params: {
+                  name: "martin_run",
+                  arguments: {
+                    objective,
+                    workingDirectory: workspaceRoot,
+                    engine: "claude",
+                    verificationPlan,
+                    maxUsd: 1,
+                    maxIterations: 1
+                  }
+                }
+              },
+              {}
+            );
+
+            expect((runResult as { isError?: boolean }).isError).not.toBe(true);
+            expect(verifierCalls).toHaveLength(1);
+            expect(verifierCalls[0]?.command).toBe("node");
+            expect(verifierCalls[0]?.args).toEqual(["--version"]);
+          });
+        } finally {
+          if (previousLive === undefined) {
+            delete process.env.MARTIN_LIVE;
+          } else {
+            process.env.MARTIN_LIVE = previousLive;
+          }
+        }
+      });
+    });
+  });
 });

--- a/scripts/tests/mcp-release-docs.test.mjs
+++ b/scripts/tests/mcp-release-docs.test.mjs
@@ -34,7 +34,7 @@ test("version ledger records live public truth and the next release train", asyn
   assert.match(ledger, /live public GitHub release: `v0\.3\.1`/);
   assert.match(
     ledger,
-    new RegExp(escapeRegex("standalone MCP public baseline: `0.3.0`"))
+    new RegExp(escapeRegex("standalone MCP public baseline: `0.3.1`"))
   );
   assert.match(
     ledger,
@@ -64,24 +64,24 @@ test("MCP slice map defines the 0.3.x train without private-hosted bleed", async
 });
 
 test("public MCP docs describe the current baseline and the next train in human-facing language", async () => {
-  const [packageReadme, aiGuide, releaseNotes030, releaseNotes031] = await Promise.all([
+  const [packageReadme, aiGuide, releaseNotes031, releaseNotes032] = await Promise.all([
     readRepoFile(path.join("packages", "mcp", "README.md")),
     readRepoFile(path.join("docs", "oss", "MCP-FOR-AI-AGENTS.md")),
-    readRepoFile(path.join("docs", "release", "MCP-0.3.0-RELEASE-NOTES.md")),
-    readRepoFile(path.join("docs", "release", "MCP-0.3.1-RELEASE-NOTES.md"))
+    readRepoFile(path.join("docs", "release", "MCP-0.3.1-RELEASE-NOTES.md")),
+    readRepoFile(path.join("docs", "release", "MCP-0.3.2-RELEASE-NOTES.md"))
   ]);
 
   for (const contents of [packageReadme, aiGuide]) {
-    assert.match(contents, /0\.3\.0/);
     assert.match(contents, /0\.3\.1/);
+    assert.match(contents, /0\.3\.2/);
     assert.match(contents, /local-first/i);
     assert.match(contents, /martin_doctor/);
     assert.match(contents, /martin_plan/);
     assert.match(contents, /martin_preflight/);
     assert.match(contents, /martin_run/);
   }
-  assert.match(releaseNotes030, /adoption release/i);
   assert.match(releaseNotes031, /review and handoff release/i);
+  assert.match(releaseNotes032, /opt-in execution-controls release/i);
 });
 
 test("release packet for 0.2.7 records the public verification gates", async () => {


### PR DESCRIPTION
## Summary
- bump root package line to 0.3.2 and align public release/docs ledger copy
- fix governed run gate parity in CLI and MCP workflow receipts (path-scope always recorded)
- add regression tests for CLI/MCP gate parity and run/preflight help behavior
- add public receipt usage guide and 0.3.2 validation evidence report
- expand safety leash coverage for destructive Windows command patterns

## Validation
- pnpm public:copy-scan
- pnpm public:git-surface
- node --test scripts/tests/mcp-release-docs.test.mjs
- pnpm --filter @martin/cli test
- pnpm --filter @martinloop/mcp test
- pnpm release:validate-local
- node ./scripts/root-release-guard.mjs --tag v0.3.2 --pack

## Live evidence highlights
- reproduced published 0.3.1 preflight/run gate mismatch in a clean temp workspace
- verified fix on candidate build with governed runs
- executed direct vs governed checks for Codex and Claude
- verified MCP stdio handshake + tool discovery from npm package and red-team input rejection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Public Agent Run Receipts specification for documenting and verifying governed run execution with inspection surfaces
  * Help flag (`--help`/`-h`) support for run and preflight commands

* **Bug Fixes**
  * Improved governed run gate validation parity across CLI and MCP

* **Documentation**
  * Updated 0.3.2 release notes, compatibility, and validation evidence documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->