### PR TITLE
fix(cli): make --proof behavior real and align receipt docs

### DIFF
--- a/docs/oss/AGENT-RUN-RECEIPTS.md
+++ b/docs/oss/AGENT-RUN-RECEIPTS.md
@@ -10,23 +10,19 @@ An agent run receipt is a local proof pack for a governed MartinLoop run. It giv
 
 The OSS receipt is intentionally local-first. It prioritizes deterministic inspection and practical evidence over hosted dashboards.
 
-## Receipt fields
+## Receipt fields (`run-receipt.json`)
 
 | Field | Purpose |
 | --- | --- |
-| `receiptVersion` | Schema version for the receipt shape. |
-| `loopId` | Stable run identifier. |
-| `createdAt` | ISO timestamp when the receipt was written. |
-| `objective` | User-facing run objective (redacted if needed). |
-| `engine` | Agent runtime used for the run (`codex`, `claude`, `gemini`, and so on). |
-| `budget` | Execution limits: spend, token, iteration, and scope boundaries. |
-| `costProvenance` | Whether usage came from authoritative provider settlement, estimate, or unavailable source. |
-| `verificationPlan` | Verifier commands the run was expected to satisfy. |
-| `verifierResult` | Final verifier status, exit code, and evidence location. |
-| `haltReason` | Terminal outcome (`verified`, `budget_exhausted`, `verifier_failed`, `policy_blocked`, etc.). |
-| `runDossier` | Paths or summaries for attempts, logs, diffs, and final run state. |
-| `replaySteps` | Minimal commands required to re-check the result locally. |
-| `evidenceBoundaries` | What is included, redacted, excluded, or unavailable. |
+| `schemaVersion` | Receipt schema identifier (`martin.share-receipt.v1`). |
+| `generatedAt` | ISO timestamp when the share receipt was generated. |
+| `loop` | Top-level run facts: `loopId`, title/objective, status/lifecycleState, attempts, spend/budget, update time. |
+| `receiptIntegrity` | Integrity verdict from local persisted evidence (`verified`, `tamper_detected`, `unsigned`). |
+| `verification` | Verifier summary for the selected run. |
+| `receipt` | Governed-run summary with next safe action and risk posture fields. |
+| `artifacts` | Local artifact references included in the dossier view. |
+| `proofCard` | Portable proof-card content rendered into the Markdown and SVG outputs. |
+| `warnings` | Non-fatal warnings collected while building the receipt bundle. |
 
 ## Expected CLI and MCP surfaces
 
@@ -115,7 +111,7 @@ Failure labels are a triage index; they do not replace raw verifier and attempt 
 4. Inspect dossier and attempt evidence for decision context.
 5. Compare the new verifier outcome with the stored `verifierResult`.
 
