### PR TITLE
fix: prevent false verifier timeout after process exit

### DIFF
--- a/packages/adapters/src/cli-bridge.ts
+++ b/packages/adapters/src/cli-bridge.ts
@@ -84,6 +84,7 @@ export async function runSubprocess(
     let outputCapped = false;
     let terminationReason: string | undefined;
     let settled = false;
+    let exited = false;
     let outputBytes = 0;
     const stdoutChunks: Buffer[] = [];
     const stderrChunks: Buffer[] = [];
@@ -165,9 +166,16 @@ export async function runSubprocess(
     });
 
     const timer = setTimeout(() => {
+      if (settled || exited || proc.exitCode !== null) {
+        return;
+      }
       timedOut = true;
       proc.kill("SIGTERM");
     }, options.timeoutMs);
+
+    proc.on("exit", () => {
+      exited = true;
+    });
 
     proc.on("error", (error) => {
       clearTimeout(timer);

--- a/packages/adapters/tests/claude-cli.test.ts
+++ b/packages/adapters/tests/claude-cli.test.ts
@@ -489,6 +489,46 @@ describe("createSpawnPlan", () => {
 });
 
 describe("runSubprocess", () => {
+  it("does not mark timeout when the process has exited but close arrives later", async () => {
+    const spawnImpl: SpawnLike = () => {
+      const child = new EventEmitter() as Partial<ChildProcess> & {
+        stdout: PassThrough;
+        stderr: PassThrough;
+        stdin: Writable;
+        exitCode: number | null;
+      };
+      child.stdout = new PassThrough();
+      child.stderr = new PassThrough();
+      child.stdin = new Writable({
+        write(_chunk, _encoding, callback) {
+          callback();
+        }
+      });
+      child.exitCode = null;
+      child.kill = () => true;
+
+      setTimeout(() => {
+        child.exitCode = 0;
+        child.emit("exit", 0, null);
+      }, 0);
+
+      setTimeout(() => {
+        child.emit("close", 0, null);
+      }, 30);
+
+      return child as ChildProcess;
+    };
+
+    const result = await runSubprocess("codex", ["exec", "-"], {
+      cwd: process.cwd(),
+      timeoutMs: 10,
+      spawnImpl
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.timedOut).toBe(false);
+  });
+
   it("handles closed stdin pipes without surfacing an unhandled EPIPE", async () => {
     const spawnImpl: SpawnLike = () => {
       const child = new EventEmitter() as Partial<ChildProcess> & {


### PR DESCRIPTION
## Summary
- fix a subprocess lifecycle race that could mark a verifier step as timed out even after the child process had already exited
- add an exit-state guard to timeout handling in `runSubprocess`
- add regression coverage for the `exit` before `close` timing case

## Verification
- `pnpm --filter @martin/adapters test -- tests/claude-cli.test.ts`
- `martin preflight --task "Sync verifier timeout race fix to OSS" --scope "packages/adapters" --verify-only --verify "pnpm --filter @martin/adapters test -- tests/claude-cli.test.ts" --budget-usd 3 --max-iterations 1 --json`
- `martin run --task "Sync verifier timeout race fix to OSS" --scope "packages/adapters" --verify-only --verify "pnpm --filter @martin/adapters test -- tests/claude-cli.test.ts" --budget-usd 3 --max-iterations 1 --json`
- `martin dossier --latest --json`
- `martin runs verify --latest --json`