### PR TITLE
ci: enforce public portability and contamination guards

### DIFF
--- a/.github/workflows/public-surface-guard.yml
+++ b/.github/workflows/public-surface-guard.yml
@@ -1,0 +1,52 @@
+name: Public Surface Guard
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  public-surface-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 10.33.0
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run public copy and portability guards
+        run: |
+          pnpm public:copy-scan
+          pnpm public:portability-guard
+          pnpm public:readme-cta-guard
+
+      - name: Run public git surface guard
+        shell: bash
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            node ./scripts/public-git-surface-guard.mjs \
+              --base "${{ github.event.pull_request.base.sha }}" \
+              --head "${{ github.event.pull_request.head.sha }}"
+          else
+            node ./scripts/public-git-surface-guard.mjs \
+              --base "${{ github.event.before }}" \
+              --head "${{ github.sha }}"
+          fi
+

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -59,7 +59,9 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Guard public git surface
-        run: pnpm public:git-surface
+        run: |
+          pnpm public:git-surface
+          pnpm public:portability-guard
 
       - name: Verify MCP package
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           pnpm lint
           pnpm public:copy-scan
+          pnpm public:portability-guard
           pnpm public:git-surface
           pnpm test
           pnpm build

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "lint": "pnpm -r lint",
     "public:copy-scan": "node ./scripts/public-copy-scan.mjs",
     "public:git-surface": "node ./scripts/public-git-surface-guard.mjs",
+    "public:portability-guard": "node ./scripts/public-portability-guard.mjs",
     "public:readme-cta-guard": "node ./scripts/readme-cta-guard.mjs",
     "oss:validate": "node ./scripts/oss-boundary.mjs && pnpm public:readme-cta-guard",
     "public:smoke": "node ./scripts/public-facade-smoke.mjs",

