### PR TITLE
docs(release): align version ledger to live 0.3.4

### DIFF
--- a/docs/release/VERSION-LEDGER.md
+++ b/docs/release/VERSION-LEDGER.md
@@ -4,10 +4,10 @@ This file is the release source of truth for package/version mapping in this rep
 
 ## Root package: `martin-loop`
 
-- live npm dist-tag `latest`: `0.3.3`
-- live public GitHub release: `v0.3.3`
-- live public baseline in this train: `0.3.3`
-- root public baseline: `0.3.3`
+- live npm dist-tag `latest`: `0.3.4`
+- live public GitHub release: `v0.3.4`
+- live public baseline in this train: `0.3.4`
+- root public baseline: `0.3.4`
 - releases consumed since the original `0.2.8` launch:
   - `0.2.9` fixed proof-run classification, Windows `.cmd` resolution, and public provider defaults
   - `0.2.10` tightened verifier evidence, `--runs-dir` consistency, and public help output


### PR DESCRIPTION
## Summary
- update root live-release truth in docs/release/VERSION-LEDGER.md from 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version tracking to 0.3.4 across release systems

<!-- end of auto-generated comment: release notes by coderabbit.ai -->