### PR TITLE
Persistence reliability: aggregation-first history + deduped reads

### DIFF
--- a/packages/cli/src/persistence.ts
+++ b/packages/cli/src/persistence.ts
@@ -1,4 +1,4 @@
-import { appendFile, mkdir, writeFile } from "node:fs/promises";
+import { appendFile, mkdir, readFile, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -127,6 +127,72 @@ async function writeJsonFile(path: string, value: unknown): Promise<void> {
 }
 
 async function writeEvents(path: string, events: LoopRecord["events"]): Promise<void> {
-  const body = events.map((e) => JSON.stringify(e)).join("\n");
+  const existing = await loadExistingEvents(path);
+  if (existing.malformed) {
+    if (events.length === 0) {
+      return;
+    }
+    const appended = events.map((event) => `${JSON.stringify(event)}\n`).join("");
+    await appendFile(path, appended, "utf8");
+    return;
+  }
+
+  const merged = mergeEvents(existing.events, events);
+  const body = merged.map((event) => JSON.stringify(event)).join("\n");
   await writeFile(path, body.length > 0 ? `${body}\n` : "", "utf8");
+}
+
+async function loadExistingEvents(path: string): Promise<{
+  events: LoopRecord["events"];
+  malformed: boolean;
+}> {
+  try {
+    const raw = await readFile(path, "utf8");
+    const trimmedLines = raw
+      .split(/\r?\n/u)
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+
+    const parsed: LoopRecord["events"] = [];
+    for (const line of trimmedLines) {
+      try {
+        parsed.push(JSON.parse(line) as LoopRecord["events"][number]);
+      } catch {
+        return { events: [], malformed: true };
+      }
+    }
+
+    return { events: parsed, malformed: false };
+  } catch {
+    return { events: [], malformed: false };
+  }
+}
+
+function mergeEvents(
+  existing: LoopRecord["events"],
+  incoming: LoopRecord["events"]
+): LoopRecord["events"] {
+  const seen = new Set<string>();
+  const merged: LoopRecord["events"] = [];
+
+  for (const event of [...existing, ...incoming]) {
+    const key = event.eventId && event.eventId.trim().length > 0
+      ? `eventId:${event.eventId}`
+      : `event:${event.type}:${event.timestamp}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    merged.push(event);
+  }
+
+  merged.sort(
+    (left, right) => safeTimestamp(left.timestamp) - safeTimestamp(right.timestamp)
+  );
+  return merged;
+}
+
+function safeTimestamp(value: string): number {
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : 0;
 }

--- a/packages/cli/tests/persistence.test.ts
+++ b/packages/cli/tests/persistence.test.ts
@@ -99,4 +99,50 @@ describe("persistLoopArtifacts", () => {
     const contract = JSON.parse(await readFile(contractPath, "utf8"));
     expect(contract.loopId).toBe(loop.loopId);
   });
+
+  it("aggregates events across repeated persists without dropping prior history", async () => {
+    const runsRoot = await mkdtemp(join(tmpdir(), "martin-persist-aggregate-"));
+    const loop = createLoopRecord({
+      workspaceId: "ws_aggregate",
+      projectId: "proj_aggregate",
+      task: {
+        title: "Aggregate event history",
+        objective: "Keep prior receipt intelligence while persisting updates.",
+        verificationPlan: ["pnpm test"]
+      },
+      events: [
+        {
+          eventId: "evt_1",
+          type: "run.started",
+          timestamp: "2026-04-01T00:00:00.000Z",
+          lifecycleState: "running",
+          payload: {}
+        }
+      ]
+    });
+
+    await persistLoopArtifacts(loop, { runsRoot });
+
+    const updated = {
+      ...loop,
+      updatedAt: "2026-04-01T00:05:00.000Z",
+      events: [
+        {
+          eventId: "evt_2",
+          type: "run.completed",
+          timestamp: "2026-04-01T00:04:00.000Z",
+          lifecycleState: "completed",
+          payload: {}
+        }
+      ]
+    };
+
+    await persistLoopArtifacts(updated, { runsRoot });
+
+    const events = await readFile(join(runsRoot, loop.loopId, "events.jsonl"), "utf8");
+    const lines = events.trim().split("\n");
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toContain('"eventId":"evt_1"');
+    expect(lines[1]).toContain('"eventId":"evt_2"');
+  });
 });

--- a/packages/core/src/persistence/runs-reader.ts
+++ b/packages/core/src/persistence/runs-reader.ts
@@ -44,6 +44,25 @@ export interface LoopRunRecord {
   task: { title: string; objective: string };
 }
 
+type LoopRecordSource = "legacy_jsonl" | "canonical_tree";
+
+export interface LoopRecordsRollup {
+  generatedAt: string;
+  totalRuns: number;
+  statusBreakdown: Record<string, number>;
+  lifecycleBreakdown: Record<string, number>;
+  latestByLoopId: Record<
+    string,
+    {
+      status: string;
+      lifecycleState: string;
+      updatedAt: string;
+      costUsd: number;
+      attempts: number;
+    }
+  >;
+}
+
 export async function readLoopRecordsFromFile(file: string): Promise<LoopRunRecord[]> {
   const text = await readFile(file, "utf8");
   const extension = extname(file).toLowerCase();
@@ -89,7 +108,7 @@ export async function readAllLoopRecords(
     return [];
   }
 
-  const records: LoopRunRecord[] = [];
+  const recordsByLoopId = new Map<string, { record: LoopRunRecord; source: LoopRecordSource }>();
 
   const jsonlFiles = entries
     .filter((entry) => entry.isFile() && entry.name.endsWith(".jsonl"))
@@ -97,7 +116,10 @@ export async function readAllLoopRecords(
 
   for (const file of jsonlFiles) {
     try {
-      records.push(...(await readLoopRecordsFromFile(join(dir, file))));
+      const fromFile = await readLoopRecordsFromFile(join(dir, file));
+      for (const record of fromFile) {
+        ingestRecord(recordsByLoopId, record, "legacy_jsonl");
+      }
     } catch {
       // skip malformed files or lines
     }
@@ -106,13 +128,16 @@ export async function readAllLoopRecords(
   const runDirectories = entries.filter((entry) => entry.isDirectory());
   for (const entry of runDirectories) {
     try {
-      records.push(...(await readLoopRecordsFromFile(join(dir, entry.name, "loop-record.json"))));
+      const canonical = await readLoopRecordsFromFile(join(dir, entry.name, "loop-record.json"));
+      for (const record of canonical) {
+        ingestRecord(recordsByLoopId, record, "canonical_tree");
+      }
     } catch {
       // skip missing or malformed canonical records
     }
   }
 
-  return records;
+  return [...recordsByLoopId.values()].map((entry) => entry.record);
 }
 
 /**
@@ -129,4 +154,69 @@ export async function readLatestLoopRecord(
     const b = new Date(latest.updatedAt ?? latest.createdAt).getTime();
     return a > b ? r : latest;
   }, records[0]!);
+}
+
+export function buildLoopRecordsRollup(records: LoopRunRecord[]): LoopRecordsRollup {
+  const statusBreakdown: Record<string, number> = {};
+  const lifecycleBreakdown: Record<string, number> = {};
+  const latestByLoopId: LoopRecordsRollup["latestByLoopId"] = {};
+
+  for (const record of records) {
+    statusBreakdown[record.status] = (statusBreakdown[record.status] ?? 0) + 1;
+    lifecycleBreakdown[record.lifecycleState] = (lifecycleBreakdown[record.lifecycleState] ?? 0) + 1;
+    latestByLoopId[record.loopId] = {
+      status: record.status,
+      lifecycleState: record.lifecycleState,
+      updatedAt: record.updatedAt,
+      costUsd: record.cost.actualUsd,
+      attempts: record.attempts.length
+    };
+  }
+
+  return {
+    generatedAt: new Date().toISOString(),
+    totalRuns: records.length,
+    statusBreakdown,
+    lifecycleBreakdown,
+    latestByLoopId
+  };
+}
+
+function ingestRecord(
+  recordsByLoopId: Map<string, { record: LoopRunRecord; source: LoopRecordSource }>,
+  record: LoopRunRecord,
+  source: LoopRecordSource
+): void {
+  const existing = recordsByLoopId.get(record.loopId);
+  if (!existing) {
+    recordsByLoopId.set(record.loopId, { record, source });
+    return;
+  }
+
+  const candidateTimestamp = resolveRecordTimestamp(record);
+  const existingTimestamp = resolveRecordTimestamp(existing.record);
+  if (candidateTimestamp > existingTimestamp) {
+    recordsByLoopId.set(record.loopId, { record, source });
+    return;
+  }
+
+  if (
+    candidateTimestamp === existingTimestamp &&
+    sourcePrecedence(source) > sourcePrecedence(existing.source)
+  ) {
+    recordsByLoopId.set(record.loopId, { record, source });
+  }
+}
+
+function resolveRecordTimestamp(record: LoopRunRecord): number {
+  const updated = Date.parse(record.updatedAt ?? "");
+  if (Number.isFinite(updated)) {
+    return updated;
+  }
+  const created = Date.parse(record.createdAt ?? "");
+  return Number.isFinite(created) ? created : 0;
+}
+
+function sourcePrecedence(source: LoopRecordSource): number {
+  return source === "canonical_tree" ? 2 : 1;
 }

--- a/packages/core/tests/runs-reader.test.ts
+++ b/packages/core/tests/runs-reader.test.ts
@@ -1,0 +1,136 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildLoopRecordsRollup,
+  type LoopRunRecord,
+  readAllLoopRecords,
+  readLatestLoopRecord
+} from "../src/persistence/runs-reader.js";
+
+function buildLoopRecord(input: {
+  loopId: string;
+  createdAt: string;
+  updatedAt: string;
+  status?: string;
+}): LoopRunRecord {
+  return {
+    loopId: input.loopId,
+    status: input.status ?? "completed",
+    lifecycleState: "completed",
+    createdAt: input.createdAt,
+    updatedAt: input.updatedAt,
+    budget: {
+      maxUsd: 2,
+      softLimitUsd: 1,
+      maxIterations: 2,
+      maxTokens: 2000
+    },
+    cost: {
+      actualUsd: 0.25,
+      tokensIn: 100,
+      tokensOut: 50
+    },
+    attempts: [],
+    task: {
+      title: "Reader test",
+      objective: "Verify dedupe semantics."
+    }
+  };
+}
+
+describe("runs-reader dedupe", () => {
+  it("prefers the most recently updated record for the same loopId across layouts", async () => {
+    const runsRoot = await mkdtemp(join(tmpdir(), "martin-runs-reader-latest-"));
+
+    try {
+      const loopId = "loop_same";
+      const legacy = buildLoopRecord({
+        loopId,
+        createdAt: "2026-06-01T00:00:00.000Z",
+        updatedAt: "2026-06-01T00:01:00.000Z",
+        status: "failed"
+      });
+      const canonical = buildLoopRecord({
+        loopId,
+        createdAt: "2026-06-01T00:00:00.000Z",
+        updatedAt: "2026-06-01T00:03:00.000Z",
+        status: "completed"
+      });
+      await writeFile(join(runsRoot, "workspace-alpha.jsonl"), `${JSON.stringify(legacy)}\n`, "utf8");
+      await mkdir(join(runsRoot, loopId), { recursive: true });
+      await writeFile(
+        join(runsRoot, loopId, "loop-record.json"),
+        `${JSON.stringify(canonical, null, 2)}\n`,
+        "utf8"
+      );
+
+      const records = await readAllLoopRecords(runsRoot);
+      expect(records).toHaveLength(1);
+      expect(records[0]?.status).toBe("completed");
+      expect(records[0]?.updatedAt).toBe("2026-06-01T00:03:00.000Z");
+    } finally {
+      await rm(runsRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("prefers canonical records when timestamps tie", async () => {
+    const runsRoot = await mkdtemp(join(tmpdir(), "martin-runs-reader-tie-"));
+
+    try {
+      const loopId = "loop_tie";
+      const timestamp = "2026-06-01T00:02:00.000Z";
+      const legacy = buildLoopRecord({
+        loopId,
+        createdAt: "2026-06-01T00:00:00.000Z",
+        updatedAt: timestamp,
+        status: "failed"
+      });
+      const canonical = buildLoopRecord({
+        loopId,
+        createdAt: "2026-06-01T00:00:00.000Z",
+        updatedAt: timestamp,
+        status: "completed"
+      });
+      await writeFile(join(runsRoot, "workspace-beta.jsonl"), `${JSON.stringify(legacy)}\n`, "utf8");
+      await mkdir(join(runsRoot, loopId), { recursive: true });
+      await writeFile(
+        join(runsRoot, loopId, "loop-record.json"),
+        `${JSON.stringify(canonical, null, 2)}\n`,
+        "utf8"
+      );
+
+      const latest = await readLatestLoopRecord(runsRoot);
+      expect(latest?.status).toBe("completed");
+      expect(latest?.loopId).toBe(loopId);
+    } finally {
+      await rm(runsRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("builds a derived rollup without mutating raw records", () => {
+    const records: LoopRunRecord[] = [
+      buildLoopRecord({
+        loopId: "loop_rollup_a",
+        createdAt: "2026-06-01T00:00:00.000Z",
+        updatedAt: "2026-06-01T00:02:00.000Z",
+        status: "completed"
+      }),
+      buildLoopRecord({
+        loopId: "loop_rollup_b",
+        createdAt: "2026-06-01T00:00:00.000Z",
+        updatedAt: "2026-06-01T00:03:00.000Z",
+        status: "failed"
+      })
+    ];
+    const rollup = buildLoopRecordsRollup(records);
+
+    expect(rollup.totalRuns).toBe(2);
+    expect(rollup.statusBreakdown.completed).toBe(1);
+    expect(rollup.statusBreakdown.failed).toBe(1);
+    expect(rollup.latestByLoopId["loop_rollup_a"]?.status).toBe("completed");
+  });
+});


### PR DESCRIPTION
## Summary
- harden CLI persistence so `events.jsonl` is aggregation-first and never truncates prior event history during repeat persists
- keep malformed historical event files append-safe (no destructive rewrite when legacy corruption exists)
- dedupe run history reads across legacy root JSONL and canonical run trees by `loopId`, selecting newest `updatedAt` and canonical-precedence tie-breakers
- add a derived rollup helper for aggregate analysis that does not mutate or delete raw receipts

## Validation
- `pnpm --filter @martin/core test -- tests/runs-reader.test.ts`
- `pnpm --filter @martin/cli test -- tests/persistence.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Event logs now preserve history with automatic deduplication instead of overwriting.
  * Loop records from different storage formats are consolidated into a single deduplicated view.
  * Added aggregation rollup to compute statistics across loop records.

* **Tests**
  * Added test coverage for event merging and record consolidation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->