### PR TITLE
docs(changelog): capture verifier timeout hardening for shipping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Verifier defaults are less prone to false stop exits on longer suites** - default verifier timeout is now `120_000ms` (up from `60_000ms`) across CLI adapter paths, reducing timeout-driven `verification_failure` exits on healthy runs that take longer than one minute.
+
 ## [0.3.6]
 
 ### Fixed


### PR DESCRIPTION
## Summary
- add a clean public changelog note for verifier timeout hardening already shipped in code
- document that default verifier timeout is now 120s to reduce false timeout-driven exits on healthy longer suites

## Validation
- `pnpm public:copy-scan`
- `pnpm public:git-surface`
- `pnpm public:readme-cta-guard`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased verifier default timeouts from 60 to 120 seconds to reduce verification timeout failures on longer-running operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->