-If exact replay is not possible because the workspace changed, the receipt should say that in `evidenceBoundaries`.
+If exact replay is not possible because the workspace changed, the `warnings` and `receipt` sections should reflect that limitation.
 
 ## Public-safe defaults
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -140,7 +140,9 @@ export type RunCommandRequest = {
   runsDir?: string;
   model?: string;
   engine?: string;
+  liveMode?: "live" | "proof";
   mutationMode?: MutationMode;
+  unsafeAllowUnguardedRun?: boolean;
   allowedPaths?: string[];
   deniedPaths?: string[];
   acceptanceCriteria?: string[];
@@ -670,7 +672,7 @@ export function renderCliHelp(): string {
     "  martin runs list [options]",
     "  martin runs get (--loop-id <id> | --file <path> | --latest) [options]",
     "  martin runs attempt (--loop-id <id> | --file <path>) [--attempt-index <n>] [options]",
-    "  martin runs verify (--loop-id <id> | --file <path>) [options]",
+    "  martin runs verify (--loop-id <id> | --file <path> | --latest) [options]",
     "  martin mcp print-config --host <codex|claude|gemini|generic> [--scope <user|project|local>] [options]",
     "  martin mcp install --host <codex|claude|gemini|generic> [--scope <user|project|local>] [--dry-run] [options]",
     "  martin demo [--dir <path>] [--force]",
@@ -747,7 +749,10 @@ export function renderCliHelp(): string {
     "  --max-iterations <n>     Set the maximum number of attempts.",
     "  --max-tokens <n>         Set the maximum total token budget.",
     "  --verify <cmd>           Shell command to run as the verifier after each attempt.",
+    "  --proof                  Run in no-spend proof mode (same as MARTIN_LIVE=false).",
     "  --verify-only            Skip the coding adapter and run the verifier only.",
+    "  --unsafe-allow-unguarded-run",
+    "                           Bypass doctor/preflight run-gate checks for this invocation only.",
     "  --allow-path <glob>      Restrict agent writes to this path pattern (repeatable).",
     "  --deny-path <glob>       Block agent from this path pattern (repeatable).",
     "  --accept <criterion>     Add an acceptance criterion to the prompt (repeatable).",
@@ -789,20 +794,24 @@ async function executeRunCommand(
   const cliEnvironment = resolveCliEnvironment({
     cwd: resolvedRequest.cwd,
     runsDir: resolvedRequest.runsDir,
-    engine: resolvedRequest.engine
+    engine: resolvedRequest.engine,
+    liveMode: resolvedRequest.liveMode
   });
+  const effectiveMutationMode =
+    resolvedRequest.mutationMode ?? (resolvedRequest.liveMode === "proof" ? "verify_only" : undefined);
   const receiptScope = buildCliReceiptScope(cliEnvironment);
   const engineRequired =
-    resolvedRequest.mutationMode !== "verify_only" && cliEnvironment.liveMode === "live";
+    effectiveMutationMode !== "verify_only" && cliEnvironment.liveMode === "live";
+  const preRunWarnings: string[] = [];
 
-  if (engineRequired) {
+  if (engineRequired && !resolvedRequest.unsafeAllowUnguardedRun) {
     const gate = await evaluateCliRunGate({
       runsRoot: cliEnvironment.runsRoot,
       workingDirectory: cliEnvironment.workingDirectory,
       objective: resolvedRequest.objective,
       engine: cliEnvironment.engine,
       verificationPlan: resolvedRequest.verificationPlan,
-      mutationMode: resolvedRequest.mutationMode,
+      mutationMode: effectiveMutationMode,
       receiptScope,
       allowedPaths: resolvedRequest.allowedPaths,
       deniedPaths: resolvedRequest.deniedPaths,
@@ -818,6 +827,10 @@ async function executeRunCommand(
         }
       });
     }
+  } else if (engineRequired && resolvedRequest.unsafeAllowUnguardedRun) {
+    preRunWarnings.push(
+      "Run-gate bypassed by --unsafe-allow-unguarded-run; doctor/preflight receipts were not enforced for this run."
+    );
   }
 
   let result: Awaited<ReturnType<typeof runMartin>>;
@@ -851,7 +864,7 @@ async function executeRunCommand(
     resolvedRequest.engine,
     cliEnvironment.workingDirectory,
     resolvedRequest.model,
-    resolvedRequest.mutationMode,
+    effectiveMutationMode,
     codexCommandOverride
   );
   try {
@@ -865,7 +878,7 @@ async function executeRunCommand(
         title: resolvedRequest.title,
         objective: resolvedRequest.objective,
         verificationPlan: resolvedRequest.verificationPlan,
-        ...(resolvedRequest.mutationMode ? { mutationMode: resolvedRequest.mutationMode } : {}),
+        ...(effectiveMutationMode ? { mutationMode: effectiveMutationMode } : {}),
         repoRoot: cliEnvironment.workingDirectory,
         ...(resolvedRequest.allowedPaths?.length ? { allowedPaths: resolvedRequest.allowedPaths } : {}),
         ...(resolvedRequest.deniedPaths?.length ? { deniedPaths: resolvedRequest.deniedPaths } : {}),
@@ -885,7 +898,7 @@ async function executeRunCommand(
         title: resolvedRequest.title,
         objective: resolvedRequest.objective,
         verificationPlan: resolvedRequest.verificationPlan,
-        ...(resolvedRequest.mutationMode ? { mutationMode: resolvedRequest.mutationMode } : {}),
+        ...(effectiveMutationMode ? { mutationMode: effectiveMutationMode } : {}),
         repoRoot: cliEnvironment.workingDirectory
       },
       budget: resolvedRequest.budget,
@@ -909,7 +922,7 @@ async function executeRunCommand(
     });
   }
 
-  const warnings: string[] = [];
+  const warnings: string[] = [...preRunWarnings];
   await persistLoopArtifacts(result.loop, { runsRoot: cliEnvironment.runsRoot }).catch((error: unknown) => {
     warnings.push(
       `Persisted run artifacts could not be written: ${error instanceof Error ? error.message : String(error)}`
@@ -1890,6 +1903,12 @@ function parseRunRequest(rest: string[]): RunCommandRequest {
       case "--verify-only":
         request.mutationMode = "verify_only";
         break;
+      case "--proof":
+        request.liveMode = "proof";
+        break;
+      case "--unsafe-allow-unguarded-run":
+        request.unsafeAllowUnguardedRun = true;
+        break;
       case "--allow-path":
         if (next) {
           request.allowedPaths = [...(request.allowedPaths ?? []), next];
@@ -1935,7 +1954,9 @@ function parseRunRequest(rest: string[]): RunCommandRequest {
     ...(request.runsDir ? { runsDir: request.runsDir } : {}),
     ...(request.model ? { model: request.model } : {}),
     ...(request.engine ? { engine: request.engine } : {}),
+    ...(request.liveMode ? { liveMode: request.liveMode } : {}),
     ...(request.mutationMode ? { mutationMode: request.mutationMode } : {}),
+    ...(request.unsafeAllowUnguardedRun ? { unsafeAllowUnguardedRun: true } : {}),
     ...(request.allowedPaths?.length ? { allowedPaths: request.allowedPaths } : {}),
     ...(request.deniedPaths?.length ? { deniedPaths: request.deniedPaths } : {}),
     ...(request.acceptanceCriteria?.length ? { acceptanceCriteria: request.acceptanceCriteria } : {})

--- a/packages/cli/tests/cli-integration.test.ts
+++ b/packages/cli/tests/cli-integration.test.ts
@@ -254,7 +254,7 @@ describe("--engine flag", () => {
 
     expect(result.exitCode).toBe(8);
     expect(result.stderr).toContain("Governed run blocked until MartinLoop receipts exist");
-    expect(result.stderr).toContain("martin-loop session-start");
+    expect(result.stderr).toMatch(/martin-loop (doctor|session-start)/);
   });
 });
 

--- a/packages/cli/tests/cli.test.ts
+++ b/packages/cli/tests/cli.test.ts
@@ -70,7 +70,9 @@ describe("parseCliArguments", () => {
       "--policy",
       "balanced",
       "--telemetry",
-      "control-plane"
+      "control-plane",
+      "--proof",
+      "--unsafe-allow-unguarded-run"
     ]);
 
     expect(parsed).toEqual({
@@ -98,7 +100,9 @@ describe("parseCliArguments", () => {
           maxTokens: true,
           maxUsd: true,
           softLimitUsd: true
-        }
+        },
+        liveMode: "proof",
+        unsafeAllowUnguardedRun: true
       }
     });
   });
@@ -112,6 +116,13 @@ describe("parseCliArguments", () => {
 });
 
 describe("executeCli", () => {
+  it("prints runs verify help with --latest selector support", async () => {
+    const result = await executeCli(["--help"]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("martin runs verify (--loop-id <id> | --file <path> | --latest) [options]");
+  });
+
   it("prints the public root package version", async () => {
     const rootPackageVersion = (
       JSON.parse(await readFile(join(process.cwd(), "..", "..", "package.json"), "utf8")) as {
@@ -315,6 +326,36 @@ describe("executeCli", () => {
       expect(payload.loop.lifecycleState).toBe("completed");
       expect(payload.loop.task.mutationMode).toBe("verify_only");
       expect(payload.loop.cost.actualUsd).toBe(0);
+    } finally {
+      await rm(directory, { force: true, recursive: true });
+    }
+  });
+
+  it("supports --proof runs as no-spend verifier-only executions", { timeout: 30_000 }, async () => {
+    const directory = await mkdtemp(join(tmpdir(), "martin-cli-proof-mode-"));
+
+    try {
+      const result = await executeCli([
+        "--json",
+        "run",
+        "--objective",
+        "Proof mode smoke",
+        "--proof",
+        "--engine",
+        "codex",
+        "--verify",
+        `"${process.execPath}" -e "process.exit(0)"`,
+        "--cwd",
+        directory
+      ]);
+
+      expect(result.exitCode).toBe(0);
+
+      const payload = JSON.parse(result.stdout);
+      expect(payload.environment.liveMode).toBe("proof");
+      expect(payload.loop.lifecycleState).toBe("completed");
+      expect(payload.loop.cost.actualUsd).toBe(0);
+      expect(payload.loop.task.mutationMode).toBe("verify_only");
     } finally {
       await rm(directory, { force: true, recursive: true });
     }


### PR DESCRIPTION
## Summary
- make `run --proof` enforce real no-spend behavior by mapping proof runs to verifier-only execution
- add explicit CLI support for documented `--proof` and `--unsafe-allow-unguarded-run` flags
- align CLI help for `runs verify --latest`
- align public receipt docs to the actual `run-receipt.json` shape emitted by `share`

## Verification
- `pnpm --filter @martin/cli test`
- `pnpm public:copy-scan`
- local proof smoke:
  - `pnpm --filter @martin/cli dev -- --json run "proof run smoke" --proof --verify "cmd /c exit 0"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--proof` flag to run verification-only operations without spending resources.
  * Added `--unsafe-allow-unguarded-run` flag to bypass pre-run gating checks.

* **Documentation**
  * Updated agent run receipt specification with revised schema structure and field definitions.

* **Tests**
  * Added test coverage for new CLI flags and proof mode behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->