### PR TITLE
docs: restore root README on repo homepage

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,3 +1,0 @@
-# GitHub Workflows
-
-This directory contains repository automation for CI, release validation, and policy checks that keep the public project surface reliable.


### PR DESCRIPTION
## Summary
- remove .github/README.md so GitHub renders root README.md on the repository landing page again
- keep other directory-level READMEs intact

## Validation
- pnpm public:readme-cta-guard
- node --test scripts/tests/readme-public-surface.test.mjs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed GitHub Workflows documentation from the project README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->