### PR TITLE
Execution-first governed run hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,15 +26,20 @@ npx -y martin-loop@latest demo
 npx -y martin-loop@latest --version
 cd martin-loop-demo
 npm install
-npx -y martin-loop@latest doctor
-npx -y martin-loop@latest session-start
-npx -y martin-loop@latest preflight "Summarize the demo workspace and prove tests still pass" --verify "npm test"
 npx -y martin-loop@latest run "Summarize the demo workspace and prove tests still pass" --proof --verify "npm test"
 npx -y martin-loop@latest dossier --latest
 npx -y martin-loop@latest share --latest
 ```
 
-`start` prints the first-run guided path. `doctor`, `session-start`, and `preflight` create the local receipts MartinLoop expects before a real governed run.
+`start` prints the first-run guided path. `run` auto-checks `doctor`, `session-start`, and `preflight`, then executes when the environment is ready. You can still run those commands directly when you want to inspect the governed checks first.
+
+Inspect-first flow:
+
+```sh
+npx -y martin-loop@latest doctor
+npx -y martin-loop@latest session-start
+npx -y martin-loop@latest preflight "Summarize the demo workspace and prove tests still pass" --verify "npm test"
+```
 
 `share --latest` writes three files into the selected run directory under `share/`: `run-receipt.json`, `run-receipt.md`, and `proof-card.svg`.
 
@@ -46,12 +51,10 @@ Use this lane from a clean temp directory to verify the public CLI flow exactly 
 
 ```sh
 npx -y martin-loop@0.3.2 --version
+npx -y martin-loop@0.3.2 start
 npx -y martin-loop@0.3.2 demo
 cd martin-loop-demo
 npm install
-npx -y martin-loop@0.3.2 doctor --json
-npx -y martin-loop@0.3.2 session-start --json
-npx -y martin-loop@0.3.2 preflight "Summarize the demo workspace and prove tests still pass" --verify "npm test" --json
 npx -y martin-loop@0.3.2 run "Summarize the demo workspace and prove tests still pass" --proof --verify "npm test" --json
 npx -y martin-loop@0.3.2 dossier --latest --json
 npx -y martin-loop@0.3.2 share --latest --json

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -16,15 +16,12 @@ npx -y martin-loop@latest start
 npx -y martin-loop@latest demo
 cd martin-loop-demo
 npm install
-npx -y martin-loop@latest doctor
-npx -y martin-loop@latest session-start
-npx -y martin-loop@latest preflight "Summarize the demo workspace and prove tests still pass" --verify "npm test"
 npx -y martin-loop@latest run "Summarize the demo workspace and prove tests still pass" --proof --verify "npm test"
 npx -y martin-loop@latest dossier --latest
 npx -y martin-loop@latest share --latest
 ```
 
-This path creates the local receipts MartinLoop expects before a real governed run, then proves the run/dossier loop without model spend.
+This path proves the run/dossier loop without model spend. `run` auto-checks `doctor`, `session-start`, and `preflight`, then executes when the environment is ready.
 
 ## Install the CLI
 
@@ -52,7 +49,15 @@ npx -y martin-loop@latest preflight "fix the auth regression" --verify "pnpm tes
 npx -y martin-loop@latest run "fix the auth regression" --budget 3.00 --verify "pnpm test"
 ```
 
-By default, MartinLoop expects recent `doctor`, `session-start`, and `preflight` receipts for the same repo and task before a real run will start.
+By default, MartinLoop auto-checks `doctor`, `session-start`, and `preflight` for the same repo and task before a real run will spend money. If preflight finds a real blocker, MartinLoop stops before live spend and tells you what to fix.
+
+If you want to inspect the governed checks first:
+
+```sh
+npx -y martin-loop@latest doctor
+npx -y martin-loop@latest session-start
+npx -y martin-loop@latest preflight "fix the auth regression" --verify "pnpm test"
+```
 
 ## Review Evidence
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -37,12 +37,11 @@ npx -y martin-loop@latest --version
 npx -y martin-loop@latest demo
 cd martin-loop-demo
 npm install
-npx -y martin-loop@latest doctor
-npx -y martin-loop@latest session-start
-npx -y martin-loop@latest preflight "Summarize the workspace and prove tests still pass" --verify "npm test"
 npx -y martin-loop@latest run "Summarize the workspace and prove tests still pass" --proof --verify "npm test"
 npx -y martin-loop@latest share --latest
 ```
+
+`run` auto-checks `doctor`, `session-start`, and `preflight`, then executes when the environment is ready. Run those commands directly when you want to inspect the governed checks first.
 
 ## Run Options
 
@@ -68,6 +67,14 @@ npx -y martin-loop@latest share --latest
 --workspace <id>        Workspace ID for the run record
 --project <id>          Project ID for the run record
 --metadata <key=value>  Attach metadata to the run record; repeatable
+```
+
+## Inspect-First Flow
+
+```sh
+npx -y martin-loop@latest doctor
+npx -y martin-loop@latest session-start
+npx -y martin-loop@latest preflight "fix the auth regression" --verify "pnpm test"
 ```
 
 ## Benchmark Reproduction

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -9,7 +9,7 @@ The `@martinloop/mcp` package exposes one primary coding execution entrypoint pl
 | `martin_doctor` | Check local MartinLoop and agent readiness. |
 | `martin_plan` | Outline scope, verification, and budget posture before spending a run. |
 | `martin_preflight` | Validate a proposed run contract before execution. |
