### PR TITLE
docs(public): professionalize landing copy and navigation language

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,3 @@
+# GitHub Workflows
+
+This directory contains repository automation for CI, release validation, and policy checks that keep the public project surface reliable.

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
   Built from thousands of agent runs where the problem was not intelligence -- it was uncontrolled execution.
 
-  **Star this repo:** [GitHub stars](https://github.com/Keesan12/martin-loop)  
-  **Try it now:** `npx -y martin-loop@latest start`
+  **Get started:** `npx -y martin-loop@latest start`  
+  **Try the demo:** `npx -y martin-loop@latest demo`
 
   [![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue?style=flat-square&logo=apache)](./LICENSE)
   [![TypeScript](https://img.shields.io/badge/TypeScript-strict-3178c6?style=flat-square&logo=typescript&logoColor=white)](./tsconfig.base.json)
@@ -15,15 +15,12 @@
   [![npm version](https://img.shields.io/npm/v/martin-loop?style=flat-square&logo=npm&logoColor=white)](https://www.npmjs.com/package/martin-loop)
   [![npm downloads](https://img.shields.io/npm/dm/martin-loop?style=flat-square&label=downloads)](https://www.npmjs.com/package/martin-loop)
 
-  MartinLoop has been accepted into the NVIDIA Inception program.
-<div align="center">
-
+  MartinLoop is part of the NVIDIA Inception program.
   <br>
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="./docs/assets/nvidia-inception-program.png">
     <img src="./docs/assets/nvidia-inception-program-light.png" alt="NVIDIA Inception Program logo" width="280">
   </picture>
-</div>
 </div>
 
 ## Why MartinLoop
@@ -34,14 +31,14 @@ A task that looked like a small fix can become dozens of attempts, a blown token
 
 Use it when AI coding work needs to stay bounded, inspectable, and safe to review before it becomes expensive or destructive.
 
-## Why Star This?
+## Why Teams Adopt MartinLoop
 
 - It turns agent behavior into inspectable run receipts you can actually review.
 - It enforces hard stop conditions before runaway retries spend more money.
 - It adds rollback-aware rules so failed attempts do not silently leave unsafe changes behind.
 - It helps teams compare outcomes across agents under one governed flow.
 
-If this repo helps you ship safer agent workflows, star it so more builders can find it.
+Teams use MartinLoop when they need governed agent execution that can be reviewed and trusted.
 
 ## 2-Minute Install Path
 
@@ -68,7 +65,7 @@ npx -y martin-loop@latest dossier --latest
 npx -y martin-loop@latest share --latest
 ```
 
-If this flow saved you time, please star the repo to help other builders find it.
+If this flow is useful, open an issue with feedback so we can keep improving the public experience.
 
 `start` prints the first-run guided path. `run` auto-checks `doctor`, `session-start`, and `preflight`, then executes when the environment is ready. You can still run those commands directly when you want to inspect the governed checks first.
 
@@ -345,8 +342,6 @@ git push -u origin feat/your-feature
 ```
 
 <div align="center">
-  **Star the repo** if you think AI coding needs budgets, brakes, and receipts.
-
   [martinloop.com](https://martinloop.com) · [support@martinloop.com](mailto:support@martinloop.com)
 
   <br>

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,5 @@
+# Benchmarks
+
+This workspace contains deterministic benchmark suites used to evaluate governed agent execution and reproducibility.
+
+Use `npx martin-loop bench --suite under-3-challenge` for the primary public benchmark lane.

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,3 @@
+# Demo Workspace
+
+The `seeded-workspace` folder provides a disposable project for first-run guided demos and receipt walkthroughs.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,5 @@
+# Documentation
+
+The docs directory contains public guides for onboarding, CLI usage, MCP integration, receipts, security, and release notes.
+
+Start with [../README.md](../README.md) for the main product entrypoint.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,3 @@
+# Examples
+
+This directory contains practical integration examples for CI/CD and adapter usage.

--- a/packages/README.md
+++ b/packages/README.md
@@ -1,0 +1,3 @@
+# Packages
+
+This directory contains MartinLoop package modules for contracts, core runtime, adapters, CLI, and MCP server support.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,3 @@
+# Scripts
+
+This directory contains public release guards, smoke checks, and repository validation utilities.

--- a/scripts/readme-cta-guard.mjs
+++ b/scripts/readme-cta-guard.mjs
@@ -6,19 +6,14 @@ import { fileURLToPath } from "node:url";
 
 export const REQUIRED_CTA_CHECKS = [
   {
-    id: "top_star_cta",
-    description: "top star CTA line",
-    needle: "**Star this repo:** [GitHub stars](https://github.com/Keesan12/martin-loop)",
+    id: "top_get_started_cta",
+    description: "top get-started CTA line",
+    needle: "**Get started:** `npx -y martin-loop@latest start`",
   },
   {
-    id: "top_try_now_cta",
-    description: "top try-now command CTA line",
-    needle: "**Try it now:** `npx -y martin-loop@latest start`",
-  },
-  {
-    id: "footer_star_cta",
-    description: "footer star CTA line",
-    needle: "**Star the repo** if you think AI coding needs budgets, brakes, and receipts.",
+    id: "top_demo_cta",
+    description: "top demo CTA line",
+    needle: "**Try the demo:** `npx -y martin-loop@latest demo`",
   },
   {
     id: "site_link",

--- a/scripts/tests/readme-cta-guard.test.mjs
+++ b/scripts/tests/readme-cta-guard.test.mjs
@@ -22,14 +22,13 @@ test("README CTA guard passes for the public README", async () => {
 test("README CTA guard reports missing anchors", () => {
   const incompleteReadme = `
 # MartinLoop
-**Star this repo:** [GitHub stars](https://github.com/Keesan12/martin-loop)
+**Get started:** \`npx -y martin-loop@latest start\`
 `;
   const result = evaluateReadmeCtaGuards(incompleteReadme);
 
   assert.equal(result.ok, false);
   assert.ok(result.missingChecks.length > 0);
   assert.ok(result.missingChecks.length < REQUIRED_CTA_CHECKS.length);
-  assert.ok(result.missingChecks.some((missing) => missing.id === "top_try_now_cta"));
-  assert.ok(result.missingChecks.some((missing) => missing.id === "footer_star_cta"));
+  assert.ok(result.missingChecks.some((missing) => missing.id === "top_demo_cta"));
   assert.ok(result.missingChecks.some((missing) => missing.id === "nvidia_marker"));
 });

--- a/scripts/tests/readme-public-surface.test.mjs
+++ b/scripts/tests/readme-public-surface.test.mjs
@@ -123,7 +123,7 @@ test("root README is a public product entry point", async () => {
 
   assert.match(readme, /MartinLoop gives AI coding agents budgets, stop conditions, rollback rules, and receipts\./i);
   assert.match(readme, /Built from thousands of agent runs where the problem was not intelligence -- it was uncontrolled execution\./i);
-  assert.match(readme, /## Why Star This\?/);
+  assert.match(readme, /## Why Teams Adopt MartinLoop/);
   assert.match(readme, /## 2-Minute Install Path/);
   assert.match(readme, /## Visual Proof/);
   assert.match(readme, /MartinLoop turns an AI coding run into an inspectable execution record/i);
@@ -132,11 +132,11 @@ test("root README is a public product entry point", async () => {
   assert.match(readme, /<img src="\.\/docs\/assets\/side-by-side\.svg" alt="MartinLoop governed run compared with an unbounded retry loop"/);
   assert.match(readme, /<img src="\.\/docs\/assets\/cli-static\.svg" alt="MartinLoop CLI terminal output"/);
   assert.doesNotMatch(readme, /martinloop-demo\.gif/);
-  assert.match(readme, /\*\*Star this repo:\*\* \[GitHub stars]\(https:\/\/github\.com\/Keesan12\/martin-loop\)/);
-  assert.match(readme, /\*\*Try it now:\*\* `npx -y martin-loop@latest start`/);
+  assert.match(readme, /\*\*Get started:\*\* `npx -y martin-loop@latest start`/);
+  assert.match(readme, /\*\*Try the demo:\*\* `npx -y martin-loop@latest demo`/);
   assert.match(readme, /\[!\[npm version]\(https:\/\/img\.shields\.io\/npm\/v\/martin-loop/);
-  assert.match(readme, /If this flow saved you time, please star the repo to help other builders find it\./);
-  assert.match(readme, /\*\*Star the repo\*\* if you think AI coding needs budgets, brakes, and receipts\./);
+  assert.match(readme, /If this flow is useful, open an issue with feedback so we can keep improving the public experience\./);
+  assert.doesNotMatch(readme, /\*\*Star the repo\*\*/);
   assert.match(readme, /\[support@martinloop\.com]\(mailto:support@martinloop\.com\)/);
   assert.match(readme, /npx(?: -y)? martin-loop(?:@latest)? demo/);
   assert.match(readme, /npx(?: -y)? martin-loop(?:@latest)? run .* --proof --verify "npm test"/);


### PR DESCRIPTION
## Summary
- professionalize README hero and conversion copy for a cleaner public-facing tone
- keep restored legacy visual proof assets while removing noisy star-heavy prompts
- add directory README entrypoints so top-level folders present clear purpose in GitHub navigation
- align README guard/tests to enforce the updated public copy anchors

## Validation
- pnpm public:readme-cta-guard
- node --test scripts/tests/readme-cta-guard.test.mjs scripts/tests/readme-public-surface.test.mjs
- pnpm oss:validate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added directory-level README files throughout the project to improve navigation and clarity.
  * Updated main README with new "Get started" and "Try the demo" call-to-action buttons.
  * Replaced marketing messaging with a new "Why Teams Adopt MartinLoop" section highlighting key features.
  * Enhanced documentation of project structure, including guides for benchmarks, examples, and integration paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->