### PR TITLE
Enforce explicit no-spend modes and live-run defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ npx -y martin-loop@latest start
 npx -y martin-loop@latest demo
 cd martin-loop-demo
 npm install
-npx -y martin-loop@latest run "Summarize the demo workspace and prove tests still pass" --proof --verify "npm test"
+npx -y martin-loop@latest run "Summarize the demo workspace and prove tests still pass" --verify "npm test" --budget-usd 2 --max-iterations 1
 ```
 
 ## Quick Start
@@ -60,7 +60,7 @@ npx -y martin-loop@latest demo
 npx -y martin-loop@latest --version
 cd martin-loop-demo
 npm install
-npx -y martin-loop@latest run "Summarize the demo workspace and prove tests still pass" --proof --verify "npm test"
+npx -y martin-loop@latest run "Summarize the demo workspace and prove tests still pass" --verify "npm test" --budget-usd 2 --max-iterations 1
 npx -y martin-loop@latest dossier --latest
 npx -y martin-loop@latest share --latest
 ```
@@ -74,7 +74,7 @@ martin-loop --version
 
 If this flow is useful, open an issue with feedback so we can keep improving the public experience.
 
-`start` prints the first-run guided path. `run` auto-checks `doctor`, `session-start`, and `preflight`, then executes when the environment is ready. You can still run those commands directly when you want to inspect the governed checks first.
+`start` prints the first-run guided path. `run` auto-checks `doctor`, `session-start`, and `preflight`, then executes when the environment is ready. Use `--proof` only when you intentionally want an explicit no-spend lane.
 
 Inspect-first flow:
 
@@ -132,7 +132,7 @@ npx -y martin-loop@0.3.6 start
 npx -y martin-loop@0.3.6 demo
 cd martin-loop-demo
 npm install
-npx -y martin-loop@0.3.6 run "Summarize the demo workspace and prove tests still pass" --proof --verify "npm test" --json
+npx -y martin-loop@0.3.6 run "Summarize the demo workspace and prove tests still pass" --verify "npm test" --budget-usd 2 --max-iterations 1 --json
 npx -y martin-loop@0.3.6 dossier --latest --json
 npx -y martin-loop@0.3.6 share --latest --json
 ```
@@ -225,7 +225,7 @@ Common options:
 --budget-usd <n>        Alias for --budget
 --soft-limit-usd <n>    Soft budget threshold in USD
 --verify <cmd>          Verifier command after each attempt
---proof                 Use the no-spend proof adapter
+--proof                 Explicitly opt into a no-spend proof adapter lane
 --max-iterations <n>    Maximum number of attempts
 --max-tokens <n>        Maximum token budget
 --engine <name>         Adapter to use: claude, codex, gemini, or openai

--- a/docs/getting-started/codex.md
+++ b/docs/getting-started/codex.md
@@ -28,6 +28,8 @@ npx martin-loop run "Summarize the demo workspace and confirm the verifier is gr
 npx martin-loop dossier --latest
 ```
 
+`--proof` is explicit opt-in. Default `martin-loop run` commands execute live governed runs with real spend controls.
+
 ## Install MCP For Codex
 
 ```sh

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -16,12 +16,12 @@ npx -y martin-loop@latest start
 npx -y martin-loop@latest demo
 cd martin-loop-demo
 npm install
-npx -y martin-loop@latest run "Summarize the demo workspace and prove tests still pass" --proof --verify "npm test"
+npx -y martin-loop@latest run "Summarize the demo workspace and prove tests still pass" --verify "npm test" --budget-usd 2 --max-iterations 1
 npx -y martin-loop@latest dossier --latest
 npx -y martin-loop@latest share --latest
 ```
 
-This path proves the run/dossier loop without model spend. `run` auto-checks `doctor`, `session-start`, and `preflight`, then executes when the environment is ready.
+This path proves the run/dossier loop with a real spend-governed execution. `run` auto-checks `doctor`, `session-start`, and `preflight`, then executes when the environment is ready.
 
 ## Install the CLI
 
