### PR TITLE
Add guided start onboarding and governed-default first-run flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Use it when AI coding work needs to stay bounded, inspectable, and safe to revie
 Try MartinLoop in a disposable demo workspace:
 
 ```sh
+npx -y martin-loop@latest start
 npx -y martin-loop@latest demo
 npx -y martin-loop@latest --version
 cd martin-loop-demo
@@ -33,7 +34,7 @@ npx -y martin-loop@latest dossier --latest
 npx -y martin-loop@latest share --latest
 ```
 
-`doctor`, `session-start`, and `preflight` create the local receipts MartinLoop expects before a real governed run.
+`start` prints the first-run guided path. `doctor`, `session-start`, and `preflight` create the local receipts MartinLoop expects before a real governed run.
 
 `share --latest` writes three files into the selected run directory under `share/`: `run-receipt.json`, `run-receipt.md`, and `proof-card.svg`.
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -12,6 +12,7 @@ Use this guide to get one governed MartinLoop run and one evidence review in a f
 ## Recommended First Run
 
 ```sh
+npx -y martin-loop@latest start
 npx -y martin-loop@latest demo
 cd martin-loop-demo
 npm install

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -6,6 +6,8 @@ The published binary is `martin-loop`. Public installs, docs, and examples shoul
 
 ```text
 martin-loop --version
+martin-loop start
+martin-loop tour
 martin-loop doctor
 martin-loop demo
 martin-loop session-start [--host <claude|codex|gemini|generic>]
