### PR TITLE
Harden governed path policy and explicit integrity verdict classes

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -67,6 +67,7 @@ import {
   buildArtifactSummary,
   buildRunDossier,
   buildVerificationSummary,
+  buildVerificationSummaryWithIntegrity,
   computeScopeFingerprint,
   describeCostProvenance,
   findPersistedLoopEvidence,
@@ -815,6 +816,9 @@ async function executeRunCommand(
       telemetryDestination: resolvedGuardrails.telemetryDestination
     }
   };
+  const allowedPaths = normalizePathPolicyPatterns(resolvedRequest.allowedPaths, "allowedPaths");
+  const deniedPaths = normalizePathPolicyPatterns(resolvedRequest.deniedPaths, "deniedPaths");
+
   const cliEnvironment = resolveCliEnvironment({
     cwd: resolvedRequest.cwd,
     runsDir: resolvedRequest.runsDir,
@@ -858,8 +862,8 @@ async function executeRunCommand(
       verificationPlan: resolvedRequest.verificationPlan,
       mutationMode: effectiveMutationMode,
       receiptScope,
-      allowedPaths: resolvedRequest.allowedPaths,
-      deniedPaths: resolvedRequest.deniedPaths,
+      allowedPaths,
+      deniedPaths,
       budget: resolvedRequest.budget
     });
 
@@ -925,8 +929,8 @@ async function executeRunCommand(
         verificationPlan: resolvedRequest.verificationPlan,
         ...(effectiveMutationMode ? { mutationMode: effectiveMutationMode } : {}),
         repoRoot: cliEnvironment.workingDirectory,
-        ...(resolvedRequest.allowedPaths?.length ? { allowedPaths: resolvedRequest.allowedPaths } : {}),
-        ...(resolvedRequest.deniedPaths?.length ? { deniedPaths: resolvedRequest.deniedPaths } : {}),
+        ...(allowedPaths?.length ? { allowedPaths } : {}),
+        ...(deniedPaths?.length ? { deniedPaths } : {}),
         ...(resolvedRequest.acceptanceCriteria?.length
           ? { acceptanceCriteria: resolvedRequest.acceptanceCriteria }
           : {})
@@ -1569,6 +1573,8 @@ async function executePreflightCommand(
   });
   const warnings: string[] = [];
   const blockingIssues: string[] = [];
+  const allowedPaths = normalizePathPolicyPatterns(request.allowedPaths, "allowedPaths");
+  const deniedPaths = normalizePathPolicyPatterns(request.deniedPaths, "deniedPaths");
   const verificationPlan =
     request.verificationPlan.length > 0
       ? request.verificationPlan
@@ -1599,6 +1605,13 @@ async function executePreflightCommand(
   if (engineRequired && environment.engine === "gemini" && !geminiAvailability.available) {
     blockingIssues.push("Gemini CLI is not available on PATH.");
   }
+  if (engineRequired && environment.engine === "openai") {
+    const openAiPreflight = evaluateOpenAiPreflight();
+    if (openAiPreflight.blockingIssue) {
+      blockingIssues.push(openAiPreflight.blockingIssue);
+    }
+    warnings.push(...openAiPreflight.warnings);
+  }
   if (engineRequired && environment.engine === "codex" && codexProbe && !codexProbe.ok) {
     blockingIssues.push(codexProbe.summary);
   }
@@ -1606,8 +1619,8 @@ async function executePreflightCommand(
     warnings.push("No verification plan is configured for this run.");
   }
 
-  const overlappingPaths = (request.allowedPaths ?? []).filter((allowedPath) =>
-    (request.deniedPaths ?? []).includes(allowedPath)
+  const overlappingPaths = (allowedPaths ?? []).filter((allowedPath) =>
+    (deniedPaths ?? []).includes(allowedPath)
   );
   if (overlappingPaths.length > 0) {
     warnings.push(`The same path appears in both allow and deny lists: ${overlappingPaths.join(", ")}`);
@@ -1657,6 +1670,8 @@ async function executePreflightCommand(
     },
     request: {
       ...request,
+      ...(allowedPaths?.length ? { allowedPaths } : {}),
+      ...(deniedPaths?.length ? { deniedPaths } : {}),
       verificationPlan,
       budget: resolvedGuardrails.budget
     },
@@ -1677,8 +1692,8 @@ async function executePreflightCommand(
       engine: environment.engine,
       verificationPlan,
       receiptScope,
-      allowedPaths: request.allowedPaths,
-      deniedPaths: request.deniedPaths,
+      allowedPaths,
+      deniedPaths,
       budget: resolvedGuardrails.budget
     }).catch(() => {});
   }
@@ -1858,8 +1873,8 @@ async function executeRunsVerifyCommand(
   selector: MartinRunSelector,
   outputMode: MartinOutputMode
 ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
-  const detail = await loadPersistedLoop(selector);
-  const verification = buildVerificationSummary(detail.loop);
+  const detail = await loadPersistedLoop(selector, { requireCanonicalRunSelector: true });
+  const verification = await buildVerificationSummaryWithIntegrity(detail);
   const receiptScope = resolveReceiptScope(detail.loop, detail.runsRoot);
 
   return renderCliSuccess(outputMode, {
@@ -2262,7 +2277,7 @@ function parseMcpScope(host: MartinMcpHost, tokens: string[]): MartinMcpScope {
   if (scope === "local") {
     if (host !== "claude") {
       throw new CliCommandError("invalid_input", `Host ${host} does not support --scope local.`, {
-        suggestion: "Use --scope user or --scope project, or switch to --host claude."
+        suggestion: "Use --scope user or --scope project for this host, or switch to --host claude for --scope local."
       });
     }
 
@@ -2804,6 +2819,82 @@ function buildDoctorRecommendations(input: {
   }
 
   return recommendations;
+}
+
+function normalizePathPolicyPatterns(
+  values: string[] | undefined,
+  label: "allowedPaths" | "deniedPaths"
+): string[] | undefined {
+  if (!values || values.length === 0) {
+    return undefined;
+  }
+
+  const normalized = values.map((value) => value.trim()).filter((value) => value.length > 0);
+  if (normalized.length === 0) {
+    return undefined;
+  }
+
+  for (const value of normalized) {
+    const unixStyle = value.replace(/\\/gu, "/");
+    const segments = unixStyle.split("/").filter((segment) => segment.length > 0);
+    const hasTraversal = segments.includes("..");
+    const isAbsolutePath =
+      isAbsolute(value) || unixStyle.startsWith("/") || unixStyle.startsWith("//") || /^[A-Za-z]:\//u.test(unixStyle);
+
+    if (hasTraversal || isAbsolutePath) {
+      throw new CliCommandError(
+        "invalid_input",
+        `Invalid ${label}. Path patterns must be relative and stay within the repository.`,
+        {
+          suggestion:
+            "Use relative globs like `src/**` or `packages/cli/**` and avoid absolute paths or `..` traversal segments."
+        }
+      );
+    }
+  }
+
+  return [...new Set(normalized)];
+}
+
+function evaluateOpenAiPreflight(): { blockingIssue?: string; warnings: string[] } {
+  const baseUrl = (process.env["MARTIN_OPENAI_BASE_URL"] ?? "https://api.openai.com").trim();
+  const model = process.env["MARTIN_OPENAI_MODEL"]?.trim();
+  const apiKey = process.env["MARTIN_OPENAI_API_KEY"]?.trim();
+  const warnings: string[] = [];
+
+  if (!model) {
+    warnings.push(
+      "OpenAI engine preflight: MARTIN_OPENAI_MODEL is not set. Configure the exact model before running spend-bearing attempts."
+    );
+  }
+
+  if (isHostedOpenAiEndpoint(baseUrl) && !apiKey) {
+    return {
+      blockingIssue:
+        "OpenAI engine preflight blocked: MARTIN_OPENAI_API_KEY is required for hosted endpoints. Configure auth or switch MARTIN_OPENAI_BASE_URL to a trusted local endpoint.",
+      warnings
+    };
+  }
+
+  if (apiKey && isHostedOpenAiEndpoint(baseUrl)) {
+    warnings.push(
+      "OpenAI engine preflight: auth appears configured. If runs still fail, verify quota and billing separately from auth."
+    );
+  }
+
+  return { warnings };
+}
+
+function isHostedOpenAiEndpoint(baseUrl: string): boolean {
+  const normalized = baseUrl.toLowerCase();
+  return !(
+    normalized.startsWith("http://localhost") ||
+    normalized.startsWith("https://localhost") ||
+    normalized.startsWith("http://127.0.0.1") ||
+    normalized.startsWith("https://127.0.0.1") ||
+    normalized.startsWith("http://[::1]") ||
+    normalized.startsWith("https://[::1]")
+  );
 }
 
 function buildCliReceiptScope(environment: {

--- a/packages/cli/src/run-store.ts
+++ b/packages/cli/src/run-store.ts
@@ -135,6 +135,16 @@ export interface PersistedLoopDetail {
 }
 
 export type IntegrityStatus = ReceiptIntegritySummary["state"];
+export type VerificationIntegrityClassification =
+  | "tampered_payload"
+  | "missing_integrity_material"
+  | "schema_unknown_fields";
+
+export interface VerificationIntegrityStatus {
+  status: "passed" | "failed" | "unavailable";
+  summary: string;
+  classification?: VerificationIntegrityClassification;
+}
 
 export interface VerificationSummary {
   status: "passed" | "failed" | "unavailable";
@@ -144,6 +154,7 @@ export interface VerificationSummary {
   completedAt?: string;
   steps: VerificationStepSummary[];
   warnings: string[];
+  integrity?: VerificationIntegrityStatus;
 }
 
 export interface VerificationStepSummary {
@@ -273,7 +284,7 @@ export async function listPersistedLoops(
 
 export async function loadPersistedLoop(
   selector: MartinRunSelector,
-  options: { invocationRoot?: string } = {}
+  options: { invocationRoot?: string; requireCanonicalRunSelector?: boolean } = {}
 ): Promise<PersistedLoopDetail> {
   const runsRoot = resolveRunsRootPath(selector.runsDir, options.invocationRoot);
   const selectors = [
@@ -307,6 +318,9 @@ export async function loadPersistedLoop(
     if (targetStats.isDirectory()) {
       const canonical = await findCanonicalLoopRecordPath(targetPath);
       if (canonical) {
+        if (options.requireCanonicalRunSelector) {
+          assertCanonicalRunSelectorPath(canonical, runsRoot);
+        }
         return await attachReceiptIntegrity({
           source: canonical,
           runsRoot,
@@ -315,6 +329,17 @@ export async function loadPersistedLoop(
           runDirectory: path.dirname(canonical),
           loopRecordPath: canonical
         });
+      }
+
+      if (options.requireCanonicalRunSelector) {
+        throw new CliCommandError(
+          "invalid_input",
+          "File selector must resolve to a canonical run selector under the configured runs root.",
+          {
+            suggestion:
+              "Use --loop-id or --latest, or point --file at <runsRoot>/<loopId>/loop-record.json."
+          }
+        );
       }
 
       const inspected = await collectPersistedLoops(targetPath);
@@ -329,6 +354,10 @@ export async function loadPersistedLoop(
         loop,
         warnings: inspected.warnings
       });
+    }
+
+    if (options.requireCanonicalRunSelector) {
+      assertCanonicalRunSelectorPath(targetPath, runsRoot);
     }
 
     const loops = await readLoopsFromFile(targetPath, runsRoot);
@@ -351,6 +380,27 @@ export async function loadPersistedLoop(
     throw new CliCommandError("not_found", "No persisted Martin loops were found.");
   }
 
+  const canonicalDetail =
+    typeof loop.loopId === "string" ? await loadLoopById(loop.loopId, runsRoot).catch(() => undefined) : undefined;
+  if (canonicalDetail) {
+    return await attachReceiptIntegrity({
+      ...canonicalDetail,
+      runsRoot,
+      warnings: inspected.warnings
+    });
+  }
+
+  if (options.requireCanonicalRunSelector) {
+    throw new CliCommandError(
+      "invalid_input",
+      "File selector must resolve to a canonical run selector under the configured runs root.",
+      {
+        suggestion:
+          "Use --loop-id or --latest, or point --file at <runsRoot>/<loopId>/loop-record.json."
+      }
+    );
+  }
+
   return await attachReceiptIntegrity({
     source: runsRoot,
     runsRoot,
@@ -361,7 +411,7 @@ export async function loadPersistedLoop(
 
 export async function loadPersistedAttempt(
   selector: MartinRunSelector,
-  options: { invocationRoot?: string } = {}
+  options: { invocationRoot?: string; requireCanonicalRunSelector?: boolean } = {}
 ): Promise<{
   detail: PersistedLoopDetail;
   attempt: LoopRecord["attempts"][number];
@@ -382,7 +432,7 @@ export async function loadPersistedAttempt(
   return {
     detail,
     attempt,
-    verification: buildVerificationSummary(detail.loop)
+    verification: await buildVerificationSummaryWithIntegrity(detail)
   };
 }
 
@@ -458,6 +508,29 @@ export function buildVerificationSummary(loop: LoopRecord): VerificationSummary 
     completedAt: latestEvent.timestamp,
     steps,
     warnings
+  };
+}
+
+export async function buildVerificationSummaryWithIntegrity(
+  detail: PersistedLoopDetail
+): Promise<VerificationSummary> {
+  const verification = buildVerificationSummary(detail.loop);
+  const integrity = await assessReceiptIntegrity(detail);
+  const warnings = [...verification.warnings];
+  let summary = verification.summary;
+
+  if (integrity.status === "failed") {
+    warnings.push(`Integrity check failed (${integrity.classification ?? "unknown"}).`);
+    summary = `${verification.summary} Integrity: ${integrity.summary}`;
+  } else if (integrity.status === "unavailable") {
+    warnings.push("Integrity verification is unavailable for this selector.");
+  }
+
+  return {
+    ...verification,
+    summary,
+    warnings,
+    integrity
   };
 }
 
@@ -745,6 +818,168 @@ function resolveAbsolutePath(targetPath: string, base = resolveInvocationRoot())
   return path.isAbsolute(targetPath) ? path.normalize(targetPath) : path.resolve(base, targetPath);
 }
 
+function assertCanonicalRunSelectorPath(candidatePath: string, runsRoot: string): void {
+  const canonicalCandidate = path.resolve(candidatePath);
+  const canonicalRoot = path.resolve(runsRoot);
+  const relativePath = path.relative(canonicalRoot, canonicalCandidate);
+
+  if (relativePath === "" || relativePath === ".") {
+    return;
+  }
+
+  if (relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
+    throw new CliCommandError(
+      "invalid_input",
+      "File selector must resolve to a canonical run selector under the configured runs root.",
+      {
+        suggestion:
+          "Use --loop-id or --latest, or point --file at <runsRoot>/<loopId>/loop-record.json."
+      }
+    );
+  }
+}
+
+async function assessReceiptIntegrity(
+  detail: PersistedLoopDetail
+): Promise<VerificationIntegrityStatus> {
+  if (!detail.runDirectory || !detail.loopRecordPath) {
+    return {
+      status: "failed",
+      classification: "missing_integrity_material",
+      summary: "Missing canonical run directory context for receipt-integrity verification."
+    };
+  }
+
+  const runDirectory = detail.runDirectory;
+  const loopRecordPath = detail.loopRecordPath;
+  const integrityPath = path.join(runDirectory, "receipt-integrity.json");
+  const integrityRaw = await readFile(integrityPath, "utf8").catch(() => undefined);
+  if (!integrityRaw) {
+    return {
+      status: "failed",
+      classification: "missing_integrity_material",
+      summary: "receipt-integrity.json is missing."
+    };
+  }
+
+  const parsed = parseJsonRecord(integrityRaw);
+  if (!parsed) {
+    return {
+      status: "failed",
+      classification: "missing_integrity_material",
+      summary: "receipt-integrity.json is unreadable JSON."
+    };
+  }
+
+  const unknownFields = Object.keys(parsed).filter((key) => !RECEIPT_INTEGRITY_ALLOWED_TOP_KEYS.has(key));
+  if (unknownFields.length > 0) {
+    return {
+      status: "failed",
+      classification: "schema_unknown_fields",
+      summary: `receipt-integrity.json contains unsupported fields: ${unknownFields.join(", ")}.`
+    };
+  }
+
+  const schemaVersion = asNonEmptyString(parsed["schemaVersion"]);
+  const runId = asNonEmptyString(parsed["runId"]);
+  const loopRecordSha256 = asNonEmptyString(parsed["loopRecordSha256"]);
+  const ledgerSha256 = asNonEmptyString(parsed["ledgerSha256"]);
+  const ledgerHeadHash = asNonEmptyString(parsed["ledgerHeadHash"]);
+  const signatureHmacSha256 = asNonEmptyString(parsed["signatureHmacSha256"]);
+  if (
+    schemaVersion !== "martin.receipt-integrity.v1" ||
+    !runId ||
+    !loopRecordSha256 ||
+    !ledgerSha256 ||
+    !ledgerHeadHash ||
+    !signatureHmacSha256
+  ) {
+    return {
+      status: "failed",
+      classification: "missing_integrity_material",
+      summary: "receipt-integrity.json is missing required integrity fields."
+    };
+  }
+
+  if (runId !== detail.loop.loopId) {
+    return {
+      status: "failed",
+      classification: "tampered_payload",
+      summary: `receipt-integrity runId (${runId}) does not match loopId (${detail.loop.loopId}).`
+    };
+  }
+
+  const loopRecordRaw = await readFile(loopRecordPath, "utf8").catch(() => undefined);
+  if (!loopRecordRaw) {
+    return {
+      status: "failed",
+      classification: "missing_integrity_material",
+      summary: "Canonical loop-record.json is missing."
+    };
+  }
+  if (sha256(loopRecordRaw) !== loopRecordSha256) {
+    return {
+      status: "failed",
+      classification: "tampered_payload",
+      summary: "loop-record.json hash does not match receipt-integrity metadata."
+    };
+  }
+
+  const ledgerPath =
+    (await stat(path.join(runDirectory, "events.jsonl")).then(() => path.join(runDirectory, "events.jsonl")).catch(() => undefined)) ??
+    (await stat(path.join(runDirectory, "ledger.jsonl")).then(() => path.join(runDirectory, "ledger.jsonl")).catch(() => undefined));
+  if (!ledgerPath) {
+    return {
+      status: "failed",
+      classification: "missing_integrity_material",
+      summary: "No events.jsonl or ledger.jsonl was found for integrity verification."
+    };
+  }
+
+  const ledgerRaw = await readFile(ledgerPath, "utf8").catch(() => undefined);
+  if (!ledgerRaw) {
+    return {
+      status: "failed",
+      classification: "missing_integrity_material",
+      summary: "Ledger material is unreadable for integrity verification."
+    };
+  }
+
+  if (sha256(ledgerRaw) !== ledgerSha256) {
+    return {
+      status: "failed",
+      classification: "tampered_payload",
+      summary: "Ledger hash does not match receipt-integrity metadata."
+    };
+  }
+
+  if (Array.isArray(parsed["chain"])) {
+    const chain = parsed["chain"] as Array<Record<string, unknown>>;
+    const declaredEntryCount = typeof parsed["entryCount"] === "number" ? parsed["entryCount"] : undefined;
+    if (declaredEntryCount !== undefined && chain.length > 0 && declaredEntryCount !== chain.length) {
+      return {
+        status: "failed",
+        classification: "tampered_payload",
+        summary: "receipt-integrity chain length does not match entryCount."
+      };
+    }
+
+    const tailHash = asNonEmptyString(chain.at(-1)?.["entryHash"]);
+    if (tailHash && tailHash !== ledgerHeadHash) {
+      return {
+        status: "failed",
+        classification: "tampered_payload",
+        summary: "receipt-integrity ledgerHeadHash does not match chain tail hash."
+      };
+    }
+  }
+
+  return {
+    status: "passed",
+    summary: "Receipt integrity checks passed for loop-record and ledger material."
+  };
+}
+
 function resolveReceiptIntegrity(loop: LoopRecord): ReceiptIntegritySummary {
   return (
     loop.receiptIntegrity ?? {
@@ -1023,6 +1258,40 @@ function isWorkspaceIndexSummary(
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
+}
+
+const RECEIPT_INTEGRITY_ALLOWED_TOP_KEYS = new Set([
+  "schemaVersion",
+  "runId",
+  "keyId",
+  "signedAt",
+  "scope",
+  "loopRecordSha256",
+  "ledgerSha256",
+  "ledgerHeadHash",
+  "entryCount",
+  "chain",
+  "signatureHmacSha256"
+]);
+
+function parseJsonRecord(value: string): Record<string, unknown> | undefined {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return undefined;
+    }
+    return parsed as Record<string, unknown>;
+  } catch {
+    return undefined;
+  }
+}
+
+function asNonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
 }
 
 function readVerificationWarnings(payload: Record<string, unknown> | undefined): string[] {

--- a/packages/cli/tests/operator-commands.test.ts
+++ b/packages/cli/tests/operator-commands.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -148,6 +149,10 @@ async function withRunsRoot<T>(fn: (runsRoot: string) => Promise<T>): Promise<T>
   }
 }
 
+function sha256(input: string): string {
+  return createHash("sha256").update(input).digest("hex");
+}
+
 describe("operator commands", () => {
   it("doctor reports environment readiness and starter MCP tools", async () => {
     const result = await withEnv("MARTIN_LIVE", "false", () => executeCli(["--json", "doctor"]));
@@ -192,6 +197,71 @@ describe("operator commands", () => {
     expect(payload.scope.workingDirectory).toBe(missingDirectory);
     expect(payload.scope.repoRoot).toBe(missingDirectory);
     expect(payload.scope.runsRoot).toBeTypeOf("string");
+  });
+
+  it("adds actionable OpenAI preflight blockers when auth is missing on hosted endpoints", async () => {
+    const previousApiKey = process.env.MARTIN_OPENAI_API_KEY;
+    const previousBaseUrl = process.env.MARTIN_OPENAI_BASE_URL;
+    const previousModel = process.env.MARTIN_OPENAI_MODEL;
+    delete process.env.MARTIN_OPENAI_API_KEY;
+    delete process.env.MARTIN_OPENAI_BASE_URL;
+    delete process.env.MARTIN_OPENAI_MODEL;
+
+    try {
+      const result = await executeCli([
+        "--json",
+        "preflight",
+        "--objective",
+        "Repair the failing MCP lane",
+        "--engine",
+        "openai"
+      ]);
+      const payload = JSON.parse(result.stdout);
+
+      expect(result.exitCode).toBe(0);
+      expect(payload.command).toBe("preflight");
+      expect(payload.ready).toBe(false);
+      expect(payload.blockingIssues.join(" ")).toContain("MARTIN_OPENAI_API_KEY");
+      expect(payload.warnings.join(" ")).toContain("MARTIN_OPENAI_MODEL");
+    } finally {
+      if (previousApiKey === undefined) {
+        delete process.env.MARTIN_OPENAI_API_KEY;
+      } else {
+        process.env.MARTIN_OPENAI_API_KEY = previousApiKey;
+      }
+      if (previousBaseUrl === undefined) {
+        delete process.env.MARTIN_OPENAI_BASE_URL;
+      } else {
+        process.env.MARTIN_OPENAI_BASE_URL = previousBaseUrl;
+      }
+      if (previousModel === undefined) {
+        delete process.env.MARTIN_OPENAI_MODEL;
+      } else {
+        process.env.MARTIN_OPENAI_MODEL = previousModel;
+      }
+    }
+  });
+
+  it("rejects path-traversing allow/deny patterns during preflight", async () => {
+    const traversalAllow = await executeCli([
+      "preflight",
+      "--objective",
+      "Repair the failing MCP lane",
+      "--allow-path",
+      "..\\..\\*"
+    ]);
+    const traversalDeny = await executeCli([
+      "preflight",
+      "--objective",
+      "Repair the failing MCP lane",
+      "--deny-path",
+      "..\\..\\*"
+    ]);
+
+    expect(traversalAllow.exitCode).toBe(2);
+    expect(traversalAllow.stderr).toContain("Invalid allowedPaths.");
+    expect(traversalDeny.exitCode).toBe(2);
+    expect(traversalDeny.stderr).toContain("Invalid deniedPaths.");
   });
 
   it("preserves explicit --runs-dir overrides for preflight commands after the objective token", async () => {
@@ -372,6 +442,139 @@ describe("operator commands", () => {
     });
   });
 
+  it("classifies missing run integrity material explicitly in runs verify", async () => {
+    await withRunsRoot(async (runsRoot) => {
+      const loop = makeLoopRecord();
+      const loopDir = join(runsRoot, loop.loopId);
+      await mkdir(loopDir, { recursive: true });
+      await writeFile(join(loopDir, "loop-record.json"), JSON.stringify(loop, null, 2), "utf8");
+
+      const verify = JSON.parse(
+        (await executeCli(["--json", "runs", "verify", "--loop-id", loop.loopId])).stdout
+      );
+
+      expect(verify.command).toBe("runs_verify");
+      expect(verify.verification.integrity.status).toBe("failed");
+      expect(verify.verification.integrity.classification).toBe("missing_integrity_material");
+    });
+  });
+
+  it("classifies tampered payloads explicitly in runs verify", async () => {
+    await withRunsRoot(async (runsRoot) => {
+      const loop = makeLoopRecord();
+      const loopDir = join(runsRoot, loop.loopId);
+      const loopRecordContents = JSON.stringify(loop, null, 2);
+      const eventsContents = `${JSON.stringify(loop.events[0])}\n${JSON.stringify(loop.events[1])}\n`;
+      await mkdir(loopDir, { recursive: true });
+      await writeFile(join(loopDir, "loop-record.json"), loopRecordContents, "utf8");
+      await writeFile(join(loopDir, "events.jsonl"), eventsContents, "utf8");
+      await writeFile(
+        join(loopDir, "receipt-integrity.json"),
+        JSON.stringify(
+          {
+            schemaVersion: "martin.receipt-integrity.v1",
+            runId: loop.loopId,
+            keyId: "test-key",
+            signedAt: loop.updatedAt,
+            scope: {
+              invocationRoot: runsRoot,
+              workingDirectory: runsRoot,
+              repoRoot: runsRoot,
+              runsRoot
+            },
+            loopRecordSha256: "0000000000000000000000000000000000000000000000000000000000000000",
+            ledgerSha256: sha256(eventsContents),
+            ledgerHeadHash: "head-hash",
+            entryCount: loop.events.length,
+            chain: [],
+            signatureHmacSha256: "signature"
+          },
+          null,
+          2
+        ),
+        "utf8"
+      );
+
+      const verify = JSON.parse(
+        (await executeCli(["--json", "runs", "verify", "--loop-id", loop.loopId])).stdout
+      );
+
+      expect(verify.command).toBe("runs_verify");
+      expect(verify.verification.integrity.status).toBe("failed");
+      expect(verify.verification.integrity.classification).toBe("tampered_payload");
+    });
+  });
+
+  it("classifies unknown receipt-integrity fields explicitly in runs verify", async () => {
+    await withRunsRoot(async (runsRoot) => {
+      const loop = makeLoopRecord();
+      const loopDir = join(runsRoot, loop.loopId);
+      const loopRecordContents = JSON.stringify(loop, null, 2);
+      const eventsContents = `${JSON.stringify(loop.events[0])}\n${JSON.stringify(loop.events[1])}\n`;
+      await mkdir(loopDir, { recursive: true });
+      await writeFile(join(loopDir, "loop-record.json"), loopRecordContents, "utf8");
+      await writeFile(join(loopDir, "events.jsonl"), eventsContents, "utf8");
+      await writeFile(
+        join(loopDir, "receipt-integrity.json"),
+        JSON.stringify(
+          {
+            schemaVersion: "martin.receipt-integrity.v1",
+            runId: loop.loopId,
+            keyId: "test-key",
+            signedAt: loop.updatedAt,
+            scope: {
+              invocationRoot: runsRoot,
+              workingDirectory: runsRoot,
+              repoRoot: runsRoot,
+              runsRoot
+            },
+            loopRecordSha256: sha256(loopRecordContents),
+            ledgerSha256: sha256(eventsContents),
+            ledgerHeadHash: "head-hash",
+            entryCount: loop.events.length,
+            chain: [],
+            signatureHmacSha256: "signature",
+            hiddenProbeField: "should-be-rejected"
+          },
+          null,
+          2
+        ),
+        "utf8"
+      );
+
+      const verify = JSON.parse(
+        (await executeCli(["--json", "runs", "verify", "--loop-id", loop.loopId])).stdout
+      );
+
+      expect(verify.command).toBe("runs_verify");
+      expect(verify.verification.integrity.status).toBe("failed");
+      expect(verify.verification.integrity.classification).toBe("schema_unknown_fields");
+    });
+  });
+
+  it("rejects non-canonical selector file paths for run verification", async () => {
+    await withRunsRoot(async () => {
+      const externalRunsRoot = await mkdtemp(join(tmpdir(), "martin-cli-external-run-"));
+      const loop = makeLoopRecord();
+      const loopDir = join(externalRunsRoot, loop.loopId);
+      await mkdir(loopDir, { recursive: true });
+      await writeFile(join(loopDir, "loop-record.json"), JSON.stringify(loop, null, 2), "utf8");
+
+      try {
+        const verify = await executeCli([
+          "runs",
+          "verify",
+          "--file",
+          join(loopDir, "loop-record.json")
+        ]);
+        expect(verify.exitCode).toBe(2);
+        expect(verify.stderr).toContain("canonical run selector");
+      } finally {
+        await rm(externalRunsRoot, { recursive: true, force: true });
+      }
+    });
+  });
+
   it("reports unsigned for ad-hoc --file loads outside the selected runs root without minting a new local key", async () => {
     const externalRunsRoot = await mkdtemp(join(tmpdir(), "martin-cli-external-runs-"));
 
@@ -527,6 +730,8 @@ describe("operator commands", () => {
     expect(invalidScope.stderr).toContain("Invalid --scope value");
     expect(invalidLocalScope.exitCode).toBe(2);
     expect(invalidLocalScope.stderr).toContain("does not support --scope local");
+    expect(invalidLocalScope.stderr).toContain("--scope user");
+    expect(invalidLocalScope.stderr).toContain("--scope project");
     expect(invalidTransport.exitCode).toBe(2);
     expect(invalidTransport.stderr).toContain("Invalid --transport value");
     expect(invalidProfile.exitCode).toBe(2);


### PR DESCRIPTION
## Summary
- reject traversal/absolute allow/deny path specs in governed preflight/run flows
- add explicit verification integrity classifications (	ampered_payload, missing_integrity_material, schema_unknown_fields)
- enforce canonical selector scope for uns verify --file
- add OpenAI hosted preflight auth blockers and actionable hints
- improve MCP local-scope alternative guidance
- add/extend operator command tests for all above behavior

## Verification
- pnpm --dir . --filter @martin/cli test -- tests/operator-commands.test.ts
- pnpm --dir . --filter @martin/cli test -- tests/cli.test.ts
- pnpm --dir . --filter @martin/cli lint
- pnpm --dir . --filter @martin/cli test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Path pattern validation now rejects invalid patterns including traversal attempts, with immediate error feedback.
  * OpenAI endpoint detection warns when required authentication credentials are missing.

* **New Features**
  * Run verification now includes receipt integrity assessment with detailed status classification.
  * File-based run selection enforces canonical path validation against the configured root directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->