### PR TITLE
Fix remaining trust blockers: packaged unsafe-bypass gate + deterministic npx docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,16 +21,16 @@ Use it when AI coding work needs to stay bounded, inspectable, and safe to revie
 Try MartinLoop in a disposable demo workspace:
 
 ```sh
-npx martin-loop demo
-npx martin-loop --version
+npx -y martin-loop@latest demo
+npx -y martin-loop@latest --version
 cd martin-loop-demo
 npm install
-npx martin-loop doctor
-npx martin-loop session-start
-npx martin-loop preflight "Summarize the demo workspace and prove tests still pass" --verify "npm test"
-npx martin-loop run "Summarize the demo workspace and prove tests still pass" --proof --verify "npm test"
-npx martin-loop dossier --latest
-npx martin-loop share --latest
+npx -y martin-loop@latest doctor
+npx -y martin-loop@latest session-start
+npx -y martin-loop@latest preflight "Summarize the demo workspace and prove tests still pass" --verify "npm test"
+npx -y martin-loop@latest run "Summarize the demo workspace and prove tests still pass" --proof --verify "npm test"
+npx -y martin-loop@latest dossier --latest
+npx -y martin-loop@latest share --latest
 ```
 
 `doctor`, `session-start`, and `preflight` create the local receipts MartinLoop expects before a real governed run.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -12,15 +12,15 @@ Use this guide to get one governed MartinLoop run and one evidence review in a f
 ## Recommended First Run
 
 ```sh
-npx martin-loop demo
+npx -y martin-loop@latest demo
 cd martin-loop-demo
 npm install
-npx martin-loop doctor
-npx martin-loop session-start
-npx martin-loop preflight "Summarize the demo workspace and prove tests still pass" --verify "npm test"
-npx martin-loop run "Summarize the demo workspace and prove tests still pass" --proof --verify "npm test"
-npx martin-loop dossier --latest
-npx martin-loop share --latest
+npx -y martin-loop@latest doctor
+npx -y martin-loop@latest session-start
+npx -y martin-loop@latest preflight "Summarize the demo workspace and prove tests still pass" --verify "npm test"
+npx -y martin-loop@latest run "Summarize the demo workspace and prove tests still pass" --proof --verify "npm test"
+npx -y martin-loop@latest dossier --latest
+npx -y martin-loop@latest share --latest
 ```
 
 This path creates the local receipts MartinLoop expects before a real governed run, then proves the run/dossier loop without model spend.
@@ -29,7 +29,7 @@ This path creates the local receipts MartinLoop expects before a real governed r
 
 ```sh
 npm install -g martin-loop
-npx martin-loop doctor
+npx -y martin-loop@latest doctor
 ```
 
 `doctor` checks whether MartinLoop can find the local tools, agents, and run directories it needs.
@@ -47,8 +47,8 @@ If `npx martin-loop --version` differs from npm live, run `npx -y martin-loop@la
 ## Run a Governed Task
 
 ```sh
-npx martin-loop preflight "fix the auth regression" --verify "pnpm test"
-npx martin-loop run "fix the auth regression" --budget 3.00 --verify "pnpm test"
+npx -y martin-loop@latest preflight "fix the auth regression" --verify "pnpm test"
+npx -y martin-loop@latest run "fix the auth regression" --budget 3.00 --verify "pnpm test"
 ```
 
 By default, MartinLoop expects recent `doctor`, `session-start`, and `preflight` receipts for the same repo and task before a real run will start.
@@ -56,9 +56,9 @@ By default, MartinLoop expects recent `doctor`, `session-start`, and `preflight`
 ## Review Evidence
 
 ```sh
