### PR TITLE
test(cli): harden preflight path-policy coverage

### DIFF
--- a/packages/cli/tests/operator-commands.test.ts
+++ b/packages/cli/tests/operator-commands.test.ts
@@ -264,6 +264,28 @@ describe("operator commands", () => {
     expect(traversalDeny.stderr).toContain("Invalid deniedPaths.");
   });
 
+  it("rejects absolute allow/deny patterns during preflight", async () => {
+    const absoluteWindowsAllow = await executeCli([
+      "preflight",
+      "--objective",
+      "Repair the failing MCP lane",
+      "--allow-path",
+      "C:\\\\temp\\\\*"
+    ]);
+    const absolutePosixDeny = await executeCli([
+      "preflight",
+      "--objective",
+      "Repair the failing MCP lane",
+      "--deny-path",
+      "/tmp/*"
+    ]);
+
+    expect(absoluteWindowsAllow.exitCode).toBe(2);
+    expect(absoluteWindowsAllow.stderr).toContain("Invalid allowedPaths.");
+    expect(absolutePosixDeny.exitCode).toBe(2);
+    expect(absolutePosixDeny.stderr).toContain("Invalid deniedPaths.");
+  });
+
   it("preserves explicit --runs-dir overrides for preflight commands after the objective token", async () => {
     await withRunsRoot(async (runsRoot) => {
       const workingDirectory = await mkdtemp(join(tmpdir(), "martin-cli-preflight-workspace-"));


### PR DESCRIPTION
## Summary
- add explicit regression coverage for absolute `--allow-path` and `--deny-path` patterns during `martin preflight`
- keep the existing traversal checks and extend the same fail-closed guarantee to Windows and POSIX absolute path forms

## Why
Design-partner red-team feedback called out absolute/traversal path-policy probing as a critical lane. This patch ensures absolute-path probes stay permanently covered in the public CLI suite.

## Validation
- `pnpm --filter @martin/cli lint`
- `pnpm --filter @martin/cli test -- tests/operator-commands.test.ts`
- `pnpm public:copy-scan`
- `pnpm public:git-surface`
- `pnpm test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation tests to verify the `preflight` command properly rejects absolute path patterns in allow/deny configurations and reports appropriate error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->