### PR TITLE
fix(readme): restore NVIDIA Inception mention and logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
   **The open-source control plane for AI coding agents.**
 
   MartinLoop wraps Claude Code, Codex, Gemini, and MCP-aware agent workflows with budgets, verifier gates, policy checks, run receipts, and review-ready evidence.
+
+  MartinLoop has been accepted into the NVIDIA Inception program.
 </div>
 
 ## Why MartinLoop
@@ -284,6 +286,13 @@ pnpm test
 git commit -m "feat: describe what you built"
 git push -u origin feat/your-feature
 ```
+
+<div align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="./docs/assets/nvidia-inception-program.png">
+    <img src="./docs/assets/nvidia-inception-program-light.png" alt="NVIDIA Inception Program logo" width="280">
+  </picture>
+</div>
 
 ## License
 


### PR DESCRIPTION
## Summary\n- restore the README sentence confirming MartinLoop is in the NVIDIA Inception program\n- restore the NVIDIA Inception logo block near the bottom of README\n\n## Why\nThese elements were removed in commit c51c028 during public release-surface tightening, and this puts them back with a minimal, README-only diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README to include NVIDIA Inception program attribution and branding.
  * Added acknowledgment of the project's acceptance into the NVIDIA Inception program.
  * Added NVIDIA Inception program logo and imagery to the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->