-npx martin-loop triage
-npx martin-loop dossier --latest
-npx martin-loop share --latest
+npx -y martin-loop@latest triage
+npx -y martin-loop@latest dossier --latest
+npx -y martin-loop@latest share --latest
 ```
 
 Use `triage` to rank saved runs by urgency. Use `dossier` when you want one run receipt: stop reason, verifier evidence, budget status, rollback or artifact evidence, and the next safe action. Use `share` when you want a redacted bundle you can attach to a ticket, send to a teammate, or keep with the run directory.
@@ -68,7 +68,7 @@ The share bundle contains `run-receipt.json`, `run-receipt.md`, and `proof-card.
 To print exact artifact paths from your latest run:
 
 ```sh
-npx martin-loop share --latest --json
+npx -y martin-loop@latest share --latest --json
 ```
 
 ## Repository Development

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -30,15 +30,15 @@ martin-loop mcp install --host <codex|claude|gemini|generic>
 Use this sequence when you are new to the product or setting up a fresh repo:
 
 ```sh
-npx martin-loop --version
-npx martin-loop demo
+npx -y martin-loop@latest --version
+npx -y martin-loop@latest demo
 cd martin-loop-demo
 npm install
-npx martin-loop doctor
-npx martin-loop session-start
-npx martin-loop preflight "Summarize the workspace and prove tests still pass" --verify "npm test"
-npx martin-loop run "Summarize the workspace and prove tests still pass" --proof --verify "npm test"
-npx martin-loop share --latest
+npx -y martin-loop@latest doctor
+npx -y martin-loop@latest session-start
+npx -y martin-loop@latest preflight "Summarize the workspace and prove tests still pass" --verify "npm test"
+npx -y martin-loop@latest run "Summarize the workspace and prove tests still pass" --proof --verify "npm test"
+npx -y martin-loop@latest share --latest
 ```
 
 ## Run Options

--- a/packages/cli/tests/cli-integration.test.ts
+++ b/packages/cli/tests/cli-integration.test.ts
@@ -256,6 +256,28 @@ describe("--engine flag", () => {
     expect(result.stderr).toContain("Governed run blocked until MartinLoop receipts exist");
     expect(result.stderr).toMatch(/martin-loop (doctor|session-start)/);
   });
+
+  it("accepts explicit unsafe gate bypass in live mode", { timeout: 15000 }, async () => {
+    const result = await withoutAgentCliOnPath(() =>
+      withEnv("MARTIN_LIVE", "true", () =>
+        executeCli([
+          "run",
+          "--objective",
+          "Fix the bug",
+          "--verify",
+          NOOP_VERIFIER,
+          "--max-iterations",
+          "1",
+          "--budget-usd",
+          "2",
+          "--unsafe-allow-unguarded-run"
+        ])
+      )
+    );
+
+    expect(result.exitCode).not.toBe(8);
+    expect(result.stderr).not.toContain("Governed run blocked until MartinLoop receipts exist");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/scripts/public-facade-smoke.mjs
+++ b/scripts/public-facade-smoke.mjs
@@ -30,6 +30,9 @@ export function createPublicFacadeSmokePlan(options = {}) {
     demoSmoke: {
       description: "npx martin-loop demo copies the packaged sandbox from a clean temp install.",
     },
+    unsafeBypassSmoke: {
+      description: "npx martin-loop run --unsafe-allow-unguarded-run bypasses the local receipt gate in packaged CLI builds.",
+    },
   };
 }
 
@@ -104,6 +107,30 @@ export async function runPublicFacadeSmoke(options = {}) {
       throw new Error(`Expected demo command to copy the packaged sandbox.\n${demoRun.stdout}${demoRun.stderr}`);
     }
 
+    // This command is expected to fail in clean temp installs when an adapter cannot launch,
+    // but it must not fail with local receipt-gate policy_blocked when unsafe bypass is explicit.
+    const unsafeBypassRun = await runCommandAllowFailure(
+      [
+        "npx",
+        "martin-loop",
+        "run",
+        "--objective",
+        "Unsafe bypass smoke",
+        "--verify",
+        "node -e \"process.exit(0)\"",
+        "--unsafe-allow-unguarded-run",
+      ],
+      { cwd: appDir },
+    );
+    if (/Governed run blocked until MartinLoop receipts exist/u.test(unsafeBypassRun.stderr)) {
+      throw new Error(
+        [
+          "Expected --unsafe-allow-unguarded-run to bypass local receipt gating in packaged CLI.",
+          unsafeBypassRun.stderr || unsafeBypassRun.stdout,
+        ].join("\n"),
+      );
+    }
+
     return {
       packageName: rootManifest.name,
       tarballPath,
@@ -120,6 +147,11 @@ export async function runPublicFacadeSmoke(options = {}) {
       demoSmoke: {
         ok: true,
         command: "npx martin-loop demo --dir ./martin-loop-demo",
+      },
+      unsafeBypassSmoke: {
+        ok: true,
+        command: "npx martin-loop run --objective \"Unsafe bypass smoke\" --verify \"node -e \\\"process.exit(0)\\\"\" --unsafe-allow-unguarded-run",
+        exitCode: unsafeBypassRun.exitCode,
       },
     };
   } finally {
@@ -169,6 +201,43 @@ async function runCommand(command, options) {
       resolve({
         stdout,
         stderr,
+      });
+    });
+  });
+}
+
+async function runCommandAllowFailure(command, options) {
+  const execution = resolveRcCommandExecution(command, process.platform);
+  const env = buildLifecycleSafeEnv();
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(execution.command, execution.args, {
+      cwd: options.cwd,
+      env,
+      shell: execution.shell,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    child.on("error", (error) => {
+      reject(error);
+    });
+
+    child.on("close", (code) => {
+      resolve({
+        stdout,
+        stderr,
+        exitCode: code ?? 1,
       });
     });
   });

--- a/scripts/tests/public-facade.test.mjs
+++ b/scripts/tests/public-facade.test.mjs
@@ -19,9 +19,10 @@ test("createPublicFacadeSmokePlan targets the frozen public package surface", ()
   assert.match(plan.sdkSmoke.description, /MartinLoop root import/i);
   assert.match(plan.cliSmoke.description, /npx martin-loop/i);
   assert.match(plan.demoSmoke.description, /demo copies the packaged sandbox/i);
+  assert.match(plan.unsafeBypassSmoke.description, /unsafe-allow-unguarded-run/i);
 });
 
