### PR TITLE
MCP/CLI reliability: host compatibility + engine contract lock

### DIFF
--- a/.github/workflows/phase13-release-matrix.yml
+++ b/.github/workflows/phase13-release-matrix.yml
@@ -42,8 +42,8 @@ jobs:
         env:
           MARTIN_RELEASE_MATRIX_OUTDIR: .artifacts/release-matrix/${{ matrix.os }}
         run: |
-          pnpm release:truth-check
-          pnpm release:matrix:local
+          node ./scripts/release-truth-check.mjs --allow-divergence-marker=[sync-parity]
+          node ./scripts/release-matrix.mjs
 
       - name: Upload release matrix artifacts
         if: always()

--- a/.github/workflows/phase13-release-matrix.yml
+++ b/.github/workflows/phase13-release-matrix.yml
@@ -1,0 +1,53 @@
+name: phase13-release-matrix
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  release-matrix:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - windows-latest
+          - macos-latest
+          - ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Run OSS release matrix lane
+        env:
+          MARTIN_RELEASE_MATRIX_OUTDIR: .artifacts/release-matrix/${{ matrix.os }}
+        run: |
+          pnpm release:truth-check
+          pnpm release:matrix:local
+
+      - name: Upload release matrix artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: phase13-release-matrix-${{ matrix.os }}
+          path: .artifacts/release-matrix/${{ matrix.os }}

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "release:root:guard": "node ./scripts/root-release-guard.mjs --pack",
     "release:validate:platforms": "node ./scripts/release-matrix.mjs",
     "release:matrix:local": "node ./scripts/release-matrix.mjs",
+    "release:truth-check": "node ./scripts/release-truth-check.mjs --allow-divergence-marker=[sync-parity]",
     "run:cli": "pnpm --filter @martin/cli dev",
     "taxonomy:sync": "node ./scripts/failure-taxonomy.mjs --write",
     "taxonomy:check": "node ./scripts/failure-taxonomy.mjs --check"

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -38,6 +38,7 @@ import {
 } from "./phase-command-center.js";
 import {
   buildMcpInstallPlan,
+  hostRequiresExperimentalRemoteOptIn,
   installMcpConfig,
   type MartinMcpHost,
   type MartinMcpPlatform,
@@ -254,6 +255,7 @@ type McpCommand =
       profile: MartinMcpProfile;
       remoteUrl?: string;
       remoteTokenEnv?: string;
+      experimentalRemoteHosts: boolean;
       platform?: MartinMcpPlatform;
     }
   | {
@@ -266,6 +268,7 @@ type McpCommand =
       profile: MartinMcpProfile;
       remoteUrl?: string;
       remoteTokenEnv?: string;
+      experimentalRemoteHosts: boolean;
       platform?: MartinMcpPlatform;
       dryRun: boolean;
     };
