### PR TITLE
Harden governed receipt gate coverage

### DIFF
--- a/docs/agent-failure-atlas.md
+++ b/docs/agent-failure-atlas.md
@@ -57,5 +57,6 @@ The public canonical subset is the runtime 12-class taxonomy documented in [./os
 | FL-049 | `replay_context_mismatch` | Verification replay uses mismatched workspace snapshot | Mark replay as non-comparable | replay notes/warnings |
 | FL-050 | `evidence_link_missing` | Receipt references missing artifact path | Degrade trust and flag dossier | dossier warnings |
 | FL-051 | `repo_readme_shadowed_by_dotgithub` | `.github/README.md` overrides root README on GitHub landing view | Block release until shadow file is removed | `public:readme-cta-guard` + repo contents |
+| FL-052 | `receipt_gate_preflight_mismatch` | `preflight` reports success but the immediately-following governed `run` still says the preflight receipt is missing | Treat as a MartinLoop receipt persistence/lookup bug, auto-replay preflight if possible, and surface the exact objective/verify/cwd/runs-dir lookup tuple in debugging output | `policy_blocked` + `Governed run blocked until MartinLoop receipts exist for preflight` |
 
 Use this atlas with `runs verify`, `dossier`, and `share` outputs to keep failure intelligence consistent across contributors.

--- a/packages/cli/tests/cli-integration.test.ts
+++ b/packages/cli/tests/cli-integration.test.ts
@@ -60,6 +60,24 @@ async function withScratchEnv<T>(vars: Record<string, string>, fn: () => Promise
   }
 }
 
