### PR TITLE
fix(mcp): allow gemini engine when setting spend limits

### DIFF
--- a/packages/mcp/src/server-validation.ts
+++ b/packages/mcp/src/server-validation.ts
@@ -244,7 +244,7 @@ function validateRunInput(args: unknown): RunLoopInput {
     "projectId"
   ]);
 
-  const engine = optionalEnum(record.engine, "engine", ["claude", "codex"] as const);
+  const engine = optionalEnum(record.engine, "engine", ["claude", "codex", "gemini"] as const);
   return {
     objective: requireString(record.objective, "objective"),
     ...(record.workingDirectory !== undefined
@@ -354,7 +354,7 @@ function validateDoctorInput(args: unknown): MartinDoctorInput {
     ...(record.runsDir !== undefined
       ? { runsDir: resolveSafeRunsRootPath(requireString(record.runsDir, "runsDir")) }
       : {}),
-    ...optionalEnumAsObject(record.engine, "engine", ["claude", "codex"] as const)
+    ...optionalEnumAsObject(record.engine, "engine", ["claude", "codex", "gemini"] as const)
   };
 }
 

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -795,7 +795,7 @@ export function createMartinMcpServer(serverInfo?: {
           },
           engine: {
             type: "string",
-            enum: ["claude", "codex"],
+            enum: ["claude", "codex", "gemini"],
             description: "Which agent CLI to use. Defaults to claude."
           },
           model: {
@@ -933,7 +933,7 @@ export function createMartinMcpServer(serverInfo?: {
           },
           engine: {
             type: "string",
-            enum: ["claude", "codex"],
+            enum: ["claude", "codex", "gemini"],
             description: "Optional engine to highlight in diagnostics."
           }
         }
@@ -998,7 +998,7 @@ export function createMartinMcpServer(serverInfo?: {
           },
           engine: {
             type: "string",
-            enum: ["claude", "codex"],
+            enum: ["claude", "codex", "gemini"],
             description: "Which agent CLI would be used. Defaults to claude."
           },
           model: {

--- a/packages/mcp/tests/server-validation.test.ts
+++ b/packages/mcp/tests/server-validation.test.ts
@@ -412,6 +412,38 @@ describe("server validation", () => {
     });
 
     expect(
+      validateToolInput("martin_doctor", {
+        engine: "gemini"
+      })
+    ).toEqual({
+      engine: "gemini"
+    });
+
+    expect(
+      validateToolInput("martin_preflight", {
+        objective: "Fix the bug",
+        engine: "gemini",
+        maxUsd: 5
+      })
+    ).toEqual({
+      objective: "Fix the bug",
+      engine: "gemini",
+      maxUsd: 5
+    });
+
+    expect(
+      validateToolInput("martin_run", {
+        objective: "Fix the bug",
+        engine: "gemini",
+        maxUsd: 5
+      })
+    ).toEqual({
+      objective: "Fix the bug",
+      engine: "gemini",
+      maxUsd: 5
+    });
+
+    expect(
       validateToolInput("martin_triage_runs", {
         includeHealthy: true,
         limit: 5


### PR DESCRIPTION
## Summary
- The MCP tool validation (`martin_run`, `martin_doctor`, `martin_preflight`) hard-coded `engine` to `["claude", "codex"]` in `server.ts` and `server-validation.ts`, even though `MartinEngine` and the run-loop adapter selection fully support `"gemini"`.
- Any call that paired `engine: "gemini"` with a budget/spend-limit field (e.g. `maxUsd`) was rejected with `"Invalid engine."` — this is the "error when adding a limit" bug a customer reported.
- Added `"gemini"` to the 5 affected enum/allow-lists and added regression coverage.

## Test plan
- [x] `pnpm --filter @martinloop/mcp test` (89 passing)
- [x] `pnpm --filter @martin/cli test` (114 passing)
- [x] Verified `validateToolInput` accepts `engine: "gemini"` + `maxUsd` for `martin_run`, `martin_doctor`, `martin_preflight`


---
_Generated by [Claude Code](https://claude.ai/code/session_01NgcspSyMyUYwSrmq682Lhs)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended engine support to include Gemini. Users can now specify "gemini" as an engine option alongside the existing "claude" and "codex" choices. This new capability is available across all tool operations including run, doctor, and preflight commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->