@@ -606,6 +609,7 @@ export function parseCliArguments(args: string[]): ParsedCliArguments {
       const remoteUrl = readOption(subcommandArgs, "--remote-url");
       const remoteTokenEnv = readOption(subcommandArgs, "--remote-token-env");
       const platform = parseMcpPlatform(subcommandArgs);
+      const experimentalRemoteHosts = hasFlag(subcommandArgs, "--experimental-remote-hosts");
 
       return {
         command: "mcp_print_config",
@@ -617,6 +621,7 @@ export function parseCliArguments(args: string[]): ParsedCliArguments {
         ...(runsDir ? { runsDir } : {}),
         ...(remoteUrl ? { remoteUrl } : {}),
         ...(remoteTokenEnv ? { remoteTokenEnv } : {}),
+        experimentalRemoteHosts,
         ...(platform ? { platform } : {})
       };
     }
@@ -631,6 +636,7 @@ export function parseCliArguments(args: string[]): ParsedCliArguments {
       const remoteUrl = readOption(subcommandArgs, "--remote-url");
       const remoteTokenEnv = readOption(subcommandArgs, "--remote-token-env");
       const platform = parseMcpPlatform(subcommandArgs);
+      const experimentalRemoteHosts = hasFlag(subcommandArgs, "--experimental-remote-hosts");
 
       return {
         command: "mcp_install",
@@ -642,6 +648,7 @@ export function parseCliArguments(args: string[]): ParsedCliArguments {
         ...(runsDir ? { runsDir } : {}),
         ...(remoteUrl ? { remoteUrl } : {}),
         ...(remoteTokenEnv ? { remoteTokenEnv } : {}),
+        experimentalRemoteHosts,
         ...(platform ? { platform } : {}),
         dryRun: hasFlag(subcommandArgs, "--dry-run")
       };
@@ -697,8 +704,8 @@ export function renderCliHelp(): string {
     "  martin runs get (--loop-id <id> | --file <path> | --latest) [options]",
     "  martin runs attempt (--loop-id <id> | --file <path>) [--attempt-index <n>] [options]",
     "  martin runs verify (--loop-id <id> | --file <path> | --latest) [options]",
-    "  martin mcp print-config --host <codex|claude|gemini|generic> [--scope <user|project|local>] [options]",
-    "  martin mcp install --host <codex|claude|gemini|generic> [--scope <user|project|local>] [--dry-run] [options]",
+    "  martin mcp print-config --host <codex|claude|gemini|cursor|copilot|continue|generic> [--scope <user|project|local>] [options]",
+    "  martin mcp install --host <codex|claude|gemini|cursor|copilot|continue|generic> [--scope <user|project|local>] [--dry-run] [options]",
     "  martin demo [--dir <path>] [--force]",
     "  martin-loop demo [--dir <path>] [--force] (published alias)",
     "  martin inspect --file <path>",
@@ -755,10 +762,11 @@ export function renderCliHelp(): string {
     "  --execute                Execute generated preflight/run command after contract validation.",
     "",
     "MCP config options:",
-    "  --host <name>            codex, claude, gemini, or generic.",
+    "  --host <name>            codex, claude, gemini, cursor, copilot, continue, or generic.",
     "  --scope <name>           user or project for all hosts; Claude also supports local.",
-    "  --transport <name>       stdio (default).",
-    "  --profile <name>         minimal (default), diagnostic, github-review, full-local, starter, or full.",
+    "  --transport <name>       stdio (default) or remote.",
+    "  --experimental-remote-hosts  Required to enable remote transport for cursor/copilot/continue.",
+    "  --profile <name>         minimal (default), diagnostic, github-review, full-local, paid-remote, starter, or full.",
     "  --platform <name>        windows, macos, or linux recipe shaping.",
     "",
     "Run options:",
@@ -1916,6 +1924,7 @@ async function executeMcpPrintConfigCommand(
   command: Extract<ParsedCliArguments, { command: "mcp_print_config" }>,
   outputMode: MartinOutputMode
 ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  const remotePolicyWarnings = assertMcpRemoteTransportPolicy(command);
   const environment = resolveCliEnvironment({
     cwd: command.cwd,
     runsDir: command.runsDir
@@ -1939,6 +1948,7 @@ async function executeMcpPrintConfigCommand(
       scope: command.scope,
       transport: command.transport,
       profile: command.profile,
+      experimentalRemoteHosts: command.experimentalRemoteHosts,
       targetPath: plan.targetPath,
       content: plan.content,
       serverId: plan.serverId,
@@ -1949,14 +1959,15 @@ async function executeMcpPrintConfigCommand(
         diagnostic: [...MARTIN_DIAGNOSTIC_TOOLS],
         "github-review": [...MARTIN_GITHUB_REVIEW_TOOLS],
         "full-local": [...MARTIN_FULL_TOOLS],
-        starter: [...MARTIN_STARTER_TOOLS],
-        full: [...MARTIN_FULL_TOOLS]
-      },
-      starterTools: [...MARTIN_STARTER_TOOLS],
-      fullTools: [...MARTIN_FULL_TOOLS]
+      starter: [...MARTIN_STARTER_TOOLS],
+      full: [...MARTIN_FULL_TOOLS]
     },
+    starterTools: [...MARTIN_STARTER_TOOLS],
+    fullTools: [...MARTIN_FULL_TOOLS]
+  },
     human: plan.content,
-    quiet: plan.targetPath
+    quiet: plan.targetPath,
+    warnings: remotePolicyWarnings
   });
 }
 
@@ -1964,6 +1975,7 @@ async function executeMcpInstallCommand(
   command: Extract<ParsedCliArguments, { command: "mcp_install" }>,
   outputMode: MartinOutputMode
 ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  const remotePolicyWarnings = assertMcpRemoteTransportPolicy(command);
   const environment = resolveCliEnvironment({
     cwd: command.cwd,
     runsDir: command.runsDir
@@ -1975,6 +1987,7 @@ async function executeMcpInstallCommand(
     runsRoot: environment.runsRoot,
     transport: command.transport,
     profile: command.profile,
+    experimentalRemoteHosts: command.experimentalRemoteHosts,
     ...(command.remoteUrl ? { remoteUrl: command.remoteUrl } : {}),
     ...(command.remoteTokenEnv ? { remoteTokenEnv: command.remoteTokenEnv } : {}),
     ...(command.platform ? { platform: command.platform } : {})
@@ -2001,7 +2014,8 @@ async function executeMcpInstallCommand(
       "",
       plan.content
     ],
-    quiet: plan.targetPath
+    quiet: plan.targetPath,
+    warnings: remotePolicyWarnings
   });
 }
 
@@ -2308,7 +2322,7 @@ function parseMcpTransport(tokens: string[]): MartinMcpTransport {
   }
 
   throw new CliCommandError("invalid_input", `Invalid --transport value: ${transport}.`, {
-    suggestion: "Use --transport stdio."
+    suggestion: "Use --transport stdio or --transport remote."
   });
 }
 
@@ -2324,6 +2338,7 @@ function parseMcpProfile(tokens: string[]): MartinMcpProfile {
     profile === "diagnostic" ||
     profile === "github-review" ||
     profile === "full-local" ||
+    profile === "paid-remote" ||
     profile === "starter" ||
     profile === "full"
   ) {
@@ -2331,8 +2346,31 @@ function parseMcpProfile(tokens: string[]): MartinMcpProfile {
   }
 
   throw new CliCommandError("invalid_input", `Invalid --profile value: ${profile}.`, {
-    suggestion: "Use --profile minimal, diagnostic, github-review, full-local, starter, or full."
+    suggestion: "Use --profile minimal, diagnostic, github-review, full-local, paid-remote, starter, or full."
   });
+}
+
+function assertMcpRemoteTransportPolicy(
+  command: Extract<ParsedCliArguments, { command: "mcp_print_config" | "mcp_install" }>
+): string[] {
+  if (command.transport !== "remote" || !hostRequiresExperimentalRemoteOptIn(command.host)) {
+    return [];
+  }
+
+  if (!command.experimentalRemoteHosts) {
+    throw new CliCommandError(
+      "invalid_input",
+      `Remote transport for ${command.host} is experimental and requires explicit opt-in.`,
+      {
+        suggestion:
+          `Re-run with --experimental-remote-hosts, or use --transport stdio for stable host behavior.`
+      }
+    );
+  }
+
+  return [
+    `Remote transport for ${command.host} is experimental. Validate host behavior and keep stdio as the default fallback lane.`
+  ];
 }
 
 function parseMcpPlatform(tokens: string[]): MartinMcpPlatform | undefined {

--- a/packages/cli/src/mcp-config.ts
+++ b/packages/cli/src/mcp-config.ts
@@ -100,6 +100,7 @@ export interface MartinMcpConfigInput {
   profile?: MartinMcpProfile;
   remoteUrl?: string;
   remoteTokenEnv?: string;
+  experimentalRemoteHosts?: boolean;
   platform?: MartinMcpPlatform;
 }
 
@@ -114,6 +115,7 @@ export interface MartinMcpInstallPlan extends Required<Omit<MartinMcpConfigInput
 
 const DEFAULT_REMOTE_URL = "https://remote.martinloop.local/mcp";
 const DEFAULT_REMOTE_TOKEN_ENV = "MARTIN_REMOTE_TOKEN";
+const REMOTE_EXPERIMENTAL_HOSTS = new Set<MartinMcpHost>(["cursor", "copilot", "continue"]);
 
 export function buildMcpInstallPlan(input: MartinMcpConfigInput): MartinMcpInstallPlan {
   const normalized = normalizeInput(input);
@@ -149,6 +151,12 @@ export async function installMcpConfig(
       return plan;
     }
 
+    const merged = mergeHostConfig(plan.host, plan.serverId, existing, plan.content);
+    if (merged) {
+      await writeFile(plan.targetPath, merged, "utf8");
+      return plan;
+    }
+
     throw new CliCommandError(
       "environment",
       `Refusing to overwrite existing MCP config: ${plan.targetPath}`,
@@ -176,6 +184,7 @@ function normalizeInput(input: MartinMcpConfigInput): Required<Omit<MartinMcpCon
     profile: input.profile ?? "minimal",
     remoteUrl: input.remoteUrl ?? DEFAULT_REMOTE_URL,
     remoteTokenEnv: input.remoteTokenEnv ?? DEFAULT_REMOTE_TOKEN_ENV,
+    experimentalRemoteHosts: input.experimentalRemoteHosts ?? false,
     platform: input.platform ?? detectPlatform()
   };
 }
@@ -468,17 +477,26 @@ function buildCursorConfigSnippet(
   input: Required<Omit<MartinMcpConfigInput, "remoteUrl">> & { remoteUrl?: string }
 ): string {
   const launcher = buildStdioLauncher(input.platform);
-  const serverId = "martin-loop";
+  const serverId = input.transport === "remote" ? "martin-loop-remote" : "martin-loop";
   return (
     JSON.stringify(
       {
         mcpServers: {
           [serverId]: {
-            command: launcher.command,
-            args: launcher.args,
-            env: {
-              MARTIN_RUNS_DIR: input.runsRoot
-            }
+            ...(input.transport === "remote"
+              ? {
+                  url: input.remoteUrl ?? DEFAULT_REMOTE_URL,
+                  headers: {
+                    Authorization: `Bearer $${input.remoteTokenEnv}`
+                  }
+                }
+              : {
+                  command: launcher.command,
+                  args: launcher.args,
+                  env: {
+                    MARTIN_RUNS_DIR: input.runsRoot
+                  }
+                })
           }
         }
       },
@@ -498,17 +516,27 @@ function buildCopilotConfigSnippet(
   input: Required<Omit<MartinMcpConfigInput, "remoteUrl">> & { remoteUrl?: string }
 ): string {
   const launcher = buildStdioLauncher(input.platform);
-  const serverId = "martin-loop";
+  const serverId = input.transport === "remote" ? "martin-loop-remote" : "martin-loop";
   return (
     JSON.stringify(
       {
         "github.copilot.chat.mcpServers": {
           [serverId]: {
-            command: launcher.command,
-            args: launcher.args,
-            env: {
-              MARTIN_RUNS_DIR: input.runsRoot
-            }
+            ...(input.transport === "remote"
+              ? {
+                  type: "http",
+                  url: input.remoteUrl ?? DEFAULT_REMOTE_URL,
+                  headers: {
+                    Authorization: `Bearer $${input.remoteTokenEnv}`
+                  }
+                }
+              : {
+                  command: launcher.command,
+                  args: launcher.args,
+                  env: {
+                    MARTIN_RUNS_DIR: input.runsRoot
+                  }
+                })
           }
         }
       },
@@ -529,17 +557,28 @@ function buildContinueConfigSnippet(
 ): string {
   const launcher = buildStdioLauncher(input.platform);
   const tools = selectTools(input.profile);
+  const serverId = input.transport === "remote" ? "martin-loop-remote" : "martin-loop";
   return (
     JSON.stringify(
       {
         mcpServers: [
           {
-            name: "martin-loop",
-            command: launcher.command,
-            args: launcher.args,
-            env: {
-              MARTIN_RUNS_DIR: input.runsRoot
-            },
+            name: serverId,
+            ...(input.transport === "remote"
+              ? {
+                  type: "http",
+                  url: input.remoteUrl ?? DEFAULT_REMOTE_URL,
+                  headers: {
+                    Authorization: `Bearer $${input.remoteTokenEnv}`
+                  }
+                }
+              : {
+                  command: launcher.command,
+                  args: launcher.args,
+                  env: {
+                    MARTIN_RUNS_DIR: input.runsRoot
+                  }
+                }),
             includeTools: tools
           }
         ]
@@ -608,14 +647,141 @@ function existingConfigAlreadyContainsMartin(
   }
 
   try {
-    const parsed = JSON.parse(existing) as {
-      mcpServers?: Record<string, unknown>;
-    };
-
-    return typeof parsed.mcpServers === "object" && parsed.mcpServers !== null && serverId in parsed.mcpServers;
+    const parsed = JSON.parse(existing) as Record<string, unknown>;
+    return hasMartinServerInParsedConfig(host, serverId, parsed);
   } catch {
     return false;
   }
+}
+
+function hasMartinServerInParsedConfig(
+  host: MartinMcpHost,
+  serverId: string,
+  parsed: Record<string, unknown>
+): boolean {
+  if (host === "copilot") {
+    const servers = parsed["github.copilot.chat.mcpServers"];
+    return isRecord(servers) && serverId in servers;
+  }
+
+  if (host === "continue") {
+    const servers = parsed.mcpServers;
+    if (Array.isArray(servers)) {
+      return servers.some((entry) => isRecord(entry) && entry.name === serverId);
+    }
+    return isRecord(servers) && serverId in servers;
+  }
+
+  const servers = parsed.mcpServers;
+  return isRecord(servers) && serverId in servers;
+}
+
+function mergeHostConfig(
+  host: MartinMcpHost,
+  serverId: string,
+  existing: string,
+  generated: string
+): string | undefined {
+  if (host === "codex" || host === "claude" && generated.startsWith("claude mcp add")) {
+    return undefined;
+  }
+
+  try {
+    const existingParsed = JSON.parse(existing) as Record<string, unknown>;
+    const generatedParsed = JSON.parse(generated) as Record<string, unknown>;
+    const merged = mergeHostParsedConfig(host, serverId, existingParsed, generatedParsed);
+    if (!merged) {
+      return undefined;
+    }
+    return `${JSON.stringify(merged, null, 2)}\n`;
+  } catch {
+    return undefined;
+  }
+}
+
+function mergeHostParsedConfig(
+  host: MartinMcpHost,
+  serverId: string,
+  existing: Record<string, unknown>,
+  generated: Record<string, unknown>
+): Record<string, unknown> | undefined {
+  if (host === "copilot") {
+    const existingServers = isRecord(existing["github.copilot.chat.mcpServers"])
+      ? { ...existing["github.copilot.chat.mcpServers"] }
+      : {};
+    const generatedServers = isRecord(generated["github.copilot.chat.mcpServers"])
+      ? generated["github.copilot.chat.mcpServers"]
+      : undefined;
+    if (!generatedServers) {
+      return undefined;
+    }
+    return {
+      ...existing,
+      "github.copilot.chat.mcpServers": {
+        ...existingServers,
+        ...generatedServers
+      }
+    };
+  }
+
+  if (host === "continue") {
+    const generatedServers = generated.mcpServers;
+    if (!Array.isArray(generatedServers)) {
+      return undefined;
+    }
+    const generatedServer = generatedServers.find((entry) => isRecord(entry) && entry.name === serverId);
+    if (!generatedServer) {
+      return undefined;
+    }
+
+    const existingServers = existing.mcpServers;
+    if (Array.isArray(existingServers)) {
+      const withoutMartin = existingServers.filter(
+        (entry) => !(isRecord(entry) && entry.name === serverId)
+      );
+      return {
+        ...existing,
+        mcpServers: [...withoutMartin, generatedServer]
+      };
+    }
+
+    if (isRecord(existingServers)) {
+      return {
+        ...existing,
+        mcpServers: {
+          ...existingServers,
+          [serverId]: generatedServer
+        }
+      };
+    }
+
+    return {
+      ...existing,
+      mcpServers: [generatedServer]
+    };
+  }
+
+  const generatedServers = generated.mcpServers;
+  if (!isRecord(generatedServers)) {
+    return undefined;
+  }
+
+  const existingServers = isRecord(existing.mcpServers) ? existing.mcpServers : {};
+  return {
+    ...existing,
+    mcpServers: {
+      ...existingServers,
+      ...generatedServers
+    }
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function hostRequiresExperimentalRemoteOptIn(host: MartinMcpHost): boolean {
+  return REMOTE_EXPERIMENTAL_HOSTS.has(host);
 }
 
 function renderClaudeLocalInstallCommand(

--- a/packages/cli/tests/cli.test.ts
+++ b/packages/cli/tests/cli.test.ts
@@ -147,6 +147,50 @@ describe("parseCliArguments", () => {
     expect(parseCliArguments(["preflight", "--help"])).toEqual({ command: "help" });
     expect(parseCliArguments(["preflight", "-h"])).toEqual({ command: "help" });
   });
+  it("parses onboarding commands and objective shorthand", () => {
+    expect(parseCliArguments(["start"])).toEqual({ command: "start" });
+    expect(parseCliArguments(["env"])).toEqual({ command: "env" });
+    expect(parseCliArguments(["review"])).toEqual({
+      command: "review",
+      selector: { latest: true }
+    });
+    expect(parseCliArguments(["receipts", "explain"])).toEqual({
+      command: "receipts_explain",
+      selector: { latest: true }
+    });
+    expect(parseCliArguments(["fix flaky tests", "--proof", "--verify", "npm test"])).toEqual({
+      command: "run",
+      request: expect.objectContaining({
+        objective: "fix flaky tests",
+        liveMode: "proof",
+        verificationPlan: ["npm test"]
+      })
+    });
+  });
+
+  it("parses MCP install with paid-remote profile and experimental host flag", () => {
+    expect(
+      parseCliArguments([
+        "mcp",
+        "install",
+        "--host",
+        "cursor",
+        "--transport",
+        "remote",
+        "--profile",
+        "paid-remote",
+        "--experimental-remote-hosts"
+      ])
+    ).toEqual({
+      command: "mcp_install",
+      host: "cursor",
+      scope: "user",
+      transport: "remote",
+      profile: "paid-remote",
+      experimentalRemoteHosts: true,
+      dryRun: false
+    });
+  });
 });
 
 describe("executeCli", () => {
@@ -156,6 +200,22 @@ describe("executeCli", () => {
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain("martin runs verify (--loop-id <id> | --file <path> | --latest) [options]");
     expect(result.stdout).toContain("martin start [options]");
+    expect(result.stdout).toContain("--experimental-remote-hosts");
+  });
+
+  it("blocks remote MCP config for cursor without explicit experimental opt-in", async () => {
+    const result = await executeCli([
+      "mcp",
+      "print-config",
+      "--host",
+      "cursor",
+      "--transport",
+      "remote"
+    ]);
+
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain("experimental");
+    expect(result.stderr).toContain("--experimental-remote-hosts");
   });
 
   it("prints the public root package version", async () => {

--- a/packages/cli/tests/cli.test.ts
+++ b/packages/cli/tests/cli.test.ts
@@ -147,27 +147,6 @@ describe("parseCliArguments", () => {
     expect(parseCliArguments(["preflight", "--help"])).toEqual({ command: "help" });
     expect(parseCliArguments(["preflight", "-h"])).toEqual({ command: "help" });
   });
-  it("parses onboarding commands and objective shorthand", () => {
-    expect(parseCliArguments(["start"])).toEqual({ command: "start" });
-    expect(parseCliArguments(["env"])).toEqual({ command: "env" });
-    expect(parseCliArguments(["review"])).toEqual({
-      command: "review",
-      selector: { latest: true }
-    });
-    expect(parseCliArguments(["receipts", "explain"])).toEqual({
-      command: "receipts_explain",
-      selector: { latest: true }
-    });
-    expect(parseCliArguments(["fix flaky tests", "--proof", "--verify", "npm test"])).toEqual({
-      command: "run",
-      request: expect.objectContaining({
-        objective: "fix flaky tests",
-        liveMode: "proof",
-        verificationPlan: ["npm test"]
-      })
-    });
-  });
-
   it("parses MCP install with paid-remote profile and experimental host flag", () => {
     expect(
       parseCliArguments([

--- a/packages/cli/tests/mcp-config.test.ts
+++ b/packages/cli/tests/mcp-config.test.ts
@@ -239,4 +239,158 @@ describe("mcp config helpers", () => {
       await rm(cwd, { recursive: true, force: true });
     }
   });
+
+  it("merges into existing Copilot settings without destructive overwrite", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "martin-cli-copilot-config-"));
+
+    try {
+      const configDir = join(cwd, ".vscode");
+      await mkdir(configDir, { recursive: true });
+      const configPath = join(configDir, "settings.json");
+      const existing = JSON.stringify(
+        {
+          "editor.formatOnSave": true,
+          "github.copilot.chat.mcpServers": {
+            "existing-server": {
+              command: "node",
+              args: ["./server.js"]
+            }
+          }
+        },
+        null,
+        2
+      );
+      await writeFile(configPath, `${existing}\n`, "utf8");
+
+      await installMcpConfig({
+        host: "copilot",
+        scope: "project",
+        cwd,
+        runsRoot: join(cwd, ".runs")
+      });
+
+      const merged = JSON.parse(await readFile(configPath, "utf8")) as {
+        "editor.formatOnSave": boolean;
+        "github.copilot.chat.mcpServers": Record<string, unknown>;
+      };
+      expect(merged["editor.formatOnSave"]).toBe(true);
+      expect(Object.keys(merged["github.copilot.chat.mcpServers"])).toEqual(
+        expect.arrayContaining(["existing-server", "martin-loop"])
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("treats existing Copilot configs with martin-loop as idempotent", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "martin-cli-copilot-idempotent-"));
+
+    try {
+      const configDir = join(cwd, ".vscode");
+      await mkdir(configDir, { recursive: true });
+      const configPath = join(configDir, "settings.json");
+      const existing = JSON.stringify(
+        {
+          "github.copilot.chat.mcpServers": {
+            "martin-loop": {
+              command: "npx",
+              args: ["-y", "@martinloop/mcp"]
+            }
+          }
+        },
+        null,
+        2
+      );
+      await writeFile(configPath, `${existing}\n`, "utf8");
+
+      await installMcpConfig({
+        host: "copilot",
+        scope: "project",
+        cwd,
+        runsRoot: join(cwd, ".runs")
+      });
+
+      expect(await readFile(configPath, "utf8")).toBe(`${existing}\n`);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("treats existing Continue array configs with martin-loop as idempotent", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "martin-cli-continue-idempotent-"));
+
+    try {
+      const configDir = join(cwd, ".continue");
+      await mkdir(configDir, { recursive: true });
+      const configPath = join(configDir, "config.json");
+      const existing = JSON.stringify(
+        {
+          mcpServers: [
+            {
+              name: "martin-loop",
+              command: "npx",
+              args: ["-y", "@martinloop/mcp"]
+            }
+          ]
+        },
+        null,
+        2
+      );
+      await writeFile(configPath, `${existing}\n`, "utf8");
+
+      await installMcpConfig({
+        host: "continue",
+        scope: "project",
+        cwd,
+        runsRoot: join(cwd, ".runs")
+      });
+
+      expect(await readFile(configPath, "utf8")).toBe(`${existing}\n`);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("merges Continue array configs while preserving non-Martin entries", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "martin-cli-continue-merge-array-"));
+
+    try {
+      const configDir = join(cwd, ".continue");
+      await mkdir(configDir, { recursive: true });
+      const configPath = join(configDir, "config.json");
+      const existing = JSON.stringify(
+        {
+          telemetryEnabled: false,
+          mcpServers: [
+            {
+              name: "existing-server",
+              command: "node",
+              args: ["./existing.js"]
+            }
+          ]
+        },
+        null,
+        2
+      );
+      await writeFile(configPath, `${existing}\n`, "utf8");
+
+      await installMcpConfig({
+        host: "continue",
+        scope: "project",
+        cwd,
+        runsRoot: join(cwd, ".runs")
+      });
+
+      const merged = JSON.parse(await readFile(configPath, "utf8")) as {
+        telemetryEnabled: boolean;
+        mcpServers: Array<{ name?: string }>;
+      };
+      expect(merged.telemetryEnabled).toBe(false);
+      expect(merged.mcpServers.map((entry) => entry.name)).toEqual(
+        expect.arrayContaining(["existing-server", "martin-loop"])
+      );
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/mcp/src/prompts.ts
+++ b/packages/mcp/src/prompts.ts
@@ -19,6 +19,7 @@ import {
   resolveMartinDiscoveryContext
 } from "./discovery-support.js";
 import { invalidArgumentsError } from "./tools/tool-errors.js";
+import type { MartinEngine } from "./tools/tool-support.js";
 
 export const MARTIN_PROMPTS: Prompt[] = [
   {
@@ -183,7 +184,7 @@ export interface MartinGetPromptInput {
   arguments?: Record<string, string>;
   runsDir?: string;
   workingDirectory?: string;
-  engine?: "claude" | "codex" | "gemini";
+  engine?: MartinEngine;
 }
 
 export function listMartinPrompts(): { prompts: Prompt[] } {

--- a/packages/mcp/src/resources.ts
+++ b/packages/mcp/src/resources.ts
@@ -21,6 +21,7 @@ import {
 } from "./discovery-support.js";
 import { loadDetailedLoopRecord, readLedgerEvents } from "./tools/run-store.js";
 import { invalidArgumentsError, MartinToolError } from "./tools/tool-errors.js";
+import type { MartinEngine } from "./tools/tool-support.js";
 
 export const MARTIN_STATIC_RESOURCE_URIS = {
   serverHealth: "martin://server/health",
@@ -211,7 +212,7 @@ export interface MartinReadResourceInput {
   uri: string;
   runsDir?: string;
   workingDirectory?: string;
-  engine?: "claude" | "codex" | "gemini";
+  engine?: MartinEngine;
 }
 
 export function listMartinResources(): { resources: Resource[] } {

--- a/packages/mcp/src/server-validation.ts
+++ b/packages/mcp/src/server-validation.ts
@@ -24,6 +24,7 @@ import type { MartinRunDossierInput } from "./tools/run-dossier.js";
 import type { MartinRunControlRequestInput } from "./tools/run-controls.js";
 import type { RunLoopInput } from "./tools/run-loop.js";
 import type { MartinTriageRunsInput } from "./tools/triage-runs.js";
+import { MARTIN_ENGINE_VALUES } from "./tools/tool-support.js";
 
 type ToolName =
   | "martin_run"
@@ -244,7 +245,7 @@ function validateRunInput(args: unknown): RunLoopInput {
     "projectId"
   ]);
 
-  const engine = optionalEnum(record.engine, "engine", ["claude", "codex", "gemini"] as const);
+  const engine = optionalEnum(record.engine, "engine", MARTIN_ENGINE_VALUES);
   return {
     objective: requireString(record.objective, "objective"),
     ...(record.workingDirectory !== undefined
@@ -354,7 +355,7 @@ function validateDoctorInput(args: unknown): MartinDoctorInput {
     ...(record.runsDir !== undefined
       ? { runsDir: resolveSafeRunsRootPath(requireString(record.runsDir, "runsDir")) }
       : {}),
-    ...optionalEnumAsObject(record.engine, "engine", ["claude", "codex", "gemini"] as const)
+    ...optionalEnumAsObject(record.engine, "engine", MARTIN_ENGINE_VALUES)
   };
 }
 

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -59,6 +59,7 @@ import { martinRunDossierTool } from "./tools/run-dossier.js";
 import { createRunControlReceipt } from "./tools/run-controls.js";
 import { martinTriageRunsTool } from "./tools/triage-runs.js";
 import { runLoopTool } from "./tools/run-loop.js";
+import { MARTIN_ENGINE_VALUES } from "./tools/tool-support.js";
 import { createToolErrorResult, createToolSuccessResult } from "./tools/tool-response.js";
 import { MartinToolError, toToolFailure } from "./tools/tool-errors.js";
 import { normalizeLoopBudget } from "./tools/workflow-governance.js";
@@ -795,7 +796,7 @@ export function createMartinMcpServer(serverInfo?: {
           },
           engine: {
             type: "string",
-            enum: ["claude", "codex", "gemini"],
+            enum: [...MARTIN_ENGINE_VALUES],
             description: "Which agent CLI to use. Defaults to claude."
           },
           model: {
@@ -933,7 +934,7 @@ export function createMartinMcpServer(serverInfo?: {
           },
           engine: {
             type: "string",
-            enum: ["claude", "codex", "gemini"],
+            enum: [...MARTIN_ENGINE_VALUES],
             description: "Optional engine to highlight in diagnostics."
           }
         }
@@ -998,7 +999,7 @@ export function createMartinMcpServer(serverInfo?: {
           },
           engine: {
             type: "string",
-            enum: ["claude", "codex", "gemini"],
+            enum: [...MARTIN_ENGINE_VALUES],
             description: "Which agent CLI would be used. Defaults to claude."
           },
           model: {

--- a/packages/mcp/src/tools/run-loop.ts
+++ b/packages/mcp/src/tools/run-loop.ts
@@ -33,7 +33,7 @@ import { normalizeLoopBudget } from "./workflow-governance.js";
 export interface RunLoopInput {
   objective: string;
   workingDirectory?: string;
-  engine?: "claude" | "codex" | "gemini";
+  engine?: MartinEngine;
   model?: string;
   maxUsd?: number;
   maxIterations?: number;

--- a/packages/mcp/src/tools/tool-support.ts
+++ b/packages/mcp/src/tools/tool-support.ts
@@ -21,7 +21,8 @@ import {
 
 import { readAllLoopRecordsSafely } from "./run-store.js";
 
-export type MartinEngine = "claude" | "codex" | "gemini";
+export const MARTIN_ENGINE_VALUES = ["claude", "codex", "gemini"] as const;
+export type MartinEngine = (typeof MARTIN_ENGINE_VALUES)[number];
 
 export interface InspectableLoopAttempt extends LoopAttemptRecord {
   attemptId?: string;

--- a/scripts/release-truth-check.mjs
+++ b/scripts/release-truth-check.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve, join } from "node:path";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(fileURLToPath(new URL("..", import.meta.url)));
+const markerFlag = process.argv.find((arg) => arg.startsWith("--allow-divergence-marker="));
+const allowedMarker = markerFlag ? markerFlag.slice("--allow-divergence-marker=".length) : undefined;
+const mirrorRoot = process.env.MARTIN_MAIN_REPO_PATH
+  ? resolve(process.env.MARTIN_MAIN_REPO_PATH, "oss-core")
+  : resolve(repoRoot, "..", "martin-loop_MAIN_FULL_REPO", "oss-core");
+
+const CRITICAL_FILES = [
+  "packages/mcp/src/tools/tool-support.ts",
+  "packages/mcp/src/server-validation.ts",
+  "packages/mcp/src/server.ts",
+  "packages/cli/src/mcp-config.ts",
+  "packages/cli/src/index.ts"
+];
+
+const divergences = [];
+for (const relativePath of CRITICAL_FILES) {
+  const local = safeReadLocal(relativePath);
+  if (!local.ok) {
+    fail(`Missing critical file in internal OSS source: ${relativePath}`);
+  }
+
+  const publicFile = safeReadGitRef("public/main", relativePath);
+  if (publicFile.ok && publicFile.text !== local.text) {
+    divergences.push({
+      lane: "public",
+      relativePath,
+      localSha: sha(local.text),
+      remoteSha: sha(publicFile.text)
+    });
+  }
+
+  const mirrorFile = safeReadMirror(relativePath);
+  if (mirrorFile.ok && mirrorFile.text !== local.text) {
+    divergences.push({
+      lane: "embedded_mirror",
+      relativePath,
+      localSha: sha(local.text),
+      remoteSha: sha(mirrorFile.text)
+    });
+  }
+}
+
+assertInvariant(
+  "engine union",
+  /MARTIN_ENGINE_VALUES\s*=\s*\["claude",\s*"codex",\s*"gemini"\]/u,
+  "packages/mcp/src/tools/tool-support.ts"
+);
+assertInvariant(
+  "schema/validator engine source",
+  /MARTIN_ENGINE_VALUES/u,
+  "packages/mcp/src/server-validation.ts"
+);
+assertInvariant(
+  "server schema engine source",
+  /MARTIN_ENGINE_VALUES/u,
+  "packages/mcp/src/server.ts"
+);
+assertInvariant(
+  "host coverage includes cursor/copilot/continue",
+  /"cursor"\s*\|\s*"copilot"\s*\|\s*"continue"/u,
+  "packages/cli/src/mcp-config.ts"
+);
+assertInvariant(
+  "experimental remote host policy helper",
+  /hostRequiresExperimentalRemoteOptIn/u,
+  "packages/cli/src/mcp-config.ts"
+);
+assertInvariant(
+  "CLI remote host opt-in flag",
+  /--experimental-remote-hosts/u,
+  "packages/cli/src/index.ts"
+);
+
+if (divergences.length === 0) {
+  console.log("release-truth-check: ok (critical MCP/CLI surfaces are in parity).");
+  process.exit(0);
+}
+
+if (allowedMarker && latestCommitMessage().includes(allowedMarker)) {
+  console.warn("release-truth-check: divergence accepted by explicit sync marker.");
+  for (const row of divergences) {
+    console.warn(
+      `  - ${row.lane}:${row.relativePath} local=${row.localSha.slice(0, 12)} remote=${row.remoteSha.slice(0, 12)}`
+    );
+  }
+  process.exit(0);
+}
+
+console.error("release-truth-check: divergence detected across critical MCP/CLI files.");
+for (const row of divergences) {
+  console.error(
+    `  - ${row.lane}:${row.relativePath} local=${row.localSha.slice(0, 12)} remote=${row.remoteSha.slice(0, 12)}`
+  );
+}
+if (allowedMarker) {
+  console.error(`Add sync marker '${allowedMarker}' in the commit message to acknowledge intentional drift.`);
+}
+process.exit(1);
+
+function assertInvariant(name, pattern, relativePath) {
+  const result = safeReadLocal(relativePath);
+  if (!result.ok) {
+    fail(`Invariant '${name}' failed because ${relativePath} could not be read.`);
+  }
+  if (!pattern.test(result.text)) {
+    fail(`Invariant '${name}' failed in ${relativePath}.`);
+  }
+}
+
+function latestCommitMessage() {
+  try {
+    return execFileSync("git", ["log", "-1", "--pretty=%B"], {
+      cwd: repoRoot,
+      encoding: "utf8"
+    }).trim();
+  } catch {
+    return "";
+  }
+}
+
+function safeReadLocal(relativePath) {
+  const filePath = join(repoRoot, relativePath);
+  if (!existsSync(filePath)) {
+    return { ok: false, text: "" };
+  }
+  return { ok: true, text: readFileSync(filePath, "utf8") };
+}
+
+function safeReadMirror(relativePath) {
+  const filePath = join(mirrorRoot, relativePath);
+  if (!existsSync(filePath)) {
+    return { ok: false, text: "" };
+  }
+  return { ok: true, text: readFileSync(filePath, "utf8") };
+}
+
+function safeReadGitRef(ref, relativePath) {
+  try {
+    const text = execFileSync("git", ["show", `${ref}:${relativePath}`], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"]
+    });
+    return { ok: true, text };
+  } catch {
+    return { ok: false, text: "" };
+  }
+}
+
+function sha(text) {
+  return createHash("sha256").update(text).digest("hex");
+}
+
+function fail(message) {
+  console.error(`release-truth-check: ${message}`);
+  process.exit(1);
+}

--- a/scripts/release-truth-check.mjs
+++ b/scripts/release-truth-check.mjs
@@ -11,7 +11,7 @@ const markerFlag = process.argv.find((arg) => arg.startsWith("--allow-divergence
 const allowedMarker = markerFlag ? markerFlag.slice("--allow-divergence-marker=".length) : undefined;
 const mirrorRoot = process.env.MARTIN_MAIN_REPO_PATH
   ? resolve(process.env.MARTIN_MAIN_REPO_PATH, "oss-core")
-  : resolve(repoRoot, "..", "martin-loop_MAIN_FULL_REPO", "oss-core");
+  : null;
 
 const CRITICAL_FILES = [
   "packages/mcp/src/tools/tool-support.ts",
@@ -136,6 +136,9 @@ function safeReadLocal(relativePath) {
 }
 
 function safeReadMirror(relativePath) {
+  if (!mirrorRoot) {
+    return { ok: false, text: "" };
+  }
   const filePath = join(mirrorRoot, relativePath);
   if (!existsSync(filePath)) {
     return { ok: false, text: "" };


### PR DESCRIPTION
## Summary
- unify MCP engine contract consumption around shared `MARTIN_ENGINE_VALUES` (`claude|codex|gemini`) across schema and validators
- harden CLI MCP host behavior for cursor/copilot/continue with host-aware idempotence detection and non-destructive merge writes
- enforce explicit experimental remote transport policy for cursor/copilot/continue (`--experimental-remote-hosts` required)
- add release truth/parity check script and wire it into release-matrix workflow with explicit sync-marker support

## Validation
- `pnpm --filter @martin/cli test -- tests/mcp-config.test.ts tests/cli.test.ts`
- `pnpm --filter @martinloop/mcp test -- tests/server-validation.test.ts tests/mcp-tools.test.ts`
- `pnpm release:truth-check`

## Notes
- `pnpm --filter @martinloop/mcp test` has unrelated baseline failures in `tests/eval.test.ts` and `tests/trajectory-triage.test.ts`.
- `pnpm --filter @martin/cli lint` has unrelated baseline type failure in `tests/run-history-intelligence.test.ts` (missing export).