### PR TITLE
Align version ledger to live root 0.3.2 truth

### DIFF
--- a/docs/release/VERSION-LEDGER.md
+++ b/docs/release/VERSION-LEDGER.md
@@ -4,10 +4,10 @@ This file is the release source of truth for package/version mapping in this rep
 
 ## Root package: `martin-loop`
 
-- live npm dist-tag `latest`: `0.3.1`
-- live public GitHub release: `v0.3.1`
-- live public baseline in this train: `0.3.1`
-- root public baseline: `0.3.1`
+- live npm dist-tag `latest`: `0.3.2`
+- live public GitHub release: `v0.3.2`
+- live public baseline in this train: `0.3.2`
+- root public baseline: `0.3.2`
 - releases consumed since the original `0.2.8` launch:
   - `0.2.9` fixed proof-run classification, Windows `.cmd` resolution, and public provider defaults
   - `0.2.10` tightened verifier evidence, `--runs-dir` consistency, and public help output

--- a/scripts/tests/mcp-release-docs.test.mjs
+++ b/scripts/tests/mcp-release-docs.test.mjs
@@ -31,7 +31,10 @@ test("version ledger records live public truth and the next release train", asyn
   const ledger = await readRepoFile(path.join("docs", "release", "VERSION-LEDGER.md"));
 
   assert.match(ledger, /root public baseline: `\d+\.\d+\.\d+`/);
-  assert.match(ledger, /live public GitHub release: `v0\.3\.1`/);
+  assert.match(
+    ledger,
+    new RegExp(escapeRegex(`live public GitHub release: \`v${rootPackageJson.version}\``))
+  );
   assert.match(
     ledger,
     new RegExp(escapeRegex("standalone MCP public baseline: `0.3.1`"))


### PR DESCRIPTION
## Summary
- update root version ledger live baseline to 