@@ -50,6 +50,12 @@ npx -y martin-loop@latest run "fix the auth regression" --budget 3.00 --verify "
 ```
 
 By default, MartinLoop auto-checks `doctor`, `session-start`, and `preflight` for the same repo and task before a real run will spend money. If preflight finds a real blocker, MartinLoop stops before live spend and tells you what to fix.
+
+For explicit no-spend validation, pass `--proof` intentionally:
+
+```sh
+npx -y martin-loop@latest run "fix the auth regression" --proof --budget 1.00 --verify "pnpm test"
+```
 
 If you want to inspect the governed checks first:
 

--- a/docs/oss/AGENT-START-HERE.md
+++ b/docs/oss/AGENT-START-HERE.md
@@ -10,19 +10,17 @@ npx martin-loop demo
 cd martin-loop-demo
 ```
 
-Windows PowerShell no-spend proof run:
+Windows PowerShell no-spend proof run (explicit opt-in):
 
 ```powershell
-$env:MARTIN_LIVE='false'
-npx martin-loop run "Summarize the demo workspace and prove tests still pass" --verify "npm test"
+npx martin-loop run "Summarize the demo workspace and prove tests still pass" --proof --verify "npm test"
 npx martin-loop dossier --latest
-Remove-Item Env:MARTIN_LIVE
 ```
 
-macOS/Linux no-spend proof run:
+macOS/Linux no-spend proof run (explicit opt-in):
 
 ```sh
-MARTIN_LIVE=false npx martin-loop run "Summarize the demo workspace and prove tests still pass" --verify "npm test"
+npx martin-loop run "Summarize the demo workspace and prove tests still pass" --proof --verify "npm test"
 npx martin-loop dossier --latest
 ```
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -37,7 +37,7 @@ npx -y martin-loop@latest --version
 npx -y martin-loop@latest demo
 cd martin-loop-demo
 npm install
