### PR TITLE
fix: align root CLI version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.3.6]
+
+### Fixed
+- **Root CLI version reporting now matches the installed package** - the packaged CLI manifest now uses the `martin-loop` package version, so `npx -y martin-loop@0.3.6 --version` reports `0.3.6`.
+- **Release guard now checks root/version parity** - root release validation fails if the vendored CLI manifest version drifts from the root package version again.
+
 ## [0.3.5]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ npx -y martin-loop@latest preflight "Summarize the demo workspace and prove test
 
 `share --latest` writes three files into the selected run directory under `share/`: `run-receipt.json`, `run-receipt.md`, and `proof-card.svg`.
 
-Release notes for the current root package: [MartinLoop 0.3.5](./docs/release/OSS-0.3.5-RELEASE-NOTES.md).
+Release notes for the current root package: [MartinLoop 0.3.6](./docs/release/OSS-0.3.6-RELEASE-NOTES.md).
 
 ## Visual Proof
 
@@ -127,17 +127,17 @@ Example receipt files: [Markdown](./docs/examples/proof-receipts/live-governed-r
 Use this lane from a clean temp directory to verify the public CLI flow exactly as shipped:
 
 ```sh
-npx -y martin-loop@0.3.5 --version
-npx -y martin-loop@0.3.5 start
-npx -y martin-loop@0.3.5 demo
+npx -y martin-loop@0.3.6 --version
+npx -y martin-loop@0.3.6 start
+npx -y martin-loop@0.3.6 demo
 cd martin-loop-demo
 npm install
-npx -y martin-loop@0.3.5 run "Summarize the demo workspace and prove tests still pass" --proof --verify "npm test" --json
-npx -y martin-loop@0.3.5 dossier --latest --json
-npx -y martin-loop@0.3.5 share --latest --json
+npx -y martin-loop@0.3.6 run "Summarize the demo workspace and prove tests still pass" --proof --verify "npm test" --json
+npx -y martin-loop@0.3.6 dossier --latest --json
+npx -y martin-loop@0.3.6 share --latest --json
 ```
 
-For deterministic installs, pin the package line (`martin-loop@0.3.5`) or use `martin-loop@latest`. Plain `npx martin-loop` can resolve a stale local cache on some machines.
+For deterministic installs, pin the package line (`martin-loop@0.3.6`) or use `martin-loop@latest`. Plain `npx martin-loop` can resolve a stale local cache on some machines.
 
 Expected share bundle outputs:
 
@@ -301,7 +301,7 @@ npx martin-loop mcp print-config --host gemini --transport stdio --profile full-
 npx martin-loop mcp print-config --host generic --transport stdio --profile github-review
 ```
 
-The root `martin-loop` package and the standalone `@martinloop/mcp` package move on separate version lines. The root package line here is `0.3.5`; the current standalone MCP package is `0.3.1`.
+The root `martin-loop` package and the standalone `@martinloop/mcp` package move on separate version lines. The root package line here is `0.3.6`; the current standalone MCP package is `0.3.1`.
 
 The public MCP release train labels are:
 

--- a/docs/release/OSS-0.3.6-RELEASE-NOTES.md
+++ b/docs/release/OSS-0.3.6-RELEASE-NOTES.md
@@ -1,0 +1,20 @@
+# MartinLoop 0.3.6 CLI Version Hotfix
+
+`0.3.6` keeps the proof receipt work from `0.3.5` and fixes the installed root CLI version report.
+
+## What Changed
+
+- `npx -y martin-loop@0.3.6 --version` now reports the root `martin-loop` package version.
+- The packaged CLI manifest now uses the root package version used by the installed binary.
+- The release guard now fails if the vendored CLI manifest version drifts from the root package version.
+
+## Why This Matters
+
+Operators pin root package versions during audits and release checks. The installed CLI must report the same version that npm installed.
+
+## Quick Check
+
+```sh
+npx -y martin-loop@0.3.6 --version
+npx -y martin-loop@0.3.6 --help
+```

--- a/docs/release/VERSION-LEDGER.md
+++ b/docs/release/VERSION-LEDGER.md
@@ -4,16 +4,16 @@ This file is the release source of truth for package/version mapping in this rep
 
 ## Root package: `martin-loop`
 
-- live npm dist-tag `latest`: `0.3.4` before the `0.3.5` proof receipt release publishes
-- live public GitHub release: `v0.3.4` before the `v0.3.5` release workflow completes
-- live public baseline in this train: `0.3.4`
-- root public baseline: `0.3.4`
+- live npm dist-tag `latest`: `0.3.5` before the `0.3.6` CLI version hotfix publishes
+- live public GitHub release: `v0.3.5` before the `v0.3.6` release workflow completes
+- live public baseline in this train: `0.3.5`
+- root public baseline: `0.3.5`
 - releases consumed since the original `0.2.8` launch:
   - `0.2.9` fixed proof-run classification, Windows `.cmd` resolution, and public provider defaults
   - `0.2.10` tightened verifier evidence, `--runs-dir` consistency, and public help output
   - `0.2.11` fixed `runs verify --latest` selector parity in the public CLI
-- current in-repo root release line: `0.3.5` for CLI-style proof receipts and share-bundle documentation
-- next planned root follow-on: `0.3.6` for additional cross-host reliability follow-ups
+- current in-repo root release line: `0.3.6` for root CLI version reporting parity
+- next planned root follow-on: `0.3.7` for additional cross-host reliability follow-ups
 
 ## Standalone package: `@martinloop/mcp`
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "martin-loop",
   "private": false,
-  "version": "0.3.5",
+  "version": "0.3.6",
   "type": "module",
   "description": "Open-source command center for governed AI coding agents with built-in onboarding, hard gates, MCP, and shareable run receipts.",
   "packageManager": "pnpm@10.33.0",

--- a/scripts/build-public-facade.mjs
+++ b/scripts/build-public-facade.mjs
@@ -38,6 +38,11 @@ const REWRITABLE_PACKAGES = {
 export async function buildPublicFacade(options = {}) {
   const rootDir = options.rootDir ?? process.cwd();
   const distDir = path.join(rootDir, "dist");
+  const rootManifest = JSON.parse(await readFile(path.join(rootDir, "package.json"), "utf8"));
+  const rootPackageVersion =
+    typeof rootManifest.version === "string" && rootManifest.version.length > 0
+      ? rootManifest.version
+      : null;
 
   await rm(distDir, { force: true, recursive: true });
   await mkdir(path.join(distDir, "bin"), { recursive: true });
@@ -49,6 +54,7 @@ export async function buildPublicFacade(options = {}) {
       targetDir: path.join(rootDir, ...facade.targetDir),
       distDir,
       packageJsonSource: facade.packageJson ? path.join(rootDir, ...facade.packageJson) : null,
+      rootPackageVersion,
     });
   }
 
@@ -76,7 +82,11 @@ async function copyFacadeDirectory(input) {
 
   if (input.packageJsonSource) {
     const rawManifest = JSON.parse(await readFile(input.packageJsonSource, "utf8"));
-    const sanitizedManifest = sanitizeVendoredPackageJson(rawManifest, input.packageName);
+    const sanitizedManifest = sanitizeVendoredPackageJson(
+      rawManifest,
+      input.packageName,
+      input.rootPackageVersion,
+    );
     await writeFile(
       path.join(input.targetDir, "package.json"),
       `${JSON.stringify(sanitizedManifest, null, 2)}\n`,
@@ -197,10 +207,14 @@ function sanitizeVendoredAdaptersIndex(contents) {
   );
 }
 
-function sanitizeVendoredPackageJson(manifest, packageName) {
+function sanitizeVendoredPackageJson(manifest, packageName, rootPackageVersion) {
+  const version =
+    packageName === "@martin/cli" && rootPackageVersion
+      ? rootPackageVersion
+      : manifest.version ?? "0.0.0";
   const sanitized = {
     name: manifest.name ?? packageName,
-    version: manifest.version ?? "0.0.0",
+    version,
     type: manifest.type ?? "module",
     description: manifest.description ?? `${packageName} vendored for the martin-loop root package.`,
     main: "./index.js",

--- a/scripts/root-release-guard.mjs
+++ b/scripts/root-release-guard.mjs
@@ -132,7 +132,14 @@ export function extractPackJsonPayload(stdout) {
 
 export async function assertVendoredCliManifest(rootDir) {
   const manifestPath = path.join(rootDir, "dist", "vendor", "cli", "package.json");
+  const rootManifest = JSON.parse(await readFile(path.join(rootDir, "package.json"), "utf8"));
   const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+
+  if (manifest.version !== rootManifest.version) {
+    throw new Error(
+      `Vendored CLI manifest version must match root package version ${rootManifest.version}. Received ${String(manifest.version)}.`,
+    );
+  }
 
   if (manifest.main !== "./index.js") {
     throw new Error(`Vendored CLI manifest must point main at ./index.js. Received ${String(manifest.main)}.`);

--- a/scripts/tests/root-release-guard.test.mjs
+++ b/scripts/tests/root-release-guard.test.mjs
@@ -70,13 +70,18 @@ test("assertPackedSurface rejects forbidden vendored implementation paths", () =
 
 test("assertVendoredCliManifest accepts the sanitized vendored CLI package manifest", async () => {
   await withTempRoot(async (tempRoot) => {
+    await writeFile(
+      path.join(tempRoot, "package.json"),
+      `${JSON.stringify({ name: "martin-loop", version: "0.3.6" }, null, 2)}\n`,
+      "utf8",
+    );
     const manifestDir = path.join(tempRoot, "dist", "vendor", "cli");
     await mkdir(manifestDir, { recursive: true });
     await writeFile(
       path.join(manifestDir, "package.json"),
       `${JSON.stringify({
         name: "@martin/cli",
-        version: "0.1.0",
+        version: "0.3.6",
         type: "module",
         description: "@martin/cli vendored for the martin-loop root package.",
         main: "./index.js",


### PR DESCRIPTION
## Summary
- Fix the root `martin-loop` facade so the installed CLI reports the root package version instead of the vendored internal CLI package version.
- Add a release guard check that fails if the vendored CLI manifest drifts from the root package version.
- Prepare the 0.3.6 hotfix release notes, changelog, README version references, and version ledger.

## Test Plan
- `pnpm build`
- `node -p "require('./dist/vendor/cli/package.json').version"` -> `0.3.6`
- `node dist/bin/martin-loop.js --version` -> `0.3.6`
- `node --test scripts/tests/root-release-guard.test.mjs scripts/tests/readme-public-surface.test.mjs`
- `pnpm public:copy-scan`
- `pnpm lint`
- `pnpm test`
- `pnpm public:smoke`
- `pnpm oss:validate`
- `pnpm public:git-surface`
- `pnpm release:root:guard`
- `pnpm release:validate-local`

## Release Notes
This hotfix follows `0.3.5`, which shipped CLI proof receipts. Post-publish smoke caught that `npx -y martin-loop@0.3.5 --version` reported `0.3.1`. This PR fixes the package facade and adds a release guard so the mismatch cannot silently recur.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CLI `--version` command to correctly report the installed package version
  * Added version validation to ensure consistency between the installed package and CLI manifest, preventing version mismatches

<!-- end of auto-generated comment: release notes by coderabbit.ai -->