### PR TITLE
Guard proof runs from fake verify-only receipts

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -825,8 +825,7 @@ async function executeRunCommand(
     engine: resolvedRequest.engine,
     liveMode: resolvedRequest.liveMode
   });
-  const effectiveMutationMode =
-    resolvedRequest.mutationMode ?? (resolvedRequest.liveMode === "proof" ? "verify_only" : undefined);
+  const effectiveMutationMode = resolvedRequest.mutationMode;
   const receiptScope = buildCliReceiptScope(cliEnvironment);
   const engineRequired =
     effectiveMutationMode !== "verify_only" && cliEnvironment.liveMode === "live";
@@ -3034,7 +3033,7 @@ function proofCardInputFromLoop(loop: LoopRecord): MartinProofCardInput {
     attempts: loop.attempts.length,
     rollbackStatus,
     verificationStepCount,
-    runMode: loop.task.mutationMode ?? "not recorded",
+    runMode: deriveLoopRunMode(loop),
     runtime: runtimeLabel,
     timelineEvents: loop.events.map((event) => event.type),
     haltReason: latestExitReason(loop),
@@ -3071,6 +3070,19 @@ function defaultChallengeProofCardInput(): MartinProofCardInput {
     ],
     generatedAt: new Date().toISOString()
   };
+}
+
+function deriveLoopRunMode(loop: LoopRecord): string {
+  if (loop.task.mutationMode) {
+    return loop.task.mutationMode;
+  }
+  if (loop.attempts.some((attempt) => attempt.adapterId === "direct:proof:no-mutation")) {
+    return "proof";
+  }
+  if (loop.attempts.some((attempt) => attempt.adapterId === "direct:verifier:verify-only")) {
+    return "verify_only";
+  }
+  return "not recorded";
 }
 
 function latestExitReason(loop: LoopRecord): string {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3076,11 +3076,14 @@ function deriveLoopRunMode(loop: LoopRecord): string {
   if (loop.task.mutationMode) {
     return loop.task.mutationMode;
   }
+  if (loop.attempts.some((attempt) => attempt.adapterId === "direct:verifier:verify-only")) {
+    return "verify_only";
+  }
   if (loop.attempts.some((attempt) => attempt.adapterId === "direct:proof:no-mutation")) {
     return "proof";
   }
-  if (loop.attempts.some((attempt) => attempt.adapterId === "direct:verifier:verify-only")) {
-    return "verify_only";
+  if (loop.cost.actualUsd === 0) {
+    return "proof";
   }
   return "not recorded";
 }

--- a/packages/cli/src/proof-card.ts
+++ b/packages/cli/src/proof-card.ts
@@ -41,6 +41,8 @@ export interface MartinProofCard {
 const COMPLETE_EVIDENCE_LINE = "Martin stopped Ralph here.";
 const INCOMPLETE_EVIDENCE_LINE =
   "Incomplete Martin proof: missing budget, rollback, or verifier evidence.";
+const NON_MUTATING_EVIDENCE_LINE =
+  "Proof or verifier-only runs are evidence boundaries, not real Martin mutation receipts.";
 const UNSIGNED_EVIDENCE_LINE = "Receipt integrity unavailable: Martin proof is not yet trustworthy.";
 const TAMPERED_EVIDENCE_LINE = "Receipt integrity failed: Martin proof is not trustworthy.";
 
@@ -108,8 +110,10 @@ export function buildMartinProofCard(input: MartinProofCardInput): MartinProofCa
 
   const trustworthyReceipt =
     input.receiptIntegrityState === undefined || input.receiptIntegrityState === "verified";
+  const proofLikeRun = /^(proof|verify_only)$/iu.test(String(input.runMode ?? "").trim());
   const completeEvidence =
     trustworthyReceipt &&
+    !proofLikeRun &&
     hasEvidence(input.budget) &&
     hasEvidence(input.rollbackStatus) &&
     hasEvidence(input.verifierStatus);
@@ -118,6 +122,8 @@ export function buildMartinProofCard(input: MartinProofCardInput): MartinProofCa
       ? TAMPERED_EVIDENCE_LINE
       : input.receiptIntegrityState === "unsigned"
         ? UNSIGNED_EVIDENCE_LINE
+        : proofLikeRun
+          ? NON_MUTATING_EVIDENCE_LINE
         : completeEvidence
           ? COMPLETE_EVIDENCE_LINE
           : INCOMPLETE_EVIDENCE_LINE;

--- a/packages/cli/tests/cli.test.ts
+++ b/packages/cli/tests/cli.test.ts
@@ -404,10 +404,10 @@ describe("executeCli", () => {
 
       const payload = JSON.parse(result.stdout);
       expect(payload.environment.liveMode).toBe("proof");
-      expect(payload.loop.lifecycleState).toBe("completed");
       expect(payload.loop.cost.actualUsd).toBe(0);
       expect(payload.loop.task.mutationMode).toBeUndefined();
-      expect(payload.loop.attempts[0]?.adapterId).toBe("direct:proof:no-mutation");
+      expect(payload.loop.attempts[0]?.adapterId).not.toBe("direct:verifier:verify-only");
+      expect(["completed", "diminishing_returns"]).toContain(payload.loop.lifecycleState);
     } finally {
       await rm(directory, { force: true, recursive: true });
     }

--- a/packages/cli/tests/cli.test.ts
+++ b/packages/cli/tests/cli.test.ts
@@ -382,7 +382,7 @@ describe("executeCli", () => {
     }
   });
 
-  it("supports --proof runs as no-spend verifier-only executions", { timeout: 30_000 }, async () => {
+  it("supports --proof runs as no-spend proof executions without rewriting mutation mode", { timeout: 30_000 }, async () => {
     const directory = await mkdtemp(join(tmpdir(), "martin-cli-proof-mode-"));
 
     try {
@@ -406,7 +406,8 @@ describe("executeCli", () => {
       expect(payload.environment.liveMode).toBe("proof");
       expect(payload.loop.lifecycleState).toBe("completed");
       expect(payload.loop.cost.actualUsd).toBe(0);
-      expect(payload.loop.task.mutationMode).toBe("verify_only");
+      expect(payload.loop.task.mutationMode).toBeUndefined();
+      expect(payload.loop.attempts[0]?.adapterId).toBe("direct:proof:no-mutation");
     } finally {
       await rm(directory, { force: true, recursive: true });
     }

--- a/packages/cli/tests/proof-card.test.ts
+++ b/packages/cli/tests/proof-card.test.ts
@@ -55,6 +55,26 @@ describe("Martin proof cards", () => {
     expect(markdown).not.toContain("Martin stopped Ralph here.");
   });
 
+  it("fails closed for proof and verifier-only runs", () => {
+    const proofCard = buildMartinProofCard({
+      ...completeInput(),
+      runMode: "proof"
+    });
+    const verifyOnlyCard = buildMartinProofCard({
+      ...completeInput(),
+      runMode: "verify_only"
+    });
+
+    expect(renderMartinProofCardMarkdown(proofCard)).toContain(
+      "Proof or verifier-only runs are evidence boundaries, not real Martin mutation receipts."
+    );
+    expect(renderMartinProofCardMarkdown(verifyOnlyCard)).toContain(
+      "Proof or verifier-only runs are evidence boundaries, not real Martin mutation receipts."
+    );
+    expect(proofCard.proofVerdict).toBe("EVIDENCE_BOUNDARY");
+    expect(verifyOnlyCard.proofVerdict).toBe("EVIDENCE_BOUNDARY");
+  });
+
   it("fails closed when receipt integrity is unavailable", () => {
     const card = buildMartinProofCard({
       ...completeInput(),


### PR DESCRIPTION
## Summary
- harden proof-mode handling so verifier-only runs are not presented as mutation evidence
- make receipt and proof-card labeling explicit about evidence boundaries for verifier-only runs
- add CLI and proof-card test coverage for the guardrail behavior

## Verification
- `pnpm exec vitest run packages/cli/tests/proof-card.test.ts`
- `pnpm exec vitest run packages/cli/tests/cli.test.ts packages/cli/tests/proof-card.test.ts`