-npx -y martin-loop@latest run "Summarize the workspace and prove tests still pass" --proof --verify "npm test"
+npx -y martin-loop@latest run "Summarize the workspace and prove tests still pass" --verify "npm test" --budget-usd 2 --max-iterations 1
 npx -y martin-loop@latest share --latest
 ```
 
@@ -51,8 +51,8 @@ npx -y martin-loop@latest share --latest
 --budget-usd <n>        Alias for --budget
 --soft-limit-usd <n>    Soft budget threshold in USD
 --verify <cmd>          Verifier command after each attempt
---proof                 Use the no-spend proof adapter instead of a live coding CLI
---verify-only           Skip the coding adapter and run the verifier only
+--proof                 Explicitly opt into a no-spend proof adapter lane
+--verify-only           Explicitly skip the coding adapter and run verifier-only
 --unsafe-allow-unguarded-run
                         Bypass the local governance gate for this one run
 --max-iterations <n>    Maximum number of attempts

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -774,7 +774,7 @@ export function renderCliHelp(): string {
     "  --max-iterations <n>     Set the maximum number of attempts.",
     "  --max-tokens <n>         Set the maximum total token budget.",
     "  --verify <cmd>           Shell command to run as the verifier after each attempt.",
-    "  --proof                  Run in no-spend proof mode (same as MARTIN_LIVE=false).",
+    "  --proof                  Run in no-spend proof mode (explicit opt-in).",
     "  --verify-only            Skip the coding adapter and run the verifier only.",
     "  --unsafe-allow-unguarded-run",
     "                           Bypass doctor/preflight run-gate checks for this invocation only.",
@@ -913,6 +913,7 @@ async function executeRunCommand(
     cliEnvironment.workingDirectory,
     resolvedRequest.model,
     effectiveMutationMode,
+    cliEnvironment.liveMode,
     codexCommandOverride
   );
   try {
@@ -962,7 +963,7 @@ async function executeRunCommand(
 
     throw new CliCommandError("environment", "Martin could not start the requested execution adapter.", {
       suggestion:
-        "Run `martin doctor` to verify engine availability, or set MARTIN_LIVE=false to use the stub adapter locally.",
+        "Run `martin doctor` to verify engine availability, or rerun with `--proof` for an explicit no-spend lane.",
       details: {
         loopId: fallbackLoop.loopId,
         reason: error instanceof Error ? error.message : String(error)
@@ -1450,7 +1451,7 @@ async function executeStartCommand(
         "npx -y martin-loop@latest doctor",
         "npx -y martin-loop@latest session-start",
         'npx -y martin-loop@latest preflight "Summarize the workspace and prove tests still pass" --verify "npm test"',
-        'npx -y martin-loop@latest run "Summarize the workspace and prove tests still pass" --proof --verify "npm test"',
+        'npx -y martin-loop@latest run "Summarize the workspace and prove tests still pass" --verify "npm test" --budget-usd 2 --max-iterations 1',
         "npx -y martin-loop@latest share --latest --json"
       ]
     },
@@ -1467,8 +1468,11 @@ async function executeStartCommand(
       "  npx -y martin-loop@latest doctor",
       "  npx -y martin-loop@latest session-start",
       '  npx -y martin-loop@latest preflight "Summarize the workspace and prove tests still pass" --verify "npm test"',
-      '  npx -y martin-loop@latest run "Summarize the workspace and prove tests still pass" --proof --verify "npm test"',
+      '  npx -y martin-loop@latest run "Summarize the workspace and prove tests still pass" --verify "npm test" --budget-usd 2 --max-iterations 1',
       "  npx -y martin-loop@latest share --latest --json",
+      "",
+      "Optional explicit no-spend lane:",
+      '  npx -y martin-loop@latest run "Summarize the workspace and prove tests still pass" --proof --verify "npm test" --budget-usd 2 --max-iterations 1',
       "",
       "One-off operator bypass exists, but is intentionally explicit: --unsafe-allow-unguarded-run"
     ],
@@ -2488,9 +2492,9 @@ function renderDemoInstructions(targetDirectory: string): string {
     "  npm install",
     "  npm test",
     "",
-    "Safe first run (no provider spend, governed path):",
+    "Default first run (live spend-governed):",
     "  npx -y martin-loop@latest start",
-    '  npx -y martin-loop@latest run "Summarize the demo workspace and confirm the verifier is green" --proof --verify "npm test"',
+    '  npx -y martin-loop@latest run "Summarize the demo workspace and confirm the verifier is green" --verify "npm test" --budget-usd 2 --max-iterations 1',
     "  npx -y martin-loop@latest share --latest --json",
     "",
     "Inspect the governed checks explicitly:",
@@ -2498,7 +2502,10 @@ function renderDemoInstructions(targetDirectory: string): string {
     "  npx -y martin-loop@latest session-start",
     '  npx -y martin-loop@latest preflight "Summarize the demo workspace and confirm the verifier is green" --verify "npm test"',
     "",
-    "Optional live run:",
+    "Optional explicit no-spend proof run:",
+    '  npx -y martin-loop@latest run "Summarize the demo workspace and confirm the verifier is green" --proof --verify "npm test" --budget-usd 2 --max-iterations 1',
+    "",
+    "Optional live implementation run:",
     '  npx -y martin-loop@latest run "Add support for a discount percentage to summarizeInvoice and update the tests" --verify "npm test" --engine codex',
     "",
     `Task ideas live in ${join(targetDirectory, "TASKS.md")}`
@@ -2735,6 +2742,7 @@ function selectAdapter(
   workingDirectory: string,
   modelOverride?: string,
   mutationMode?: MutationMode,
+  liveMode: "live" | "proof" = "live",
   codexCommandOverride?: string
 ): MartinAdapter {
   if (runAdapterOverrideForTests) {
@@ -2745,9 +2753,9 @@ function selectAdapter(
     return createVerifierOnlyAdapter({ workingDirectory });
   }
 
-  if (process.env.MARTIN_LIVE === "false") {
+  if (liveMode === "proof") {
     return createStubDirectProviderAdapter({
-      label: "Stub adapter (MARTIN_LIVE=false)",
+      label: "Stub adapter (--proof)",
       providerId: "stub",
       model: "stub"
     });
@@ -2807,14 +2815,14 @@ function buildDoctorRecommendations(input: {
   }
 
   if (input.liveMode === "live" && input.engine === "codex" && !input.codexAvailable) {
-    recommendations.push("Install or expose the Codex CLI on PATH, or set MARTIN_LIVE=false while iterating locally.");
+    recommendations.push("Install or expose the Codex CLI on PATH, or rerun with `--proof` for explicit no-spend validation.");
   }
   if (input.liveMode === "live" && input.engine === "codex" && input.codexAvailable && input.codexLaunchReady === false) {
     recommendations.push(input.codexRemediation ?? "Run `martin preflight --engine codex` and fix the reported Codex host issue before governed work.");
   }
 
   if (input.liveMode === "live" && input.engine === "gemini" && !input.geminiAvailable) {
-    recommendations.push("Install or expose the Gemini CLI on PATH, or set MARTIN_LIVE=false while iterating locally.");
+    recommendations.push("Install or expose the Gemini CLI on PATH, or rerun with `--proof` for explicit no-spend validation.");
   }
 
   return recommendations;

--- a/packages/cli/src/phase-command-center.ts
+++ b/packages/cli/src/phase-command-center.ts
@@ -610,7 +610,7 @@ function buildSessionStartHostDiagnostics(
   host: string,
   receiptScope: ResolvedReceiptScope
 ): NativePhaseSnapshot["sessionStart"]["hostDiagnostics"] {
-  const mode = process.env.MARTIN_LIVE === "false" ? "proof" : "live";
+  const mode: "live" | "proof" = "live";
   if (host !== "codex") {
     return {
       mode,

--- a/packages/cli/src/run-store.ts
+++ b/packages/cli/src/run-store.ts
@@ -228,7 +228,7 @@ export function resolveCliEnvironment(input: {
     workingDirectory,
     runsRoot,
     engine,
-    liveMode: input.liveMode ?? (env.MARTIN_LIVE === "false" ? "proof" : "live")
+    liveMode: input.liveMode ?? "live"
   };
 }
 

--- a/packages/cli/tests/cli-integration.test.ts
+++ b/packages/cli/tests/cli-integration.test.ts
@@ -1,6 +1,6 @@
 /**
  * CLI integration tests covering adapter selection, engine flags,
- * and the MARTIN_LIVE guard introduced with the real adapter.
+ * and explicit no-spend proof mode guardrails.
  */
 
 import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
@@ -214,24 +214,23 @@ async function readWorkflowState(
 }
 
 // ---------------------------------------------------------------------------
-// MARTIN_LIVE guard
+// explicit --proof guard
 // ---------------------------------------------------------------------------
 
-describe("MARTIN_LIVE=false — stub adapter", () => {
+describe("--proof — stub adapter", () => {
   it("run command completes without spawning a real subprocess", async () => {
     const result = await withRunsRoot(() =>
-      withEnv("MARTIN_LIVE", "false", () =>
-        executeCli([
-          "--json",
-          "run",
-          "--objective",
-          "Add a greeting function",
-          "--max-iterations",
-          "1",
-          "--budget-usd",
-          "5"
-        ])
-      )
+      executeCli([
+        "--json",
+        "run",
+        "--objective",
+        "Add a greeting function",
+        "--proof",
+        "--max-iterations",
+        "1",
+        "--budget-usd",
+        "5"
+      ])
     );
 
     expect(result.exitCode).toBe(0);
@@ -243,20 +242,19 @@ describe("MARTIN_LIVE=false — stub adapter", () => {
 
   it("returns a valid loop record structure in stub mode", async () => {
     const result = await withRunsRoot(() =>
-      withEnv("MARTIN_LIVE", "false", () =>
-        executeCli([
-          "--json",
-          "run",
-          "--workspace",
-          "ws_stub",
-          "--project",
-          "proj_stub",
-          "--objective",
-          "Write a hello world function",
-          "--max-iterations",
-          "1"
-        ])
-      )
+      executeCli([
+        "--json",
+        "run",
+        "--workspace",
+        "ws_stub",
+        "--project",
+        "proj_stub",
+        "--objective",
+        "Write a hello world function",
+        "--proof",
+        "--max-iterations",
+        "1"
+      ])
     );
 
     const payload = JSON.parse(result.stdout);
@@ -272,21 +270,20 @@ describe("MARTIN_LIVE=false — stub adapter", () => {
 
 describe("--engine flag", () => {
   it("defaults to claude when no --engine flag is given", { timeout: 45_000 }, async () => {
-    // Use stub mode — we verify no engine flag selects the claude adapter path,
+    // Use explicit no-spend proof mode — we verify no engine flag selects the claude adapter path,
     // not that claude itself runs successfully
     const result = await withRunsRoot(() =>
-      withEnv("MARTIN_LIVE", "false", () =>
-        executeCli([
-          "--json",
-          "run",
-          "--objective",
-          "Fix the bug",
-          "--max-iterations",
-          "1",
-          "--budget-usd",
-          "2"
-        ])
-      )
+      executeCli([
+        "--json",
+        "run",
+        "--objective",
+        "Fix the bug",
+        "--proof",
+        "--max-iterations",
+        "1",
+        "--budget-usd",
+        "2"
+      ])
     );
 
     expect(result.exitCode).toBe(0);
@@ -295,25 +292,23 @@ describe("--engine flag", () => {
     expect(payload.loop.loopId).toMatch(/^loop_/u);
   });
 
-  it("passes codex launch preflight when a compatible Codex CLI is present", async () => {
+  it("passes codex launch preflight when a compatible Codex CLI is present", { timeout: 45_000 }, async () => {
     const result = await withTempDir((workspace) =>
       withFakeCodexCli(async () => {
         initializeGitRepo(workspace);
         return withRunsRoot(() =>
-          withEnv("MARTIN_LIVE", "true", () =>
-            executeCli([
-              "--json",
-              "preflight",
-              "--engine",
-              "codex",
-              "--cwd",
-              workspace,
-              "--objective",
-              "Fix the bug",
-              "--verify",
-              NOOP_VERIFIER
-            ])
-          )
+          executeCli([
+            "--json",
+            "preflight",
+            "--engine",
+            "codex",
+            "--cwd",
+            workspace,
+            "--objective",
+            "Fix the bug",
+            "--verify",
+            NOOP_VERIFIER
+          ])
         );
       })
     );
@@ -331,23 +326,21 @@ describe("--engine flag", () => {
     await withTempDir(async (workspace) => {
       const runsDir = join(workspace, ".martin-runs");
       const result = await withoutAgentCliOnPath(() =>
-        withEnv("MARTIN_LIVE", "true", () =>
-          executeCli([
-            "run",
-            "--cwd",
-            workspace,
-            "--runs-dir",
-            runsDir,
-            "--objective",
-            "Fix the bug",
-            "--verify",
-            NOOP_VERIFIER,
-            "--max-iterations",
-            "1",
-            "--budget-usd",
-            "2"
-          ])
-        )
+        executeCli([
+          "run",
+          "--cwd",
+          workspace,
+          "--runs-dir",
+          runsDir,
+          "--objective",
+          "Fix the bug",
+          "--verify",
+          NOOP_VERIFIER,
+          "--max-iterations",
+          "1",
+          "--budget-usd",
+          "2"
+        ])
       );
 
       expect(result.exitCode).toBe(8);
@@ -362,7 +355,7 @@ describe("--engine flag", () => {
     });
   });
 
-  it("auto-bootstraps governed prerequisites and executes a live Codex run when host is ready", { timeout: 45000 }, async () => {
+  it("auto-bootstraps governed prerequisites and executes a live Codex run when host is ready", { timeout: 90_000 }, async () => {
     await withTempDir((workspace) =>
       withFakeCodexCli(() =>
         withScratchEnv(
@@ -373,26 +366,24 @@ describe("--engine flag", () => {
           async () => {
             initializeGitRepo(workspace);
             const runsDir = join(workspace, ".martin-runs");
-            const result = await withEnv("MARTIN_LIVE", "true", () =>
-              executeCli([
-                "--json",
-                "run",
-                "--engine",
-                "codex",
-                "--cwd",
-                workspace,
-                "--runs-dir",
-                runsDir,
-                "--objective",
-                "Fix the bug",
-                "--verify",
-                NOOP_VERIFIER,
-                "--max-iterations",
-                "1",
-                "--budget-usd",
-                "2",
-              ])
-            );
+            const result = await executeCli([
+              "--json",
+              "run",
+              "--engine",
+              "codex",
+              "--cwd",
+              workspace,
+              "--runs-dir",
+              runsDir,
+              "--objective",
+              "Fix the bug",
+              "--verify",
+              NOOP_VERIFIER,
+              "--max-iterations",
+              "1",
+              "--budget-usd",
+              "2",
+            ]);
 
             expect(result.exitCode).toBe(0);
             const payload = JSON.parse(result.stdout);
@@ -657,20 +648,18 @@ describe("--engine flag", () => {
         },
         async () => {
           const result = await withoutAgentCliOnPath(() =>
-            withEnv("MARTIN_LIVE", "true", () =>
-              executeCli([
-                "run",
-                "--objective",
-                "Fix the bug",
-                "--verify",
-                NOOP_VERIFIER,
-                "--max-iterations",
-                "1",
-                "--budget-usd",
-                "2",
-                "--unsafe-allow-unguarded-run"
-              ])
-            )
+            executeCli([
+              "run",
+              "--objective",
+              "Fix the bug",
+              "--verify",
+              NOOP_VERIFIER,
+              "--max-iterations",
+              "1",
+              "--budget-usd",
+              "2",
+              "--unsafe-allow-unguarded-run"
+            ])
           );
 
           expect(result.exitCode).not.toBe(8);
@@ -689,17 +678,16 @@ describe("--cwd flag", () => {
   it("passes working directory to the adapter", async () => {
     await withTempDir(async (dir) => {
       const result = await withRunsRoot(() =>
-        withEnv("MARTIN_LIVE", "false", () =>
-          executeCli([
-            "run",
-            "--objective",
-            "Fix the bug",
-            "--cwd",
-            dir,
-            "--max-iterations",
-            "1"
-          ])
-        )
+        executeCli([
+          "run",
+          "--objective",
+          "Fix the bug",
+          "--cwd",
+          dir,
+          "--proof",
+          "--max-iterations",
+          "1"
+        ])
       );
 
       expect(result.exitCode).toBe(0);

--- a/packages/cli/tests/cli.test.ts
+++ b/packages/cli/tests/cli.test.ts
@@ -171,7 +171,7 @@ describe("executeCli", () => {
     expect(result.stdout).toBe(rootPackageVersion);
   });
 
-  it("renders start onboarding guidance with governed defaults", async () => {
+  it("renders start onboarding guidance with governed defaults", { timeout: 30_000 }, async () => {
     const result = await executeCli(["start"]);
 
     expect(result.exitCode).toBe(0);
@@ -179,6 +179,9 @@ describe("executeCli", () => {
     expect(result.stdout).toContain("Governed runs are the default path");
     expect(result.stdout).toContain("auto-checks doctor, session-start, and preflight");
     expect(result.stdout).toContain("npx -y martin-loop@latest demo");
+    expect(result.stdout).toContain(
+      'npx -y martin-loop@latest run "Summarize the workspace and prove tests still pass" --verify "npm test" --budget-usd 2 --max-iterations 1'
+    );
   });
 
   it("resolves effectivePolicy from config and applies it to the run", async () => {
@@ -508,7 +511,8 @@ describe("executeCli", () => {
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain(targetDirectory);
       expect(result.stdout).toContain("npm install");
-      expect(result.stdout).toContain("Safe first run (no provider spend, governed path)");
+      expect(result.stdout).toContain("Default first run (live spend-governed):");
+      expect(result.stdout).toContain("--budget-usd 2 --max-iterations 1");
       expect(result.stdout).toContain("npx -y martin-loop@latest start");
       expect(result.stdout).toContain("Inspect the governed checks explicitly");
       expect(await readFile(join(targetDirectory, "README.md"), "utf8")).toContain("Demo Sandbox");
@@ -580,7 +584,7 @@ describe("executeCli", () => {
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain(`cd ${targetDirectory}`);
-      expect(result.stdout).toContain("Optional live run");
+      expect(result.stdout).toContain("Optional live implementation run");
       expect(await readFile(join(targetDirectory, "martin.config.yaml"), "utf8")).toContain(
         "strict_local"
       );

--- a/packages/cli/tests/run-store.test.ts
+++ b/packages/cli/tests/run-store.test.ts
@@ -51,10 +51,10 @@ describe("resolveCliEnvironment", () => {
     expect(environment.engine).toBe("openai");
   });
 
-  it("exposes MARTIN_LIVE=false as proof mode for public surfaces", () => {
+  it("defaults to live mode even when MARTIN_LIVE is false", () => {
     const environment = resolveCliEnvironment({ env: { ...process.env, MARTIN_LIVE: "false" } });
 
-    expect(environment.liveMode).toBe("proof");
+    expect(environment.liveMode).toBe("live");
   });
 
   it("honors explicit proof mode without requiring environment mutation", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,11 +8,13 @@ overrides:
   '@hono/node-server': ^1.19.13
   ajv: ^8.20.0
   fast-uri: ^3.1.2
-  hono: ^4.12.21
+  hono: 4.12.25
   ip-address: ^10.1.1
   postcss: ^8.5.15
   qs: ^6.15.2
   vite: ^7.3.2
+  zod: 4.4.0
+  undici: 7.26.0
 
 importers:
 
@@ -95,7 +97,7 @@ importers:
     dependencies:
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
-        version: 1.29.0(zod@4.3.6)
+        version: 1.29.0(zod@4.4.0)
       '@open-policy-agent/opa-wasm':
         specifier: ^1.10.0
         version: 1.10.0
@@ -281,7 +283,7 @@ packages:
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: ^4.12.21
+      hono: 4.12.25
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
@@ -291,7 +293,7 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
-      zod: ^3.25 || ^4.0
+      zod: 4.4.0
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
@@ -826,8 +828,8 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
-  hono@4.12.23:
-    resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
+  hono@4.12.25:
+    resolution: {integrity: sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==}
     engines: {node: '>=16.9.0'}
 
   http-errors@2.0.1:
@@ -1242,10 +1244,10 @@ packages:
   zod-to-json-schema@3.25.2:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
     peerDependencies:
-      zod: ^3.25.28 || ^4
+      zod: 4.4.0
 
-  zod@4.3.6:
-    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+  zod@4.4.0:
+    resolution: {integrity: sha512-932TE3dEKhhYkEZFv6meaxLaCyg1m6LSI0ETKCIyUqIim+KgIsB/kha/4CKwDEbYgMzS5QxAe2mtDPpaHLHdsQ==}
 
 snapshots:
 
@@ -1327,15 +1329,15 @@ snapshots:
   '@esbuild/win32-x64@0.27.4':
     optional: true
 
-  '@hono/node-server@1.19.14(hono@4.12.23)':
+  '@hono/node-server@1.19.14(hono@4.12.25)':
     dependencies:
-      hono: 4.12.23
+      hono: 4.12.25
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
-  '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.0)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.23)
+      '@hono/node-server': 1.19.14(hono@4.12.25)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -1345,13 +1347,13 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.2(express@5.2.1)
-      hono: 4.12.23
+      hono: 4.12.25
       jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
-      zod: 4.3.6
-      zod-to-json-schema: 3.25.2(zod@4.3.6)
+      zod: 4.4.0
+      zod-to-json-schema: 3.25.2(zod@4.4.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -1876,7 +1878,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hono@4.12.23: {}
+  hono@4.12.25: {}
 
   http-errors@2.0.1:
     dependencies:
@@ -2247,8 +2249,8 @@ snapshots:
 
   yaml@1.10.3: {}
 
-  zod-to-json-schema@3.25.2(zod@4.3.6):
+  zod-to-json-schema@3.25.2(zod@4.4.0):
     dependencies:
-      zod: 4.3.6
+      zod: 4.4.0
 
-  zod@4.3.6: {}
+  zod@4.4.0: {}


### PR DESCRIPTION
## Summary
- remove hidden `MARTIN_LIVE=false` fallback from CLI environment resolution and adapter selection
- keep no-spend lanes explicit via `--proof` and `--verify-only`, while defaulting normal `run` to live governed execution
- update onboarding/docs/demo text to make live-governed default clear and proof lane explicit
- update CLI tests to validate explicit proof-mode behavior and live-default expectations

## Validation
- `pnpm --filter @martin/cli test -- --run tests/run-store.test.ts tests/cli.test.ts tests/cli-integration.test.ts`
- governed evidence sequence (live mode):
  - `pnpm exec martin-loop preflight ... --engine codex --json`
  - `pnpm exec martin-loop run ... --engine codex --json`
  - `pnpm exec martin-loop dossier --loop-id loop_l6aab4s4 --json`
  - `pnpm exec martin-loop runs verify --loop-id loop_l6aab4s4 --json`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI examples across guides to show budgeted, governed runs with `--budget-usd` and `--max-iterations` controls
  * Clarified `--proof` flag as explicit opt-in for no-spend proof validation

* **Improvements**
  * Adjusted CLI to prioritize explicit command-line flags over environment variables for run mode selection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->