### PR TITLE
fix(adapters): prevent false verifier timeouts on longer test suites

### DIFF
--- a/packages/adapters/src/claude-cli.ts
+++ b/packages/adapters/src/claude-cli.ts
@@ -533,7 +533,7 @@ export interface AgentCliAdapterOptions {
   workingDirectory?: string;
   /** Timeout for the agent subprocess in ms. Defaults to 300_000 (5 min). */
   timeoutMs?: number;
-  /** Timeout per verification command in ms. Defaults to 60_000 (1 min). */
+  /** Timeout per verification command in ms. Defaults to 120_000 (2 min). */
   verifyTimeoutMs?: number;
   /** Human-readable label shown in loop records. */
   label?: string;
@@ -617,7 +617,7 @@ export interface GeminiCliAdapterOptions {
 export function createAgentCliAdapter(options: AgentCliAdapterOptions): MartinAdapter {
   const workingDirectory = options.workingDirectory ?? process.cwd();
   const timeoutMs = options.timeoutMs ?? 300_000;
-  const verifyTimeoutMs = options.verifyTimeoutMs ?? 60_000;
+  const verifyTimeoutMs = options.verifyTimeoutMs ?? 120_000;
   const adapterId = `agent-cli:${options.adapterIdSuffix ?? options.command}`;
   const supportsJsonOutput = options.supportsJsonOutput === true;
   const supportsUsageSettlement =

--- a/packages/adapters/src/openai-compatible.ts
+++ b/packages/adapters/src/openai-compatible.ts
@@ -131,7 +131,7 @@ export interface OpenAiCompatibleAdapterOptions {
   systemPrompt?: string;
   /** Request timeout in milliseconds. Default: 300_000 (5 min). */
   timeoutMs?: number;
-  /** Verifier timeout in milliseconds. Default: 60_000. */
+  /** Verifier timeout in milliseconds. Default: 120_000. */
   verifyTimeoutMs?: number;
   /** Working directory for git artifact collection and verification. */
   workingDirectory?: string;
@@ -221,7 +221,7 @@ export function createOpenAiCompatibleAdapter(
 ): MartinAdapter {
   const workingDirectory = options.workingDirectory ?? process.cwd();
   const timeoutMs = options.timeoutMs ?? 300_000;
-  const verifyTimeoutMs = options.verifyTimeoutMs ?? 60_000;
+  const verifyTimeoutMs = options.verifyTimeoutMs ?? 120_000;
   const systemPrompt = options.systemPrompt ?? DEFAULT_SYSTEM_PROMPT;
   const fetchFn = options.fetchImpl ?? globalThis.fetch;
   const runtimeConfig = resolveOpenAiCompatibleRuntimeConfig();

--- a/packages/adapters/src/verifier-only.ts
+++ b/packages/adapters/src/verifier-only.ts
@@ -14,7 +14,7 @@ export function createVerifierOnlyAdapter(
   options: VerifierOnlyAdapterOptions = {}
 ): MartinAdapter {
   const workingDirectory = options.workingDirectory ?? process.cwd();
-  const verifyTimeoutMs = options.verifyTimeoutMs ?? 60_000;
+  const verifyTimeoutMs = options.verifyTimeoutMs ?? 120_000;
 
   return {
     adapterId: "direct:verifier:verify-only",


### PR DESCRIPTION
## Summary
- raise default verifier timeout from 60s to 120s across Claude CLI, OpenAI-compatible, and verify-only adapters
- keep behavior fully overrideable via `verifyTimeoutMs` when callers need tighter/looser limits

## Why
- real-world verification commands can pass but exceed 60s, causing false `verification_failure` exits
- this update reduces premature budget exits while preserving bounded execution

## Validation
- `pnpm --filter @martin/adapters test -- tests/claude-cli.test.ts tests/openai-compatible.test.ts tests/stub-adapters.test.ts`
- `pnpm --filter @martin/cli test -- tests/cli.test.ts tests/proof-card.test.ts tests/cli-integration.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased default verification timeout from 60 seconds to 120 seconds across all adapters, improving reliability for slower verification operations and reducing timeout-related failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->