### PR TITLE
fix(core): ignore baseline dirty files for patch attribution

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,6 +18,7 @@ import {
   type PatchDecisionArtifact,
   type PatchScore,
   type ReceiptScope,
+  type RollbackBoundaryArtifact,
   type RollbackOutcomeArtifact,
   type PolicyPhase
 } from "@martin/contracts";
@@ -63,7 +64,11 @@ import {
   type RepoGroundingHit,
   type RepoGroundingIndex
 } from "./grounding.js";
-import { captureRollbackBoundary, restoreRollbackBoundary } from "./rollback.js";
+import {
+  captureRollbackBoundary,
+  listAttemptChangedFilesSinceBoundary,
+  restoreRollbackBoundary
+} from "./rollback.js";
 import { compilePromptPacket } from "./compiler.js";
 import { makeLedgerEvent, resolveRunsRoot, runDir, type RunStore } from "./persistence/index.js";
 import {
@@ -116,6 +121,7 @@ export {
   queryRepoGroundingIndex,
   scanPatchForGroundingViolations,
   captureRollbackBoundary,
+  listAttemptChangedFilesSinceBoundary,
   restoreRollbackBoundary
 };
 export type {
@@ -1074,7 +1080,7 @@ export async function runMartin(input: RunMartinInput): Promise<RunMartinResult>
     }
 
     const changedFiles = tracksWorkspaceMutations
-      ? resolveChangedFiles(result, request.context.repoRoot)
+      ? resolveChangedFiles(result, request.context.repoRoot, rollbackBoundary)
       : [];
     // Evidence is only reliable when the adapter explicitly reported files OR git actually
     // returned a non-empty list. A repoRoot alone is insufficient — git may fail (e.g. not
@@ -1741,32 +1747,16 @@ function mergeCostProvenance(
   return COST_PROVENANCE_RANK[current] < COST_PROVENANCE_RANK[previous] ? current : previous;
 }
 
-function resolveChangedFiles(result: MartinAdapterResult, repoRoot?: string): string[] {
+function resolveChangedFiles(
+  result: MartinAdapterResult,
+  repoRoot?: string,
+  rollbackBoundary?: RollbackBoundaryArtifact
+): string[] {
   if (result.execution?.changedFiles !== undefined) {
     return result.execution.changedFiles;
   }
 
-  if (!repoRoot) {
-    return [];
-  }
-
-  try {
-    const diff = spawnSync("git", ["diff", "--name-only", "HEAD", "--", "."], {
-      cwd: repoRoot,
-      encoding: "utf8"
-    });
-
-    if (diff.status !== 0 || typeof diff.stdout !== "string") {
-      return [];
-    }
-
-    return diff.stdout
-      .split(/\r?\n/u)
-      .map((entry) => entry.trim())
-      .filter(Boolean);
-  } catch {
-    return [];
-  }
+  return listAttemptChangedFilesSinceBoundary({ repoRoot, boundary: rollbackBoundary });
 }
 
 function buildPatchDiff(result: MartinAdapterResult, changedFiles: string[]): string | undefined {

--- a/packages/core/src/rollback.ts
+++ b/packages/core/src/rollback.ts
@@ -14,6 +14,28 @@ interface RepoStateSnapshot {
   untrackedFiles: string[];
 }
 
+export function listAttemptChangedFilesSinceBoundary(input: {
+  repoRoot?: string;
+  boundary?: RollbackBoundaryArtifact;
+}): string[] {
+  if (!input.repoRoot) {
+    return [];
+  }
+
+  const repoState = readRepoState(input.repoRoot);
+  if (!input.boundary) {
+    return uniqueSorted([...repoState.trackedDirtyFiles, ...repoState.untrackedFiles]);
+  }
+
+  const baselineTracked = new Set(input.boundary.trackedDirtyFiles);
+  const baselineUntracked = new Set(input.boundary.untrackedFiles);
+
+  return uniqueSorted([
+    ...repoState.trackedDirtyFiles.filter((filePath) => !baselineTracked.has(filePath)),
+    ...repoState.untrackedFiles.filter((filePath) => !baselineUntracked.has(filePath))
+  ]);
+}
+
 export async function captureRollbackBoundary(input: {
   repoRoot?: string;
   capturedAt: string;

--- a/packages/core/tests/runtime.test.ts
+++ b/packages/core/tests/runtime.test.ts
@@ -555,6 +555,96 @@ describe("runMartin", () => {
     ]);
   });
 
+  it("does not attribute pre-existing dirty repo files to a tool-launch-blocked attempt", async () => {
+    const runsRoot = await mkdtemp(join(tmpdir(), "martin-env-dirty-boundary-"));
+    const repoRoot = join(runsRoot, "repo");
+    await mkdir(join(repoRoot, "src"), { recursive: true });
+    await mkdir(join(repoRoot, "docs"), { recursive: true });
+    await writeFile(join(repoRoot, "src", "real.ts"), "export const real = 1;\n", "utf8");
+    await writeFile(join(repoRoot, "docs", "notes.md"), "clean baseline\n", "utf8");
+    initializeGitRepo(repoRoot);
+    await writeFile(join(repoRoot, "docs", "notes.md"), "pre-existing dirty notes\n", "utf8");
+    const store = createFileRunStore({ runsRoot });
+
+    const adapter: MartinAdapter = {
+      adapterId: "agent-cli:codex",
+      kind: "agent-cli",
+      label: "Codex CLI adapter",
+      metadata: {
+        providerId: "codex",
+        model: "codex",
+        transport: "cli"
+      },
+      async execute() {
+        return {
+          status: "completed",
+          summary: "CreateProcessAsUserW failed: 5 before verifier execution in the adapter transcript.",
+          usage: {
+            actualUsd: 0.02,
+            tokensIn: 12,
+            tokensOut: 6
+          },
+          verification: {
+            passed: true,
+            summary: "All 1 verification step(s) passed.",
+            steps: [
+              {
+                command: "npm test",
+                launched: true,
+                exitCode: 0,
+                timedOut: false,
+                fastFail: true,
+                detail: "tests passed"
+              }
+            ]
+          }
+        };
+      }
+    };
+
+    const result = await runMartin({
+      workspaceId: "ws_ops",
+      projectId: "proj_runtime",
+      task: {
+        title: "Avoid false repo-grounding failures after sandbox launch errors",
+        objective: "Keep pre-existing dirty files out of attempt attribution when the adapter could not execute.",
+        verificationPlan: ["npm test"],
+        repoRoot,
+        allowedPaths: ["src/**"]
+      },
+      budget: {
+        maxUsd: 10,
+        softLimitUsd: 6,
+        maxIterations: 1,
+        maxTokens: 2_000
+      },
+      adapter,
+      store,
+      now: createTimestampSource([
+        "2026-06-18T10:00:00.000Z",
+        "2026-06-18T10:00:01.000Z",
+        "2026-06-18T10:00:02.000Z",
+        "2026-06-18T10:00:03.000Z",
+        "2026-06-18T10:00:04.000Z",
+        "2026-06-18T10:00:05.000Z",
+        "2026-06-18T10:00:06.000Z"
+      ]),
+      idFactory: createIdFactory()
+    });
+
+    const verificationEvent = result.loop.events.find((event) => event.type === "verification.completed");
+    const failureEvent = result.loop.events.find((event) => event.type === "failure.classified");
+
+    expect(result.decision.lifecycleState).toBe("completed");
+    expect(failureEvent).toBeUndefined();
+    expect(verificationEvent?.payload["warnings"]).toContain(
+      "Adapter output reported a tool-launch problem before MartinLoop ran its own verifier: CreateProcessAsUserW failed: 5 before verifier execution in the adapter transcript."
+    );
+    await expect(readFile(join(repoRoot, "docs", "notes.md"), "utf8")).resolves.toBe(
+      "pre-existing dirty notes\n"
+    );
+  });
+
   it("writes context integrity precheck artifacts into the active runs root", async () => {
     const runsRoot = await mkdtemp(join(tmpdir(), "martin-context-precheck-"));
     const store = createFileRunStore({ runsRoot });


### PR DESCRIPTION
## Summary
- compute inferred changed files relative to the captured rollback boundary instead of raw git diff HEAD
- stop attributing pre-existing dirty repo state to failed or blocked adapter attempts
- cover the Windows sandbox/tool-launch contradiction path with a runtime regression test

## Testing
- pnpm --dir packages/core test -- tests/runtime.test.ts

## Notes
- pnpm --dir packages/core build remains red in this worktree because the existing workspace package-resolution/build baseline is not currently green; this PR does not modify that broader build setup.