### PR TITLE
Fix root Vitest CLI validation path

### DIFF
--- a/packages/cli/tests/cli.test.ts
+++ b/packages/cli/tests/cli.test.ts
@@ -160,7 +160,7 @@ describe("executeCli", () => {
 
   it("prints the public root package version", async () => {
     const rootPackageVersion = (
-      JSON.parse(await readFile(join(process.cwd(), "..", "..", "package.json"), "utf8")) as {
+      JSON.parse(await readFile(new URL("../../../package.json", import.meta.url), "utf8")) as {
         version: string;
       }
     ).version;

--- a/scripts/oss-boundary.mjs
+++ b/scripts/oss-boundary.mjs
@@ -35,6 +35,7 @@ const ALLOWED_TOP_LEVEL_ENTRIES = [
   "README.md",
   "SECURITY.md",
   "tsconfig.base.json",
+  "vitest.config.ts",
   "vitest.workspace.ts",
 ];
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,19 @@
+import { fileURLToPath } from "node:url";
+
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@martin/adapters": fileURLToPath(new URL("./packages/adapters/src/index.ts", import.meta.url)),
+      "@martin/benchmarks": fileURLToPath(new URL("./benchmarks/src/index.ts", import.meta.url)),
+      "@martin/cli": fileURLToPath(new URL("./packages/cli/src/index.ts", import.meta.url)),
+      "@martin/contracts": fileURLToPath(new URL("./packages/contracts/src/index.ts", import.meta.url)),
+      "@martin/core": fileURLToPath(new URL("./packages/core/src/index.ts", import.meta.url)),
+      "@martinloop/mcp": fileURLToPath(new URL("./packages/mcp/src/index.ts", import.meta.url))
+    }
+  },
+  test: {
+    testTimeout: 15_000
+  }
+});


### PR DESCRIPTION
## Summary
- add a repo-root Vitest config so root-launched CLI tests resolve OSS workspace packages from source
- harden the CLI version test so it resolves the root package manifest from the test file instead of `process.cwd()`
- allow the new root Vitest config in OSS boundary validation

## Verification
- `pnpm exec vitest run packages/cli/tests/cli.test.ts packages/cli/tests/proof-card.test.ts`
- `pnpm public:git-surface && pnpm public:copy-scan && pnpm oss:validate`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing infrastructure and build configuration for improved project setup.
  * Enhanced module resolution and test environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->