### PR TITLE
docs(public): trust-hardening audit walkthrough + deterministic version guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,36 @@ npx martin-loop dossier --latest
 npx martin-loop share --latest
 ```
 
-`doctor`, `session-start`, and `preflight` create the local receipts MartinLoop expects before a real governed run. If you intentionally need to bypass that local gate for a one-off run, use `--unsafe-allow-unguarded-run` explicitly.
+`doctor`, `session-start`, and `preflight` create the local receipts MartinLoop expects before a real governed run.
 
 `share --latest` writes three files into the selected run directory under `share/`: `run-receipt.json`, `run-receipt.md`, and `proof-card.svg`.
 
 Release notes for the current root package: [MartinLoop 0.3.2](./docs/release/OSS-0.3.2-RELEASE-NOTES.md).
+
+## Run This Audit Yourself
+
+Use this lane from a clean temp directory to verify the public CLI flow exactly as shipped:
+
+```sh
+npx -y martin-loop@0.3.2 --version
+npx -y martin-loop@0.3.2 demo
+cd martin-loop-demo
+npm install
+npx -y martin-loop@0.3.2 doctor --json
+npx -y martin-loop@0.3.2 session-start --json
+npx -y martin-loop@0.3.2 preflight "Summarize the demo workspace and prove tests still pass" --verify "npm test" --json
+npx -y martin-loop@0.3.2 run "Summarize the demo workspace and prove tests still pass" --proof --verify "npm test" --json
+npx -y martin-loop@0.3.2 dossier --latest --json
+npx -y martin-loop@0.3.2 share --latest --json
+```
+
+For deterministic installs, pin the package line (`martin-loop@0.3.2`) or use `martin-loop@latest`. Plain `npx martin-loop` can resolve a stale local cache on some machines.
+
+Expected share bundle outputs:
+
+- `share/run-receipt.json`
+- `share/run-receipt.md`
+- `share/proof-card.svg`
 
 ## What It Does
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -34,6 +34,16 @@ npx martin-loop doctor
 
 `doctor` checks whether MartinLoop can find the local tools, agents, and run directories it needs.
 
+For deterministic package-line verification in fresh environments:
+
+```sh
+npx -y martin-loop@0.3.2 --version
+npm view martin-loop version
+npm view @martinloop/mcp version
+```
+
+If `npx martin-loop --version` differs from npm live, run `npx -y martin-loop@latest --version` or pin `@0.3.2` to avoid local cache drift.
+
 ## Run a Governed Task
 
 ```sh
@@ -41,7 +51,7 @@ npx martin-loop preflight "fix the auth regression" --verify "pnpm test"
 npx martin-loop run "fix the auth regression" --budget 3.00 --verify "pnpm test"
 ```
 
-By default, MartinLoop expects recent `doctor`, `session-start`, and `preflight` receipts for the same repo and task before a real run will start. If you intentionally need to bypass that local gate for a one-off run, use `--unsafe-allow-unguarded-run` explicitly.
+By default, MartinLoop expects recent `doctor`, `session-start`, and `preflight` receipts for the same repo and task before a real run will start.
 
 ## Review Evidence
 
@@ -54,6 +64,12 @@ npx martin-loop share --latest
 Use `triage` to rank saved runs by urgency. Use `dossier` when you want one run receipt: stop reason, verifier evidence, budget status, rollback or artifact evidence, and the next safe action. Use `share` when you want a redacted bundle you can attach to a ticket, send to a teammate, or keep with the run directory.
 
 The share bundle contains `run-receipt.json`, `run-receipt.md`, and `proof-card.svg`.
+
+To print exact artifact paths from your latest run:
+
+```sh
+npx martin-loop share --latest --json
+```
 
 ## Repository Development
 

--- a/docs/oss/AGENT-RUN-RECEIPTS.md
+++ b/docs/oss/AGENT-RUN-RECEIPTS.md
@@ -73,6 +73,12 @@ npx martin-loop runs verify --latest
 npx martin-loop share --latest
 ```
 
+To print exact output locations:
+
+```sh
+npx martin-loop share --latest --json
+```
+
 Expected bundle output under the selected run directory in `share/`:
 
 - `run-receipt.json` (machine-readable summary)


### PR DESCRIPTION
## Summary
- add a reproducible public audit walkthrough to README
- add deterministic package-line checks in quickstart (@0.3.2, npm view checks)
- add explicit share --latest --json artifact-path guidance to receipts docs
- remove misleading one-off gate bypass guidance from public getting-started copy

## Validation
- pnpm public:copy-scan
- pnpm public:git-surface
- 
ode --test scripts/tests/readme-public-surface.test.mjs scripts/tests/mcp-release-docs.test.mjs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced audit reproduction instructions with step-by-step CLI examples and version pinning guidance
  * Added JSON output examples and artifact location clarification for the share command
  * Updated quickstart with deterministic verification steps and clarified prerequisite requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->