-| `martin_run` | Execute a governed coding run after matching doctor, plan, and preflight receipts exist. |
+| `martin_run` | Execute a governed coding run. MartinLoop auto-runs the matching readiness checks and only stops when preflight finds a real blocker. |
 
 ## Status and Run Control
 

--- a/docs/release/OSS-0.3.3-RELEASE-NOTES.md
+++ b/docs/release/OSS-0.3.3-RELEASE-NOTES.md
@@ -11,12 +11,16 @@
   - `npx -y martin-loop@latest start`
   - `npx -y martin-loop@latest demo`
 - Public facade smoke validation now asserts that `--unsafe-allow-unguarded-run` does not regress into a local receipt-gate `policy_blocked` failure on packaged installs.
+- Public facade smoke validation now proves packaged `start` plus a healthy governed `run` from a clean temp install.
 - Updated public docs and quickstart examples to deterministic `npx -y martin-loop@latest ...` command forms.
+- `run` now auto-bootstraps doctor/session-start/preflight checks before enforcing the gate, so execution-ready environments proceed without manual setup churn.
+- `phase session-start` now works as the documented compatibility alias for the command-center flow.
 
 ## Why This Matters
 
 - New users get a clear path immediately after install, without guessing command order.
-- Governed runs remain default behavior: MartinLoop still enforces doctor/session-start/preflight receipts before live spend.
+- Governed runs remain default behavior, but the default path is now execution-first: `run` auto-checks the governed prerequisites and only stops when preflight finds a real blocker.
+- Execution-first behavior: if the environment is healthy, MartinLoop executes after auto-checks instead of stopping on missing local workflow-state markers.
 - Release validation now catches packaged CLI regressions earlier, before publish.
 
 ## Quick Check
@@ -26,9 +30,6 @@ npx -y martin-loop@latest start
 npx -y martin-loop@latest demo
 cd martin-loop-demo
 npm install
