### PR TITLE
docs: guard README precedence and fix footer rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,15 +341,18 @@ git commit -m "feat: describe what you built"
 git push -u origin feat/your-feature
 ```
 
-<div align="center">
-  [martinloop.com](https://martinloop.com) · [support@martinloop.com](mailto:support@martinloop.com)
-
-  <br>
+<p align="center">
+  <a href="https://martinloop.com">martinloop.com</a> · <a href="mailto:support@martinloop.com">support@martinloop.com</a>
+</p>
+<p align="center">
+  MartinLoop is part of the NVIDIA Inception program.
+</p>
+<p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="./docs/assets/nvidia-inception-program.png">
     <img src="./docs/assets/nvidia-inception-program-light.png" alt="NVIDIA Inception Program logo" width="280">
   </picture>
-</div>
+</p>
 
 ## License
 

--- a/docs/agent-failure-atlas.md
+++ b/docs/agent-failure-atlas.md
@@ -54,5 +54,6 @@ This atlas is a practical failure-mode catalog for governed AI coding runs. Each
 | FL-048 | `rollback_restore_failed` | Restore action fails after unsafe change | Escalate with evidence | rollback artifacts |
 | FL-049 | `replay_context_mismatch` | Verification replay uses mismatched workspace snapshot | Mark replay as non-comparable | replay notes/warnings |
 | FL-050 | `evidence_link_missing` | Receipt references missing artifact path | Degrade trust and flag dossier | dossier warnings |
+| FL-051 | `repo_readme_shadowed_by_dotgithub` | `.github/README.md` overrides root README on GitHub landing view | Block release until shadow file is removed | `public:readme-cta-guard` + repo contents |
 
 Use this atlas with `runs verify`, `dossier`, and `share` outputs to keep failure intelligence consistent across contributors.

--- a/scripts/readme-cta-guard.mjs
+++ b/scripts/readme-cta-guard.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { readFile } from "node:fs/promises";
+import { access, readFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -18,12 +18,12 @@ export const REQUIRED_CTA_CHECKS = [
   {
     id: "site_link",
     description: "martinloop.com link",
-    needle: "[martinloop.com](https://martinloop.com)",
+    needle: 'href="https://martinloop.com"',
   },
   {
     id: "support_link",
     description: "support@martinloop.com mailto link",
-    needle: "[support@martinloop.com](mailto:support@martinloop.com)",
+    needle: 'href="mailto:support@martinloop.com"',
   },
   {
     id: "nvidia_marker",
@@ -46,18 +46,47 @@ export async function readRootReadme(rootDir = process.cwd()) {
   return readFile(readmePath, "utf8");
 }
 
-async function main() {
-  const readmeContents = await readRootReadme(process.cwd());
-  const result = evaluateReadmeCtaGuards(readmeContents);
+export async function checkReadmePrecedenceHazards(rootDir = process.cwd()) {
+  const githubReadmePath = path.join(rootDir, ".github", "README.md");
 
-  if (result.ok) {
+  try {
+    await access(githubReadmePath);
+    return [
+      {
+        id: "github_readme_shadow",
+        description: "remove .github/README.md because it shadows the repo homepage README",
+      },
+    ];
+  } catch {
+    return [];
+  }
+}
+
+async function main() {
+  const rootDir = process.cwd();
+  const readmeContents = await readRootReadme(rootDir);
+  const result = evaluateReadmeCtaGuards(readmeContents);
+  const precedenceHazards = await checkReadmePrecedenceHazards(rootDir);
+
+  if (result.ok && precedenceHazards.length === 0) {
     process.stdout.write("README CTA guard passed.\n");
     return;
   }
 
-  process.stderr.write("README CTA guard failed. Missing required anchors:\n");
-  for (const missing of result.missingChecks) {
-    process.stderr.write(`- ${missing.id}: ${missing.description}\n`);
+  process.stderr.write("README CTA guard failed.\n");
+
+  if (result.missingChecks.length > 0) {
+    process.stderr.write("Missing required anchors:\n");
+    for (const missing of result.missingChecks) {
+      process.stderr.write(`- ${missing.id}: ${missing.description}\n`);
+    }
+  }
+
+  if (precedenceHazards.length > 0) {
+    process.stderr.write("README precedence hazards:\n");
+    for (const hazard of precedenceHazards) {
+      process.stderr.write(`- ${hazard.id}: ${hazard.description}\n`);
+    }
   }
 
   process.exitCode = 1;

--- a/scripts/tests/readme-cta-guard.test.mjs
+++ b/scripts/tests/readme-cta-guard.test.mjs
@@ -1,10 +1,13 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import {
   REQUIRED_CTA_CHECKS,
+  checkReadmePrecedenceHazards,
   evaluateReadmeCtaGuards,
   readRootReadme,
 } from "../readme-cta-guard.mjs";
@@ -31,4 +34,16 @@ test("README CTA guard reports missing anchors", () => {
   assert.ok(result.missingChecks.length < REQUIRED_CTA_CHECKS.length);
   assert.ok(result.missingChecks.some((missing) => missing.id === "top_demo_cta"));
   assert.ok(result.missingChecks.some((missing) => missing.id === "nvidia_marker"));
+});
+
+test("README CTA guard blocks .github README shadowing", async () => {
+  const tempRoot = await mkdtemp(path.join(tmpdir(), "readme-cta-guard-"));
+  await writeFile(path.join(tempRoot, "README.md"), "# MartinLoop\n", "utf8");
+  await mkdir(path.join(tempRoot, ".github"), { recursive: true });
+  await writeFile(path.join(tempRoot, ".github", "README.md"), "# Workflow docs\n", "utf8");
+
+  const hazards = await checkReadmePrecedenceHazards(tempRoot);
+
+  assert.equal(hazards.length, 1);
+  assert.equal(hazards[0].id, "github_readme_shadow");
 });

--- a/scripts/tests/readme-public-surface.test.mjs
+++ b/scripts/tests/readme-public-surface.test.mjs
@@ -137,7 +137,8 @@ test("root README is a public product entry point", async () => {
   assert.match(readme, /\[!\[npm version]\(https:\/\/img\.shields\.io\/npm\/v\/martin-loop/);
   assert.match(readme, /If this flow is useful, open an issue with feedback so we can keep improving the public experience\./);
   assert.doesNotMatch(readme, /\*\*Star the repo\*\*/);
-  assert.match(readme, /\[support@martinloop\.com]\(mailto:support@martinloop\.com\)/);
+  assert.match(readme, /href="https:\/\/martinloop\.com"/);
+  assert.match(readme, /href="mailto:support@martinloop\.com"/);
   assert.match(readme, /npx(?: -y)? martin-loop(?:@latest)? demo/);
   assert.match(readme, /npx(?: -y)? martin-loop(?:@latest)? run .* --proof --verify "npm test"/);
   assert.match(readme, /npx(?: -y)? martin-loop(?:@latest)? dossier --latest/);
@@ -178,6 +179,7 @@ test("public markdown links resolve inside the repo", async () => {
 test("obsolete public distribution folder is absent", async () => {
   const removedPaths = [
     path.join(ROOT_DIR, "docs", "distribution"),
+    path.join(ROOT_DIR, ".github", "README.md"),
   ];
 
   for (const removedPath of removedPaths) {


### PR DESCRIPTION
## Summary
- add a hard README guard that fails if .github/README.md can shadow the repo homepage
- fix README footer links so website and support email render as proper hyperlinks
- restore NVIDIA footer copy and align footer spacing/rendering
- add atlas failure mode FL-051 for README shadow regressions

## Governed run evidence
- doctor/session-start/preflight/proof/live/dossier/verify/share executed
- live loop: loop_cj7di2cn
- share bundle: C:\\Users\\Torram\\.martin\\runs\\loop_cj7di2cn\\share

## Validation
- pnpm public:readme-cta-guard
- node --test scripts/tests/readme-cta-guard.test.mjs scripts/tests/readme-public-surface.test.mjs
- pnpm oss:validate