--- a/scripts/public-portability-guard.mjs
+++ b/scripts/public-portability-guard.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+const TEXT_FILE_EXTENSIONS = new Set([
+  ".md",
+  ".txt",
+  ".json",
+  ".yml",
+  ".yaml",
+  ".js",
+  ".mjs",
+  ".cjs",
+  ".ts",
+  ".tsx",
+  ".mts",
+  ".cts",
+  ".sh",
+  ".ps1",
+  ".cmd",
+  ".xml",
+]);
+
+const PORTABILITY_RULES = [
+  { label: "windows user profile path", pattern: /[A-Za-z]:(?:\\{1,2}|\/)Users(?:\\{1,2}|\/)/i },
+  { label: "macOS user profile path", pattern: /\/Users\/[A-Za-z0-9._-]+\//i },
+  { label: "OneDrive machine path", pattern: /\bOneDrive\b/i },
+  { label: "Codex attachment path", pattern: /\.codex[\\/]+attachments/i },
+  { label: "internal main repo name", pattern: /\bML_Main_Repo_Internal\b/i },
+  { label: "internal OSS repo name", pattern: /\bML_Core_OSS_Internal\b/i },
+  { label: "internal machine workspace path", pattern: /\bmartin-loop_MAIN_FULL_REPO\b/i },
+];
+
+const PATH_ALLOWLIST = [
+  /^scripts\/public-copy-scan\.mjs$/,
+  /^scripts\/public-git-surface-guard\.mjs$/,
+  /^scripts\/public-portability-guard\.mjs$/,
+  /^scripts\/tests\//,
+  /(^|\/)tests\//,
+  /\.test\.[cm]?[jt]sx?$/i,
+  /^benchmarks\/fixtures\//,
+];
+
+export function normalizeRelativePath(value) {
+  return value.replaceAll("\\", "/").replace(/^\.\//, "");
+}
+
+export function shouldScanPath(relativePath) {
+  const normalized = normalizeRelativePath(relativePath);
+  if (!normalized) {
+    return false;
+  }
+
+  const extension = path.extname(normalized).toLowerCase();
+  if (!TEXT_FILE_EXTENSIONS.has(extension) && !normalized.endsWith("Dockerfile")) {
+    return false;
+  }
+
+  return !PATH_ALLOWLIST.some((rule) => rule.test(normalized));
+}
+
+export function findPortabilityViolations(contents, relativePath) {
+  const normalized = normalizeRelativePath(relativePath);
+  const normalizedContents = normalizeContents(contents, normalized);
+
+  return PORTABILITY_RULES
+    .filter((rule) => rule.pattern.test(normalizedContents))
+    .map((rule) => ({
+      path: normalized,
+      rule: rule.label,
+    }));
+}
+
+function normalizeContents(contents, relativePath) {
+  if (relativePath.endsWith(".json")) {
+    try {
+      const parsed = JSON.parse(contents);
+      return JSON.stringify(parsed, null, 2);
+    } catch {
+      return contents;
+    }
+  }
+
+  if (/\.(md|markdown|ya?ml)$/iu.test(relativePath)) {
+    return contents.replace(/```[\s\S]*?```/gu, "\n");
+  }
+
+  return contents;
+}
+
+export function collectTrackedFiles(rootDir = ROOT_DIR) {
+  const stdout = execFileSync("git", ["-C", rootDir, "ls-files", "-z"], { encoding: "utf8" });
+  return stdout
+    .split("\0")
+    .map((value) => value.trim())
+    .filter(Boolean)
+    .map((value) => normalizeRelativePath(value))
+    .sort();
+}
+
+export async function runPublicPortabilityGuard(options = {}) {
+  const rootDir = options.rootDir ?? ROOT_DIR;
+  const trackedFiles = options.files ?? collectTrackedFiles(rootDir);
+  const scannedFiles = trackedFiles.filter((file) => shouldScanPath(file));
+  const violations = [];
+
+  for (const relativePath of scannedFiles) {
+    const fullPath = path.join(rootDir, relativePath);
+    const contents = await readFile(fullPath, "utf8");
+    violations.push(...findPortabilityViolations(contents, relativePath));
+  }
+
+  if (violations.length > 0) {
+    const details = violations.map((entry) => `- ${entry.path}: ${entry.rule}`).join("\n");
+    throw new Error(`Public portability guard failed:\n${details}`);
+  }
+
+  return {
+    checkedFiles: scannedFiles.length,
+    trackedFiles: trackedFiles.length,
+    rootDir,
+  };
+}
+
+async function main() {
+  const result = await runPublicPortabilityGuard();
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : "";
+const modulePath = fileURLToPath(import.meta.url);
+if (invokedPath === path.resolve(modulePath)) {
+  main().catch((error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/tests/public-portability-guard.test.mjs
+++ b/scripts/tests/public-portability-guard.test.mjs
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  findPortabilityViolations,
+  runPublicPortabilityGuard,
+  shouldScanPath,
+} from "../public-portability-guard.mjs";
+
+test("findPortabilityViolations detects local machine paths and internal repo names", () => {
+  const windowsPath = findPortabilityViolations(
+    "See C:\\Users\\Example\\OneDrive\\Documents\\notes.md",
+    "README.md",
+  );
+  const internalRepo = findPortabilityViolations(
+    "Mirror from ML_Main_Repo_Internal before release.",
+    "docs/guide.md",
+  );
+
+  assert.ok(windowsPath.length > 0);
+  assert.ok(internalRepo.length > 0);
+});
+
+test("shouldScanPath skips known fixture and guard files", () => {
+  assert.equal(shouldScanPath("scripts/tests/public-copy-scan.test.mjs"), false);
+  assert.equal(shouldScanPath("packages/core/tests/runtime.test.ts"), false);
+  assert.equal(shouldScanPath("scripts/public-copy-scan.mjs"), false);
+  assert.equal(shouldScanPath("scripts/public-portability-guard.mjs"), false);
+  assert.equal(shouldScanPath("packages/core/src/index.ts"), true);
+});
+
+test("runPublicPortabilityGuard passes on clean portable files", async () => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "martin-portability-clean-"));
+  await mkdir(path.join(rootDir, "packages", "core", "src"), { recursive: true });
+  await mkdir(path.join(rootDir, "docs"), { recursive: true });
+
+  await writeFile(
+    path.join(rootDir, "packages", "core", "src", "index.ts"),
+    "export const message = 'portable';\n",
+  );
+  await writeFile(path.join(rootDir, "docs", "quickstart.md"), "# Quickstart\n");
+
+  const result = await runPublicPortabilityGuard({
+    rootDir,
+    files: ["packages/core/src/index.ts", "docs/quickstart.md"],
+  });
+
+  assert.equal(result.checkedFiles, 2);
+  assert.equal(result.trackedFiles, 2);
+});
+
+test("runPublicPortabilityGuard fails when source includes local machine dependencies", async () => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "martin-portability-fail-"));
+  await mkdir(path.join(rootDir, "packages", "core", "src"), { recursive: true });
+
+  await writeFile(
+    path.join(rootDir, "packages", "core", "src", "index.ts"),
+    "export const leakedPath = 'C:\\\\Users\\\\Example\\\\Desktop\\\\proof.txt';\n",
+  );
+
+  await assert.rejects(
+    () =>
+      runPublicPortabilityGuard({
+        rootDir,
+        files: ["packages/core/src/index.ts"],
+      }),
+    /Public portability guard failed/i,
+  );
+});
+


### PR DESCRIPTION
## Summary
- add a dedicated `public-portability-guard` to detect local machine path leakage and internal-repo references in public tracked files
- add coverage for the new guard in `scripts/tests/public-portability-guard.test.mjs`
- enforce public-surface checks on `pull_request` and `push` to `main` with a new `public-surface-guard` workflow
- include portability guard in release and MCP publish workflows

## Verification
- `pnpm public:copy-scan`
- `pnpm public:git-surface`
- `pnpm public:readme-cta-guard`
- `pnpm public:portability-guard`
- `node --test scripts/tests/public-portability-guard.test.mjs`
- governed verify lane (loop `loop_fghy07gs`): `martin preflight` -> `martin run` -> `martin dossier --latest` -> `martin runs verify --latest`