@@ -30,6 +32,7 @@ martin-loop mcp install --host <codex|claude|gemini|generic>
 Use this sequence when you are new to the product or setting up a fresh repo:
 
 ```sh
+npx -y martin-loop@latest start
 npx -y martin-loop@latest --version
 npx -y martin-loop@latest demo
 cd martin-loop-demo

--- a/docs/release/OSS-0.3.3-RELEASE-NOTES.md
+++ b/docs/release/OSS-0.3.3-RELEASE-NOTES.md
@@ -1,0 +1,34 @@
+# MartinLoop 0.3.3 Release Notes
+
+`0.3.3` hardens first-run onboarding and closes packaged-surface trust gaps discovered after `0.3.2`.
+
+## What Changed
+
+- Added `martin-loop start` as the first-run guided command.
+- Added `martin-loop tour` as a compatibility alias for `start`.
+- Help output now surfaces onboarding commands directly (`start`, `demo`, `doctor`).
+- Install-time onboarding prompt now shows a deterministic command path:
+  - `npx -y martin-loop@latest start`
+  - `npx -y martin-loop@latest demo`
+- Public facade smoke validation now asserts that `--unsafe-allow-unguarded-run` does not regress into a local receipt-gate `policy_blocked` failure on packaged installs.
+- Updated public docs and quickstart examples to deterministic `npx -y martin-loop@latest ...` command forms.
+
+## Why This Matters
+
+- New users get a clear path immediately after install, without guessing command order.
+- Governed runs remain default behavior: MartinLoop still enforces doctor/session-start/preflight receipts before live spend.
+- Release validation now catches packaged CLI regressions earlier, before publish.
+
+## Quick Check
+
+```sh
+npx -y martin-loop@latest start
+npx -y martin-loop@latest demo
+cd martin-loop-demo
+npm install
+npx -y martin-loop@latest doctor
+npx -y martin-loop@latest session-start
+npx -y martin-loop@latest preflight "Summarize the demo workspace and prove tests still pass" --verify "npm test"
+npx -y martin-loop@latest run "Summarize the demo workspace and prove tests still pass" --proof --verify "npm test"
+npx -y martin-loop@latest share --latest --json
+```

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "access": "public"
   },
   "scripts": {
+    "postinstall": "node -e \"if(process.env.CI==='true'||process.env.MARTIN_SUPPRESS_POSTINSTALL==='1'){process.exit(0)};const lines=['','MartinLoop installed. First-run guided flow:','  npx -y martin-loop@latest start','  npx -y martin-loop@latest demo','  npx -y martin-loop@latest run \\\"your objective\\\" --verify \\\"npm test\\\"','','Governed runs are default. MartinLoop enforces doctor/session-start/preflight before live run spend.'];console.log(lines.join('\\\\n'));\"",
     "build": "pnpm --filter @martin/contracts build && pnpm --filter @martin/core build && pnpm --filter @martin/adapters build && pnpm --filter @martin/benchmarks build && pnpm --filter @martin/cli build && pnpm --filter @martinloop/mcp build && node ./scripts/build-public-facade.mjs",
     "bench:build": "pnpm --filter @martin/benchmarks build",
     "bench:test": "pnpm --filter @martin/benchmarks test",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -82,7 +82,7 @@ import {
   type IntegrityStatus
 } from "./run-store.js";
 import { CliCommandError, renderCliError, renderCliSuccess } from "./ux.js";
-import { evaluateCliRunGate, recordCliWorkflowStep } from "./workflow-state.js";
+import { consumeFirstRunBanner, evaluateCliRunGate, recordCliWorkflowStep } from "./workflow-state.js";
 
 const require = createRequire(import.meta.url);
 const packageJson = require("../package.json") as { version: string };
@@ -191,6 +191,12 @@ type DoctorCommand = {
   runsDir?: string;
   engine?: "claude" | "codex" | "gemini" | "openai";
   configPath?: string;
+};
+
+type StartCommand = {
+  command: "start";
+  cwd?: string;
+  runsDir?: string;
 };
 
 type NativePhaseCommand = {
@@ -346,6 +352,7 @@ export type ParsedCliArguments =
     }
   | InspectCommand
   | ResumeCommand
+  | StartCommand
   | DoctorCommand
   | NativePhaseCommand
   | PreflightCommand
@@ -371,9 +378,12 @@ export async function executeCli(args: string[]): Promise<{
 
     switch (parsed.command) {
       case "help":
+        const firstRunBanner = await consumeFirstRunBanner(
+          resolveCliEnvironment().runsRoot
+        ).catch(() => undefined);
         return {
           exitCode: 0,
-          stdout: renderCliHelp(),
+          stdout: firstRunBanner ? `${firstRunBanner}\n\n${renderCliHelp()}` : renderCliHelp(),
           stderr: ""
         };
       case "version":
@@ -405,6 +415,8 @@ export async function executeCli(args: string[]): Promise<{
         return await executeInspectCommand(parsed, outputMode);
       case "resume":
         return await executeResumeCommand(parsed, outputMode);
+      case "start":
+        return await executeStartCommand(parsed, outputMode);
       case "doctor":
         return await executeDoctorCommand(parsed, outputMode);
       case "native_phase":
@@ -495,6 +507,14 @@ export function parseCliArguments(args: string[]): ParsedCliArguments {
         loopId,
         ...(readOption(rest, "--runs-dir") ? { runsDir: readOption(rest, "--runs-dir") } : {})
       }
+    };
+  }
+
+  if (command === "start" || command === "tour") {
+    return {
+      command: "start",
+      ...(readOption(rest, "--cwd") ? { cwd: readOption(rest, "--cwd") } : {}),
+      ...(readOption(rest, "--runs-dir") ? { runsDir: readOption(rest, "--runs-dir") } : {})
     };
   }
 
@@ -662,6 +682,8 @@ export function renderCliHelp(): string {
     "",
     "Usage:",
     "  martin run <objective> [options]",
+    "  martin start [options]",
+    "  martin tour [options]                (compatibility alias for start)",
     "  martin-loop run <objective> [options]    (published alias)",
     "  martin preflight <objective> [options]",
     "  martin doctor [options]",
@@ -687,6 +709,7 @@ export function renderCliHelp(): string {
     "  martin badge [--format svg|json]",
     "",
     "Operator commands:",
+    "  start        Guided first-run onboarding and governed command path.",
     "  doctor       Check CLI, engine, working directory, and run-store readiness.",
     "  session-start Show latest local run state, phase state, and command hints.",
     "  phase status    Read local phase state and run-store posture.",
@@ -1237,6 +1260,74 @@ async function executeDoctorCommand(
     ],
     quiet: environment.runsRoot,
     warnings
+  });
+}
+
+async function executeStartCommand(
+  command: StartCommand,
+  outputMode: MartinOutputMode
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  const environment = resolveCliEnvironment({
+    cwd: command.cwd,
+    runsDir: command.runsDir
+  });
+  const claudeAvailable = isCommandAvailable("claude");
+  const codexAvailable = resolveCliCommandAvailability("codex").available;
+  const geminiAvailable = resolveCliCommandAvailability("gemini").available;
+  const hasGitRepo = await stat(join(environment.workingDirectory, ".git"))
+    .then(() => true)
+    .catch(() => false);
+  const receiptScope = buildCliReceiptScope(environment);
+
+  await recordCliWorkflowStep({
+    runsRoot: environment.runsRoot,
+    step: "start",
+    workingDirectory: environment.workingDirectory,
+    receiptScope
+  }).catch(() => {});
+
+  return renderCliSuccess(outputMode, {
+    data: {
+      command: "start",
+      cliVersion: rootPackageVersion,
+      environment: {
+        ...environment,
+        hasGitRepo
+      },
+      engines: {
+        claude: { available: claudeAvailable },
+        codex: { available: codexAvailable },
+        gemini: { available: geminiAvailable }
+      },
+      governedByDefault: true,
+      nextCommands: [
+        "npx -y martin-loop@latest demo",
+        "npx -y martin-loop@latest doctor",
+        "npx -y martin-loop@latest session-start",
+        'npx -y martin-loop@latest preflight "Summarize the workspace and prove tests still pass" --verify "npm test"',
+        'npx -y martin-loop@latest run "Summarize the workspace and prove tests still pass" --proof --verify "npm test"',
+        "npx -y martin-loop@latest share --latest --json"
+      ]
+    },
+    human: [
+      `MartinLoop start (${rootPackageVersion})`,
+      "",
+      "Governed runs are the default path: MartinLoop blocks live run spend until doctor/session-start/preflight receipts exist.",
+      `Working directory: ${environment.workingDirectory}${hasGitRepo ? " (git detected)" : " (no git repo detected)"}`,
+      `Runs root: ${environment.runsRoot}`,
+      `Engines: claude=${claudeAvailable ? "ready" : "blocked"}, codex=${codexAvailable ? "ready" : "blocked"}, gemini=${geminiAvailable ? "ready" : "blocked"}`,
+      "",
+      "Recommended first-run commands:",
+      "  npx -y martin-loop@latest demo",
+      "  npx -y martin-loop@latest doctor",
+      "  npx -y martin-loop@latest session-start",
+      '  npx -y martin-loop@latest preflight "Summarize the workspace and prove tests still pass" --verify "npm test"',
+      '  npx -y martin-loop@latest run "Summarize the workspace and prove tests still pass" --proof --verify "npm test"',
+      "  npx -y martin-loop@latest share --latest --json",
+      "",
+      "One-off operator bypass exists, but is intentionally explicit: --unsafe-allow-unguarded-run"
+    ],
+    quiet: environment.runsRoot
   });
 }
 
@@ -2241,11 +2332,15 @@ function renderDemoInstructions(targetDirectory: string): string {
     "  npm install",
     "  npm test",
     "",
-    "Safe first run (no provider spend):",
-    '  MARTIN_LIVE=false npx martin run "Summarize the demo workspace and confirm the verifier is green" --verify "npm test"',
+    "Safe first run (no provider spend, governed path):",
+    "  npx -y martin-loop@latest doctor",
+    "  npx -y martin-loop@latest session-start",
+    '  npx -y martin-loop@latest preflight "Summarize the demo workspace and confirm the verifier is green" --verify "npm test"',
+    '  npx -y martin-loop@latest run "Summarize the demo workspace and confirm the verifier is green" --proof --verify "npm test"',
+    "  npx -y martin-loop@latest share --latest --json",
     "",
     "Optional live run:",
-    '  npx martin run "Add support for a discount percentage to summarizeInvoice and update the tests" --verify "npm test" --engine codex',
+    '  npx -y martin-loop@latest run "Add support for a discount percentage to summarizeInvoice and update the tests" --verify "npm test" --engine codex',
     "",
     `Task ideas live in ${join(targetDirectory, "TASKS.md")}`
   ].join("\n");

--- a/packages/cli/tests/cli-integration.test.ts
+++ b/packages/cli/tests/cli-integration.test.ts
@@ -254,7 +254,7 @@ describe("--engine flag", () => {
 
     expect(result.exitCode).toBe(8);
     expect(result.stderr).toContain("Governed run blocked until MartinLoop receipts exist");
-    expect(result.stderr).toMatch(/martin-loop (doctor|session-start)/);
+    expect(result.stderr).toMatch(/martin-loop (doctor|session-start|preflight)/);
   });
 
   it("accepts explicit unsafe gate bypass in live mode", { timeout: 15000 }, async () => {

--- a/packages/cli/tests/cli.test.ts
+++ b/packages/cli/tests/cli.test.ts
@@ -42,6 +42,11 @@ describe("parseCliArguments", () => {
     expect(parseCliArguments(["version"])).toEqual({ command: "version" });
   });
 
+  it("parses start and tour onboarding aliases", () => {
+    expect(parseCliArguments(["start"])).toEqual({ command: "start" });
+    expect(parseCliArguments(["tour"])).toEqual({ command: "start" });
+  });
+
   it("parses a run command into a typed request", () => {
     const parsed = parseCliArguments([
       "run",
@@ -121,6 +126,7 @@ describe("executeCli", () => {
 
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain("martin runs verify (--loop-id <id> | --file <path> | --latest) [options]");
+    expect(result.stdout).toContain("martin start [options]");
   });
 
   it("prints the public root package version", async () => {
@@ -134,6 +140,15 @@ describe("executeCli", () => {
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe(rootPackageVersion);
+  });
+
+  it("renders start onboarding guidance with governed defaults", async () => {
+    const result = await executeCli(["start"]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("MartinLoop start");
+    expect(result.stdout).toContain("Governed runs are the default path");
+    expect(result.stdout).toContain("npx -y martin-loop@latest demo");
   });
 
   it("resolves effectivePolicy from config and applies it to the run", async () => {
@@ -454,7 +469,8 @@ describe("executeCli", () => {
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain(targetDirectory);
       expect(result.stdout).toContain("npm install");
-      expect(result.stdout).toContain("MARTIN_LIVE=false");
+      expect(result.stdout).toContain("Safe first run (no provider spend, governed path)");
+      expect(result.stdout).toContain("npx -y martin-loop@latest doctor");
       expect(await readFile(join(targetDirectory, "README.md"), "utf8")).toContain("Demo Sandbox");
     } finally {
       process.chdir(previousCwd);


### PR DESCRIPTION
## Summary
- add martin-loop start guided onboarding command (with 	our alias)
- show first-run onboarding banner in help output via workflow-state first-run marker
- update demo output to deterministic governed command path (doctor -> session-start -> preflight -> run --proof -> share)
- add install-time onboarding prompt in package postinstall with deterministic command examples
- update README/quickstart/CLI reference with start-first flow and latest-pinned command style
- add docs/release/OSS-0.3.3-RELEASE-NOTES.md

## Behavior
- governed runs remain default and gated
- onboarding is explicit and user-visible
- one-off unsafe bypass remains explicit (--unsafe-allow-unguarded-run)

## Validation
- pnpm --filter @martin/cli test
- 
ode --test scripts/tests/readme-public-surface.test.mjs scripts/tests/public-facade.test.mjs
- pnpm public:copy-scan
- pnpm public:git-surface
- 
ode --test scripts/tests/mcp-release-docs.test.mjs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `martin-loop start` command providing guided first-run onboarding workflow
  * `martin-loop tour` now available as an alias for the start command
  * Installation displays onboarding instructions with suggested command examples

* **Documentation**
  * Updated Quick Start guide to include the new start command in first-run sequence
  * Updated CLI reference documentation to document start command and tour alias

<!-- end of auto-generated comment: release notes by coderabbit.ai -->