+async function withEnvVars<T>(vars: Record<string, string>, fn: () => Promise<T>): Promise<T> {
+  const originals = new Map(Object.keys(vars).map((key) => [key, process.env[key]]));
+  for (const [key, value] of Object.entries(vars)) {
+    process.env[key] = value;
+  }
+  try {
+    return await fn();
+  } finally {
+    for (const [key, original] of originals) {
+      if (original === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = original;
+      }
+    }
+  }
+}
+
 async function withRunsRoot<T>(fn: (runsRoot: string) => Promise<T>): Promise<T> {
   const previousRunsRoot = process.env.MARTIN_RUNS_DIR;
   const previousGroundingRoot = process.env.MARTIN_GROUNDING_DIR;
@@ -407,6 +425,222 @@ describe("--engine flag", () => {
             expect(verifyResult.exitCode).toBe(0);
             const verificationPayload = JSON.parse(verifyResult.stdout);
             expect(verificationPayload.verification.status).toBe("passed");
+          }
+        )
+      )
+    );
+  });
+
+  it("accepts an explicit session-start -> preflight -> run governed receipt chain", { timeout: 45000 }, async () => {
+    await withTempDir((workspace) =>
+      withFakeCodexCli(() =>
+        withScratchEnv(
+          {
+            MARTIN_INTEGRITY_KEY_DIR: join(workspace, ".martin-receipt-integrity"),
+            MARTIN_GROUNDING_DIR: join(workspace, ".martin-grounding")
+          },
+          async () => {
+            initializeGitRepo(workspace);
+            const runsDir = join(workspace, ".martin-runs");
+
+            const sessionStartResult = await withEnv("MARTIN_LIVE", "true", () =>
+              executeCli([
+                "--json",
+                "session-start",
+                "--cwd",
+                workspace,
+                "--runs-dir",
+                runsDir
+              ])
+            );
+            expect(sessionStartResult.exitCode).toBe(0);
+
+            const preflightResult = await withEnv("MARTIN_LIVE", "true", () =>
+              executeCli([
+                "--json",
+                "preflight",
+                "--engine",
+                "codex",
+                "--cwd",
+                workspace,
+                "--runs-dir",
+                runsDir,
+                "--objective",
+                "Fix the bug",
+                "--verify",
+                NOOP_VERIFIER,
+                "--max-iterations",
+                "1",
+                "--budget-usd",
+                "2"
+              ])
+            );
+            expect(preflightResult.exitCode).toBe(0);
+
+            const workflowStateAfterPreflight = await readWorkflowState(runsDir);
+            const cliStateAfterPreflight = (workflowStateAfterPreflight?.cli ?? {}) as Record<string, { workingDirectory?: string }>;
+            const normalizedWorkingDirectory = normalizeWorkingDirectoryForExpectation(workspace);
+            expect(cliStateAfterPreflight["session-start"]?.workingDirectory).toBe(normalizedWorkingDirectory);
+            expect(cliStateAfterPreflight.preflight?.workingDirectory).toBe(normalizedWorkingDirectory);
+
+            const runResult = await withEnv("MARTIN_LIVE", "true", () =>
+              executeCli([
+                "--json",
+                "run",
+                "--engine",
+                "codex",
+                "--cwd",
+                workspace,
+                "--runs-dir",
+                runsDir,
+                "--objective",
+                "Fix the bug",
+                "--verify",
+                NOOP_VERIFIER,
+                "--max-iterations",
+                "1",
+                "--budget-usd",
+                "2"
+              ])
+            );
+
+            expect(runResult.exitCode).toBe(0);
+            const payload = JSON.parse(runResult.stdout);
+            expect(payload.command).toBe("run");
+            expect(payload.environment.engine).toBe("codex");
+            expect(payload.environment.liveMode).toBe("live");
+          }
+        )
+      )
+    );
+  });
+
+  it("keeps governed receipts valid when guardrails normalize configured budgets", { timeout: 45000 }, async () => {
+    await withTempDir((workspace) =>
+      withFakeCodexCli(() =>
+        withScratchEnv(
+          {
+            MARTIN_INTEGRITY_KEY_DIR: join(workspace, ".martin-receipt-integrity"),
+            MARTIN_GROUNDING_DIR: join(workspace, ".martin-grounding")
+          },
+          async () => {
+            initializeGitRepo(workspace);
+            await writeFile(
+              join(workspace, "martin.config.yaml"),
+              [
+                "budget:",
+                "  maxUsd: 2",
+                "  softLimitUsd: 2",
+                "  maxIterations: 1",
+                "  maxTokens: 1000",
+                ""
+              ].join("\n"),
+              "utf8"
+            );
+            const runsDir = join(workspace, ".martin-runs");
+
+            const preflightResult = await withEnv("MARTIN_LIVE", "true", () =>
+              executeCli([
+                "--json",
+                "preflight",
+                "--engine",
+                "codex",
+                "--cwd",
+                workspace,
+                "--runs-dir",
+                runsDir,
+                "--objective",
+                "Verify the outreach runtime",
+                "--verify",
+                NOOP_VERIFIER
+              ])
+            );
+            expect(preflightResult.exitCode).toBe(0);
+
+            const runResult = await withEnv("MARTIN_LIVE", "true", () =>
+              executeCli([
+                "--json",
+                "run",
+                "--engine",
+                "codex",
+                "--cwd",
+                workspace,
+                "--runs-dir",
+                runsDir,
+                "--objective",
+                "Verify the outreach runtime",
+                "--verify",
+                NOOP_VERIFIER
+              ])
+            );
+
+            expect(runResult.exitCode).toBe(0);
+          }
+        )
+      )
+    );
+  });
+
+  it("keeps governed receipts valid when INIT_CWD changes between preflight and run", { timeout: 45000 }, async () => {
+    await withTempDir((workspace) =>
+      withFakeCodexCli(() =>
+        withScratchEnv(
+          {
+            MARTIN_INTEGRITY_KEY_DIR: join(workspace, ".martin-receipt-integrity"),
+            MARTIN_GROUNDING_DIR: join(workspace, ".martin-grounding")
+          },
+          async () => {
+            initializeGitRepo(workspace);
+            const runsDir = join(workspace, ".martin-runs");
+            const alternateInvocationRoot = join(workspace, "tools");
+            await writeFile(join(workspace, ".gitkeep"), "", "utf8");
+
+            const preflightResult = await withEnvVars(
+              {
+                MARTIN_LIVE: "true",
+                INIT_CWD: workspace
+              },
+              () =>
+                executeCli([
+                  "--json",
+                  "preflight",
+                  "--engine",
+                  "codex",
+                  "--cwd",
+                  workspace,
+                  "--runs-dir",
+                  runsDir,
+                  "--objective",
+                  "Verify the outreach runtime",
+                  "--verify",
+                  NOOP_VERIFIER
+                ])
+            );
+            expect(preflightResult.exitCode).toBe(0);
+
+            const runResult = await withEnvVars(
+              {
+                MARTIN_LIVE: "true",
+                INIT_CWD: alternateInvocationRoot
+              },
+              () =>
+                executeCli([
+                  "--json",
+                  "run",
+                  "--engine",
+                  "codex",
+                  "--cwd",
+                  workspace,
+                  "--runs-dir",
+                  runsDir,
+                  "--objective",
+                  "Verify the outreach runtime",
+                  "--verify",
+                  NOOP_VERIFIER
+                ])
+            );
+
+            expect(runResult.exitCode).toBe(0);
           }
         )
       )


### PR DESCRIPTION
## Summary
- add governed receipt-chain regression coverage for explicit session-start -> preflight -> run
- cover budget normalization and INIT_CWD drift scenarios
- register the preflight receipt mismatch failure mode in the agent failure atlas

## Validation
- pnpm --dir . exec vitest run packages/cli/tests/cli-integration.test.ts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added FL-052 failure mode entry to Agent Failure Atlas, providing handling procedures for receipt mismatch scenarios between preflight and run phases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->