-npx -y martin-loop@latest doctor
-npx -y martin-loop@latest session-start
-npx -y martin-loop@latest preflight "Summarize the demo workspace and prove tests still pass" --verify "npm test"
 npx -y martin-loop@latest run "Summarize the demo workspace and prove tests still pass" --proof --verify "npm test"
 npx -y martin-loop@latest share --latest --json
 ```

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "access": "public"
   },
   "scripts": {
-    "postinstall": "node -e \"if(process.env.CI==='true'||process.env.MARTIN_SUPPRESS_POSTINSTALL==='1'){process.exit(0)};const lines=['','MartinLoop installed. First-run guided flow:','  npx -y martin-loop@latest start','  npx -y martin-loop@latest demo','  npx -y martin-loop@latest run \\\"your objective\\\" --verify \\\"npm test\\\"','','Governed runs are default. MartinLoop enforces doctor/session-start/preflight before live run spend.'];console.log(lines.join('\\\\n'));\"",
+    "postinstall": "node -e \"if(process.env.CI==='true'||process.env.MARTIN_SUPPRESS_POSTINSTALL==='1'){process.exit(0)};const lines=['','MartinLoop installed. First-run guided flow:','  npx -y martin-loop@latest start','  npx -y martin-loop@latest demo','  npx -y martin-loop@latest run \\\"your objective\\\" --verify \\\"npm test\\\"','','Governed runs are default. MartinLoop auto-checks doctor, session-start, and preflight, then executes when the environment is ready.'];console.log(lines.join('\\\\n'));\"",
     "build": "pnpm --filter @martin/contracts build && pnpm --filter @martin/core build && pnpm --filter @martin/adapters build && pnpm --filter @martin/benchmarks build && pnpm --filter @martin/cli build && pnpm --filter @martinloop/mcp build && node ./scripts/build-public-facade.mjs",
     "bench:build": "pnpm --filter @martin/benchmarks build",
     "bench:test": "pnpm --filter @martin/benchmarks test",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -540,6 +540,7 @@ export function parseCliArguments(args: string[]): ParsedCliArguments {
     if (
       subcommand === "status" ||
       subcommand === "contract" ||
+      subcommand === "session-start" ||
       subcommand === "preflight" ||
       subcommand === "run"
     ) {
@@ -828,6 +829,27 @@ async function executeRunCommand(
   const preRunWarnings: string[] = [];
 
   if (engineRequired && !resolvedRequest.unsafeAllowUnguardedRun) {
+    const bootstrap = await autoBootstrapGovernedRun({
+      request: resolvedRequest,
+      environment: cliEnvironment,
+      receiptScope
+    });
+    if (bootstrap.warnings.length > 0) {
+      preRunWarnings.push(...bootstrap.warnings);
+    }
+    if (!bootstrap.ready) {
+      throw new CliCommandError(
+        "policy_blocked",
+        "Governed run preflight blocked execution. Resolve the blocking issues and retry.",
+        {
+          suggestion: buildPreflightSuggestion(resolvedRequest.objective, resolvedRequest.verificationPlan),
+          details: {
+            blockingIssues: bootstrap.blockingIssues
+          }
+        }
+      );
+    }
+
     const gate = await evaluateCliRunGate({
       runsRoot: cliEnvironment.runsRoot,
       workingDirectory: cliEnvironment.workingDirectory,
@@ -992,6 +1014,126 @@ async function executeRunCommand(
     quiet: result.loop.loopId,
     warnings
   });
+}
+
+function buildPreflightSuggestion(objective: string, verificationPlan: string[]): string {
+  const verify = verificationPlan[0] ? ` --verify "${verificationPlan[0]}"` : "";
+  return `martin-loop preflight "${objective}"${verify}`;
+}
+
+function describeWorkflowPersistenceIssue(step: "doctor" | "session-start" | "preflight"): string {
+  if (step === "doctor") {
+    return "MartinLoop could not persist the doctor receipt needed for governed execution.";
+  }
+  if (step === "session-start") {
+    return "MartinLoop could not persist the session-start receipt needed for governed execution.";
+  }
+  return "MartinLoop could not persist the preflight receipt needed for governed execution.";
+}
+
+async function autoBootstrapGovernedRun(input: {
+  request: RunCommandRequest;
+  environment: ReturnType<typeof resolveCliEnvironment>;
+  receiptScope: ReturnType<typeof buildCliReceiptScope>;
+}): Promise<{
+  ready: boolean;
+  blockingIssues: string[];
+  warnings: string[];
+}> {
+  const preflightResult = await executePreflightCommand(input.request, "json");
+  let payload: {
+    ready?: boolean;
+    blockingIssues?: unknown;
+    warnings?: unknown;
+  } = {};
+  try {
+    payload = JSON.parse(preflightResult.stdout) as {
+      ready?: boolean;
+      blockingIssues?: unknown;
+      warnings?: unknown;
+    };
+  } catch {
+    return {
+      ready: false,
+      blockingIssues: ["Unable to parse preflight output."],
+      warnings: []
+    };
+  }
+
+  const blockingIssues = Array.isArray(payload.blockingIssues)
+    ? payload.blockingIssues.filter((item): item is string => typeof item === "string")
+    : [];
+  const warnings = Array.isArray(payload.warnings)
+    ? payload.warnings.filter((item): item is string => typeof item === "string")
+    : [];
+  if (payload.ready !== true) {
+    return {
+      ready: false,
+      blockingIssues,
+      warnings
+    };
+  }
+
+  const persistenceWarnings: string[] = [];
+  await recordCliWorkflowStep({
+    runsRoot: input.environment.runsRoot,
+    step: "doctor",
+    workingDirectory: input.environment.workingDirectory,
+    engine: input.environment.engine,
+    receiptScope: input.receiptScope
+  }).catch((error: unknown) => {
+    persistenceWarnings.push(
+      `${describeWorkflowPersistenceIssue("doctor")} ${error instanceof Error ? error.message : String(error)}`
+    );
+  });
+
+  await recordCliWorkflowStep({
+    runsRoot: input.environment.runsRoot,
+    step: "session-start",
+    workingDirectory: input.environment.workingDirectory,
+    engine: input.environment.engine,
+    receiptScope: input.receiptScope
+  }).catch((error: unknown) => {
+    persistenceWarnings.push(
+      `${describeWorkflowPersistenceIssue("session-start")} ${error instanceof Error ? error.message : String(error)}`
+    );
+  });
+
+  const gate = await evaluateCliRunGate({
+    runsRoot: input.environment.runsRoot,
+    workingDirectory: input.environment.workingDirectory,
+    objective: input.request.objective,
+    engine: input.environment.engine,
+    verificationPlan: input.request.verificationPlan,
+    mutationMode: input.request.mutationMode,
+    receiptScope: input.receiptScope,
+    allowedPaths: input.request.allowedPaths,
+    deniedPaths: input.request.deniedPaths,
+    budget: input.request.budget
+  });
+
+  if (!gate.allowed) {
+    const gateIssues =
+      gate.missingSteps.length > 0
+        ? gate.missingSteps
+            .filter(
+              (step): step is "doctor" | "session-start" | "preflight" =>
+                step === "doctor" || step === "session-start" || step === "preflight"
+            )
+            .map((step) => describeWorkflowPersistenceIssue(step))
+        : [gate.message];
+    return {
+      ready: false,
+      blockingIssues: persistenceWarnings.length > 0 ? persistenceWarnings : gateIssues,
+      warnings
+    };
+  }
+
+  return {
+    ready: true,
+    blockingIssues: [],
+    warnings: [...warnings, ...persistenceWarnings]
+  };
 }
 
 async function executeInspectCommand(
@@ -1312,7 +1454,7 @@ async function executeStartCommand(
     human: [
       `MartinLoop start (${rootPackageVersion})`,
       "",
-      "Governed runs are the default path: MartinLoop blocks live run spend until doctor/session-start/preflight receipts exist.",
+      "Governed runs are the default path: `run` auto-checks doctor, session-start, and preflight, then executes when the environment is ready.",
       `Working directory: ${environment.workingDirectory}${hasGitRepo ? " (git detected)" : " (no git repo detected)"}`,
       `Runs root: ${environment.runsRoot}`,
       `Engines: claude=${claudeAvailable ? "ready" : "blocked"}, codex=${codexAvailable ? "ready" : "blocked"}, gemini=${geminiAvailable ? "ready" : "blocked"}`,
@@ -2333,11 +2475,14 @@ function renderDemoInstructions(targetDirectory: string): string {
     "  npm test",
     "",
     "Safe first run (no provider spend, governed path):",
+    "  npx -y martin-loop@latest start",
+    '  npx -y martin-loop@latest run "Summarize the demo workspace and confirm the verifier is green" --proof --verify "npm test"',
+    "  npx -y martin-loop@latest share --latest --json",
+    "",
+    "Inspect the governed checks explicitly:",
     "  npx -y martin-loop@latest doctor",
     "  npx -y martin-loop@latest session-start",
     '  npx -y martin-loop@latest preflight "Summarize the demo workspace and confirm the verifier is green" --verify "npm test"',
-    '  npx -y martin-loop@latest run "Summarize the demo workspace and confirm the verifier is green" --proof --verify "npm test"',
-    "  npx -y martin-loop@latest share --latest --json",
     "",
     "Optional live run:",
     '  npx -y martin-loop@latest run "Add support for a discount percentage to summarizeInvoice and update the tests" --verify "npm test" --engine codex',

--- a/packages/cli/tests/cli-integration.test.ts
+++ b/packages/cli/tests/cli-integration.test.ts
@@ -3,7 +3,7 @@
  * and the MARTIN_LIVE guard introduced with the real adapter.
  */
 
-import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
@@ -129,6 +129,22 @@ function initializeGitRepo(directory: string): void {
   }
 }
 
+function normalizeWorkingDirectoryForExpectation(workingDirectory: string): string {
+  return process.platform === "win32" ? workingDirectory.toLowerCase() : workingDirectory;
+}
+
+async function readWorkflowState(
+  runsRoot: string
+): Promise<{ cli?: Record<string, unknown> } | undefined> {
+  try {
+    return JSON.parse(await readFile(join(runsRoot, "_martin", "workflow-state.json"), "utf8")) as {
+      cli?: Record<string, unknown>;
+    };
+  } catch {
+    return undefined;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // MARTIN_LIVE guard
 // ---------------------------------------------------------------------------
@@ -236,25 +252,99 @@ describe("--engine flag", () => {
   });
 
   it("blocks live run execution before spend when the governed receipt chain is missing", { timeout: 15000 }, async () => {
-    const result = await withoutAgentCliOnPath(() =>
-      withEnv("MARTIN_LIVE", "true", () =>
-        executeCli([
-          "run",
-          "--objective",
-          "Fix the bug",
-          "--verify",
-          NOOP_VERIFIER,
-          "--max-iterations",
-          "1",
-          "--budget-usd",
-          "2"
-        ])
-      )
-    );
+    await withTempDir(async (workspace) => {
+      const runsDir = join(workspace, ".martin-runs");
+      const result = await withoutAgentCliOnPath(() =>
+        withEnv("MARTIN_LIVE", "true", () =>
+          executeCli([
+            "run",
+            "--cwd",
+            workspace,
+            "--runs-dir",
+            runsDir,
+            "--objective",
+            "Fix the bug",
+            "--verify",
+            NOOP_VERIFIER,
+            "--max-iterations",
+            "1",
+            "--budget-usd",
+            "2"
+          ])
+        )
+      );
 
-    expect(result.exitCode).toBe(8);
-    expect(result.stderr).toContain("Governed run blocked until MartinLoop receipts exist");
-    expect(result.stderr).toMatch(/martin-loop (doctor|session-start|preflight)/);
+      expect(result.exitCode).toBe(8);
+      expect(result.stderr).toContain("Governed run preflight blocked execution");
+      expect(result.stderr).toContain("martin-loop preflight");
+
+      const workflowState = await readWorkflowState(runsDir);
+      const cliState = (workflowState?.cli ?? {}) as Record<string, unknown>;
+      expect(cliState.doctor).toBeUndefined();
+      expect(cliState["session-start"]).toBeUndefined();
+      expect(cliState.preflight).toBeUndefined();
+    });
+  });
+
+  it("auto-bootstraps governed prerequisites and executes a live Codex run when host is ready", { timeout: 45000 }, async () => {
+    await withTempDir((workspace) =>
+      withFakeCodexCli(async () => {
+        initializeGitRepo(workspace);
+        const runsDir = join(workspace, ".martin-runs");
+        const result = await withEnv("MARTIN_LIVE", "true", () =>
+          executeCli([
+            "--json",
+            "run",
+            "--engine",
+            "codex",
+            "--cwd",
+            workspace,
+            "--runs-dir",
+            runsDir,
+            "--objective",
+            "Fix the bug",
+            "--verify",
+            NOOP_VERIFIER,
+            "--max-iterations",
+            "1",
+            "--budget-usd",
+            "2",
+          ])
+        );
+
+        expect(result.exitCode).toBe(0);
+        const payload = JSON.parse(result.stdout);
+        expect(payload.command).toBe("run");
+        expect(payload.environment.engine).toBe("codex");
+        expect(payload.environment.liveMode).toBe("live");
+        expect(payload.loop.loopId).toMatch(/^loop_/u);
+        expect(payload.loop.attempts).toHaveLength(1);
+        expect(payload.loop.attempts[0].adapterId).toBe("agent-cli:codex");
+        expect(payload.loop.attempts[0].summary).toContain("fake codex completed");
+        const verificationEvent = payload.loop.events.find((event: { type: string }) => event.type === "verification.completed");
+        expect(verificationEvent?.payload?.passed).toBe(true);
+        expect(verificationEvent?.payload?.summary).toContain("passed");
+
+        const workflowState = await readWorkflowState(runsDir);
+        const cliState = (workflowState?.cli ?? {}) as Record<string, { workingDirectory?: string }>;
+        const normalizedWorkingDirectory = normalizeWorkingDirectoryForExpectation(payload.environment.workingDirectory);
+        expect(cliState.doctor?.workingDirectory).toBe(normalizedWorkingDirectory);
+        expect(cliState["session-start"]?.workingDirectory).toBe(normalizedWorkingDirectory);
+        expect(cliState.preflight?.workingDirectory).toBe(normalizedWorkingDirectory);
+
+        const verifyResult = await executeCli([
+          "--json",
+          "runs",
+          "verify",
+          "--latest",
+          "--runs-dir",
+          runsDir
+        ]);
+        expect(verifyResult.exitCode).toBe(0);
+        const verificationPayload = JSON.parse(verifyResult.stdout);
+        expect(verificationPayload.verification.status).toBe("passed");
+      })
+    );
   });
 
   it("accepts explicit unsafe gate bypass in live mode", { timeout: 15000 }, async () => {
@@ -276,7 +366,7 @@ describe("--engine flag", () => {
     );
 
     expect(result.exitCode).not.toBe(8);
-    expect(result.stderr).not.toContain("Governed run blocked until MartinLoop receipts exist");
+    expect(result.stderr).not.toContain("Governed run preflight blocked execution");
   });
 });
 

--- a/packages/cli/tests/cli.test.ts
+++ b/packages/cli/tests/cli.test.ts
@@ -148,6 +148,7 @@ describe("executeCli", () => {
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain("MartinLoop start");
     expect(result.stdout).toContain("Governed runs are the default path");
+    expect(result.stdout).toContain("auto-checks doctor, session-start, and preflight");
     expect(result.stdout).toContain("npx -y martin-loop@latest demo");
   });
 
@@ -470,7 +471,8 @@ describe("executeCli", () => {
       expect(result.stdout).toContain(targetDirectory);
       expect(result.stdout).toContain("npm install");
       expect(result.stdout).toContain("Safe first run (no provider spend, governed path)");
-      expect(result.stdout).toContain("npx -y martin-loop@latest doctor");
+      expect(result.stdout).toContain("npx -y martin-loop@latest start");
+      expect(result.stdout).toContain("Inspect the governed checks explicitly");
       expect(await readFile(join(targetDirectory, "README.md"), "utf8")).toContain("Demo Sandbox");
     } finally {
       process.chdir(previousCwd);

--- a/packages/cli/tests/operator-commands.test.ts
+++ b/packages/cli/tests/operator-commands.test.ts
@@ -23,6 +23,22 @@ async function withEnv<T>(key: string, value: string, fn: () => Promise<T>): Pro
   }
 }
 
+async function withoutAgentCliOnPath<T>(fn: () => Promise<T>): Promise<T> {
+  const pathKey = Object.keys(process.env).find((key) => key.toLowerCase() === "path") ?? "PATH";
+  const original = process.env[pathKey];
+  process.env[pathKey] = "";
+
+  try {
+    return await fn();
+  } finally {
+    if (original === undefined) {
+      delete process.env[pathKey];
+    } else {
+      process.env[pathKey] = original;
+    }
+  }
+}
+
 function makeLoopRecord(): LoopRecord {
   const loop = createLoopRecord({
     workspaceId: "ws_ops",
@@ -205,25 +221,27 @@ describe("operator commands", () => {
     });
   });
 
-  it("blocks live run execution before spend when the governed receipt chain is missing", async () => {
+  it("blocks live run execution before spend when the governed receipt chain is missing", { timeout: 45000 }, async () => {
     await withRunsRoot(async () => {
-      const result = await executeCli([
-        "run",
-        "--objective",
-        "Repair the failing MCP lane",
-        "--engine",
-        "codex",
-        "--verify",
-        "pnpm --filter @martinloop/mcp test",
-        "--budget-usd",
-        "2",
-        "--max-iterations",
-        "1"
-      ]);
+      const result = await withoutAgentCliOnPath(() =>
+        executeCli([
+          "run",
+          "--objective",
+          "Repair the failing MCP lane",
+          "--engine",
+          "codex",
+          "--verify",
+          "pnpm --filter @martinloop/mcp test",
+          "--budget-usd",
+          "2",
+          "--max-iterations",
+          "1"
+        ])
+      );
 
       expect(result.exitCode).toBe(8);
-      expect(result.stderr).toContain("Governed run blocked until MartinLoop receipts exist");
-      expect(result.stderr).toContain("martin-loop doctor");
+      expect(result.stderr).toContain("Governed run preflight blocked execution");
+      expect(result.stderr).toContain("martin-loop preflight");
     });
   });
 

--- a/packages/cli/tests/phase-command-center.test.ts
+++ b/packages/cli/tests/phase-command-center.test.ts
@@ -161,6 +161,12 @@ describe("native phase command center", () => {
       host: "claude",
       execute: false
     });
+    expect(parseCliArguments(["phase", "session-start", "--host", "claude"])).toEqual({
+      command: "native_phase",
+      subcommand: "session-start",
+      host: "claude",
+      execute: false
+    });
     expect(parseCliArguments(["phase", "run", "--execute", "--run-scan-limit", "5"])).toEqual({
       command: "native_phase",
       subcommand: "run",
@@ -237,6 +243,42 @@ describe("native phase command center", () => {
         expect(payload.sessionStart.hostDiagnostics.codex.launchReady).toBe(true);
         expect(payload.sessionStart.commands[0]).toContain(`--cwd ${rootDir}`);
         expect(payload.sessionStart.commands[0]).toContain(`--runs-dir ${runsDir}`);
+      });
+    } finally {
+      if (previousLive === undefined) {
+        delete process.env.MARTIN_LIVE;
+      } else {
+        process.env.MARTIN_LIVE = previousLive;
+      }
+      await rm(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it("executes phase session-start as the documented compatibility alias", async () => {
+    const { rootDir, runsDir } = await createPhaseFixture();
+    const previousLive = process.env.MARTIN_LIVE;
+    process.env.MARTIN_LIVE = "true";
+
+    try {
+      await withFakeCodexCli(async () => {
+        await mkdir(join(rootDir, ".git"), { recursive: true });
+        const result = await executeCli([
+          "--json",
+          "phase",
+          "session-start",
+          "--host",
+          "codex",
+          "--cwd",
+          rootDir,
+          "--runs-dir",
+          runsDir
+        ]);
+        const payload = JSON.parse(result.stdout);
+
+        expect(result.exitCode).toBe(0);
+        expect(payload.command).toBe("session_start");
+        expect(payload.sessionStart.hostDiagnostics.engine).toBe("codex");
+        expect(payload.receiptScope.runsRoot).toBe(runsDir);
       });
     } finally {
       if (previousLive === undefined) {

--- a/scripts/public-facade-smoke.mjs
+++ b/scripts/public-facade-smoke.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { spawn } from "node:child_process";
-import { access, mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -27,8 +27,14 @@ export function createPublicFacadeSmokePlan(options = {}) {
     cliSmoke: {
       description: "npx martin-loop --help resolves through the root public package facade.",
     },
+    startSmoke: {
+      description: "npx martin-loop start prints the first-run governed workflow from a clean temp install.",
+    },
     demoSmoke: {
       description: "npx martin-loop demo copies the packaged sandbox from a clean temp install.",
+    },
+    governedRunSmoke: {
+      description: "npx martin-loop run auto-bootstraps governed prerequisites and executes when a healthy adapter is available.",
     },
     unsafeBypassSmoke: {
       description: "npx martin-loop run --unsafe-allow-unguarded-run bypasses the local receipt gate in packaged CLI builds.",
@@ -98,6 +104,11 @@ export async function runPublicFacadeSmoke(options = {}) {
       throw new Error(`Expected CLI help output to include "martin-loop run" or "Martin Loop CLI".\n${cliRun.stdout}${cliRun.stderr}`);
     }
 
+    const startRun = await runCommand(["npx", "martin-loop", "start"], { cwd: appDir });
+    if (!startRun.stdout.includes("MartinLoop start") || !startRun.stdout.includes("Governed runs are the default path")) {
+      throw new Error(`Expected start command to print the governed first-run flow.\n${startRun.stdout}${startRun.stderr}`);
+    }
+
     const demoTarget = path.join(appDir, "martin-loop-demo");
     const demoRun = await runCommand(["npx", "martin-loop", "demo", "--dir", demoTarget], {
       cwd: appDir,
@@ -105,6 +116,93 @@ export async function runPublicFacadeSmoke(options = {}) {
     const demoReadme = await readFile(path.join(demoTarget, "README.md"), "utf8");
     if (!/Martin\s*Loop demo sandbox created at/u.test(demoRun.stdout) || !demoReadme.includes("Demo Sandbox")) {
       throw new Error(`Expected demo command to copy the packaged sandbox.\n${demoRun.stdout}${demoRun.stderr}`);
+    }
+
+    await runCommand(["git", "init"], { cwd: appDir });
+    const governedRunsRoot = path.join(tempRoot, "runs");
+    const fakeCodexRoot = path.join(tempRoot, "fake-codex");
+    await mkdir(fakeCodexRoot, { recursive: true });
+    const fakeCodexPath = path.join(fakeCodexRoot, process.platform === "win32" ? "codex.cmd" : "codex");
+    await writeFile(
+      fakeCodexPath,
+      process.platform === "win32"
+        ? [
+            "@echo off",
+            "echo %* | findstr /C:\"--help\" >nul",
+            "if %errorlevel%==0 (",
+            "  echo usage: codex exec ...",
+            "  exit /b 0",
+            ")",
+            "echo {\"type\":\"item.completed\",\"item\":{\"type\":\"command_execution\",\"status\":\"completed\",\"exit_code\":0}}",
+            "echo {\"type\":\"item.completed\",\"item\":{\"type\":\"agent_message\",\"text\":\"fake codex completed\"}}",
+            "echo {\"type\":\"turn.completed\",\"usage\":{\"input_tokens\":10,\"output_tokens\":5}}",
+            "exit /b 0",
+            "",
+          ].join("\r\n")
+        : [
+            "#!/usr/bin/env sh",
+            "case \"$*\" in",
+            "  *--help*)",
+            "    echo 'usage: codex exec ...'",
+            "    ;;",
+            "  *)",
+            "    echo '{\"type\":\"item.completed\",\"item\":{\"type\":\"command_execution\",\"status\":\"completed\",\"exit_code\":0}}'",
+            "    echo '{\"type\":\"item.completed\",\"item\":{\"type\":\"agent_message\",\"text\":\"fake codex completed\"}}'",
+            "    echo '{\"type\":\"turn.completed\",\"usage\":{\"input_tokens\":10,\"output_tokens\":5}}'",
+            "    ;;",
+            "esac",
+            "",
+          ].join("\n"),
+      "utf8",
+    );
+    if (process.platform !== "win32") {
+      await chmod(fakeCodexPath, 0o755);
+    }
+
+    const governedRun = await runCommand(
+      [
+        "npx",
+        "martin-loop",
+        "run",
+        "--json",
+        "--engine",
+        "codex",
+        "--cwd",
+        appDir,
+        "--runs-dir",
+        governedRunsRoot,
+        "--objective",
+        "Summarize the demo workspace and confirm the verifier is green",
+        "--verify",
+        process.platform === "win32" ? "cmd /c exit 0" : "true",
+        "--max-iterations",
+        "1",
+        "--budget-usd",
+        "2",
+      ],
+      {
+        cwd: appDir,
+        env: {
+          MARTIN_LIVE: "true",
+          LOCALAPPDATA: fakeCodexRoot,
+          PATH: `${fakeCodexRoot}${path.delimiter}${process.env.PATH ?? ""}`,
+        },
+      },
+    );
+    const governedPayload = JSON.parse(governedRun.stdout);
+    if (
+      governedPayload.command !== "run" ||
+      governedPayload.loop?.attempts?.[0]?.adapterId !== "agent-cli:codex" ||
+      !governedPayload.loop?.attempts?.[0]?.summary?.includes("fake codex completed")
+    ) {
+      throw new Error(`Expected packaged governed run to execute with the fake Codex adapter.\n${governedRun.stdout}${governedRun.stderr}`);
+    }
+
+    const workflowState = JSON.parse(
+      await readFile(path.join(governedRunsRoot, "_martin", "workflow-state.json"), "utf8"),
+    );
+    if (!workflowState?.cli?.doctor || !workflowState?.cli?.["session-start"] || !workflowState?.cli?.preflight) {
+      throw new Error("Expected packaged governed run to persist doctor, session-start, and preflight workflow receipts.");
     }
 
     // This command is expected to fail in clean temp installs when an adapter cannot launch,
@@ -122,7 +220,10 @@ export async function runPublicFacadeSmoke(options = {}) {
       ],
       { cwd: appDir },
     );
-    if (/Governed run blocked until MartinLoop receipts exist/u.test(unsafeBypassRun.stderr)) {
+    if (
+      /Governed run blocked until MartinLoop receipts exist/u.test(unsafeBypassRun.stderr) ||
+      /Governed run preflight blocked execution/u.test(unsafeBypassRun.stderr)
+    ) {
       throw new Error(
         [
           "Expected --unsafe-allow-unguarded-run to bypass local receipt gating in packaged CLI.",
@@ -144,9 +245,18 @@ export async function runPublicFacadeSmoke(options = {}) {
         ok: true,
         command: "npx martin-loop --help",
       },
+      startSmoke: {
+        ok: true,
+        command: "npx martin-loop start",
+      },
       demoSmoke: {
         ok: true,
         command: "npx martin-loop demo --dir ./martin-loop-demo",
+      },
+      governedRunSmoke: {
+        ok: true,
+        command: "npx martin-loop run --json --engine codex --cwd . --runs-dir ./runs --objective \"Summarize the demo workspace and confirm the verifier is green\" --verify \"<platform verifier>\" --max-iterations 1 --budget-usd 2",
+        adapterId: governedPayload.loop.attempts[0].adapterId,
       },
       unsafeBypassSmoke: {
         ok: true,
@@ -156,14 +266,14 @@ export async function runPublicFacadeSmoke(options = {}) {
     };
   } finally {
     if (!options.keepTempDir) {
-      await rm(tempRoot, { force: true, recursive: true });
+      await rm(tempRoot, { force: true, recursive: true }).catch(() => {});
     }
   }
 }
 
 async function runCommand(command, options) {
   const execution = resolveRcCommandExecution(command, process.platform);
-  const env = buildLifecycleSafeEnv();
+  const env = buildLifecycleSafeEnv(options.env);
 
   return new Promise((resolve, reject) => {
     const child = spawn(execution.command, execution.args, {
@@ -208,7 +318,7 @@ async function runCommand(command, options) {
 
 async function runCommandAllowFailure(command, options) {
   const execution = resolveRcCommandExecution(command, process.platform);
-  const env = buildLifecycleSafeEnv();
+  const env = buildLifecycleSafeEnv(options.env);
 
   return new Promise((resolve, reject) => {
     const child = spawn(execution.command, execution.args, {
@@ -244,24 +354,11 @@ async function runCommandAllowFailure(command, options) {
 }
 
 async function ensureBuiltPublicFacade(rootDir) {
-  const requiredFiles = [
-    path.join(rootDir, "dist", "index.js"),
-    path.join(rootDir, "dist", "index.d.ts"),
-    path.join(rootDir, "dist", "bin", "martin-loop.js"),
-  ];
-  const allPresent = await Promise.all(
-    requiredFiles.map((filePath) => access(filePath).then(() => true).catch(() => false)),
-  );
-
-  if (allPresent.every(Boolean)) {
-    return;
-  }
-
   await runCommand(["pnpm", "build"], { cwd: rootDir });
 }
 
-function buildLifecycleSafeEnv(sourceEnv = process.env) {
-  const env = { ...sourceEnv };
+function buildLifecycleSafeEnv(overrides = {}) {
+  const env = { ...process.env, ...overrides };
 
   for (const key of Object.keys(env)) {
     if (

--- a/scripts/tests/public-facade.test.mjs
+++ b/scripts/tests/public-facade.test.mjs
@@ -18,11 +18,13 @@ test("createPublicFacadeSmokePlan targets the frozen public package surface", ()
   assert.equal(plan.npxCommand, "npx martin-loop --help");
   assert.match(plan.sdkSmoke.description, /MartinLoop root import/i);
   assert.match(plan.cliSmoke.description, /npx martin-loop/i);
+  assert.match(plan.startSmoke.description, /first-run governed workflow/i);
   assert.match(plan.demoSmoke.description, /demo copies the packaged sandbox/i);
+  assert.match(plan.governedRunSmoke.description, /auto-bootstraps governed prerequisites/i);
   assert.match(plan.unsafeBypassSmoke.description, /unsafe-allow-unguarded-run/i);
 });
 
-test("runPublicFacadeSmoke proves the root SDK import, CLI help, demo sandbox, and unsafe gate bypass behavior from a clean temp project", async () => {
+test("runPublicFacadeSmoke proves the root SDK import, CLI help, start flow, demo sandbox, governed run, and unsafe gate bypass behavior from a clean temp project", async () => {
   const result = await runPublicFacadeSmoke({ rootDir: ROOT_DIR });
 
   assert.equal(result.packageName, "martin-loop");
@@ -32,8 +34,12 @@ test("runPublicFacadeSmoke proves the root SDK import, CLI help, demo sandbox, a
   assert.equal(result.sdkSmoke.exportName, "MartinLoop");
   assert.equal(result.cliSmoke.ok, true);
   assert.equal(result.cliSmoke.command, "npx martin-loop --help");
+  assert.equal(result.startSmoke.ok, true);
+  assert.equal(result.startSmoke.command, "npx martin-loop start");
   assert.equal(result.demoSmoke.ok, true);
   assert.equal(result.demoSmoke.command, "npx martin-loop demo --dir ./martin-loop-demo");
+  assert.equal(result.governedRunSmoke.ok, true);
+  assert.equal(result.governedRunSmoke.adapterId, "agent-cli:codex");
   assert.equal(result.unsafeBypassSmoke.ok, true);
   assert.match(result.unsafeBypassSmoke.command, /unsafe-allow-unguarded-run/);
   assert.notEqual(result.unsafeBypassSmoke.exitCode, 8);


### PR DESCRIPTION
## Summary
- make governed `run` auto-bootstrap doctor, session-start, and preflight before execution
- ship the documented `phase session-start` compatibility alias and execution-first onboarding copy
- extend packaged smoke coverage to prove `start`, healthy governed packaged runs, and unsafe bypass behavior

## Verification
- `pnpm --filter @martin/cli test`
- `node --test scripts/tests/readme-public-surface.test.mjs scripts/tests/public-facade.test.mjs scripts/tests/mcp-release-docs.test.mjs`
- `pnpm public:copy-scan`
- `pnpm public:git-surface`
- `pnpm public:smoke`
- `pnpm release:validate-local`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Governed run execution now auto-performs readiness checks (doctor, session-start, preflight) before execution.
  * Added `session-start` as a compatibility alias for the phase command.

* **Documentation**
  * Updated quickstart, CLI reference, and release notes to reflect the simplified first-run workflow using `run --proof --verify`.
  * Added "Inspect-First Flow" section for users preferring explicit readiness checks.
  * Clarified auto-bootstrapping behavior in tool documentation.

* **Tests**
  * Enhanced test coverage for auto-bootstrapped governed runs and workflow receipts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->