-test("runPublicFacadeSmoke proves the root SDK import, CLI help, and demo sandbox work from a clean temp project", async () => {
+test("runPublicFacadeSmoke proves the root SDK import, CLI help, demo sandbox, and unsafe gate bypass behavior from a clean temp project", async () => {
   const result = await runPublicFacadeSmoke({ rootDir: ROOT_DIR });
 
   assert.equal(result.packageName, "martin-loop");
@@ -33,4 +34,7 @@ test("runPublicFacadeSmoke proves the root SDK import, CLI help, and demo sandbo
   assert.equal(result.cliSmoke.command, "npx martin-loop --help");
   assert.equal(result.demoSmoke.ok, true);
   assert.equal(result.demoSmoke.command, "npx martin-loop demo --dir ./martin-loop-demo");
+  assert.equal(result.unsafeBypassSmoke.ok, true);
+  assert.match(result.unsafeBypassSmoke.command, /unsafe-allow-unguarded-run/);
+  assert.notEqual(result.unsafeBypassSmoke.exitCode, 8);
 });

--- a/scripts/tests/readme-public-surface.test.mjs
+++ b/scripts/tests/readme-public-surface.test.mjs
@@ -122,9 +122,9 @@ test("root README is a public product entry point", async () => {
   }
 
   assert.match(readme, /The open-source control plane for AI coding agents/i);
-  assert.match(readme, /npx martin-loop demo/);
-  assert.match(readme, /npx martin-loop run .* --proof --verify "npm test"/);
-  assert.match(readme, /npx martin-loop dossier --latest/);
+  assert.match(readme, /npx(?: -y)? martin-loop(?:@latest)? demo/);
+  assert.match(readme, /npx(?: -y)? martin-loop(?:@latest)? run .* --proof --verify "npm test"/);
+  assert.match(readme, /npx(?: -y)? martin-loop(?:@latest)? dossier --latest/);
   assert.match(readme, /npx martin-loop bench --suite under-3-challenge/);
   assert.match(readme, /pnpm --filter @martin\/benchmarks build/);
   assert.match(readme, /pnpm --filter @martin\/benchmarks eval/);


### PR DESCRIPTION
## Summary
- add packaged-facade smoke assertion that --unsafe-allow-unguarded-run does not fail with local receipt-gate policy_blocked
- add CLI integration regression test proving unsafe bypass in live mode is not blocked by local receipt-chain gate
- update public quickstart/reference/README onboarding commands to deterministic 
px -y martin-loop@latest
- update README surface tests for the new deterministic command style

## Why
This closes the two open trust blockers from audit follow-up:
1) future packaged releases now hard-fail CI if unsafe bypass regresses into policy gate behavior,
2) public onboarding copy now defaults to deterministic npx invocation to avoid stale local-cache confusion.

## Validation
- pnpm --filter @martin/cli test
- pnpm public:copy-scan
- pnpm public:git-surface
- 
ode --test scripts/tests/readme-public-surface.test.mjs
- 
ode --test scripts/tests/public-facade.test.mjs
- pnpm public:smoke
