### PR TITLE
test(benchmarks): isolate workspace-portability residue lane

### DIFF
--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -9,11 +9,9 @@
     "build": "tsc -p tsconfig.build.json",
     "test": "vitest run",
     "lint": "tsc -p tsconfig.json --noEmit",
-    "preeval": "pnpm build",
-    "eval": "node dist/eval.js --suite under-3-challenge",
-    "eval:phase12": "node dist/eval.js --suite under-3-challenge",
-    "prereport:ralphy": "pnpm build",
-    "report:ralphy": "node dist/eval.js --suite ralphy-engineering-50"
+    "eval": "tsx src/eval.ts --suite under-3-challenge",
+    "eval:phase12": "tsx src/eval.ts --suite under-3-challenge",
+    "report:ralphy": "tsx src/eval.ts --suite ralphy-engineering-50"
   },
   "dependencies": {
     "@martin/contracts": "workspace:*",

--- a/benchmarks/src/eval.ts
+++ b/benchmarks/src/eval.ts
@@ -11,8 +11,12 @@ import {
   renderUnder3ChallengeMarkdown
 } from "./challenge.js";
 
-const outputDir = fileURLToPath(new URL("../output/", import.meta.url));
 const entryFilePath = fileURLToPath(import.meta.url);
+
+function resolveOutputDir(): string {
+  const configured = process.env.MARTIN_BENCHMARK_OUTPUT_DIR?.trim();
+  return configured && configured.length > 0 ? resolve(configured) : fileURLToPath(new URL("../output/", import.meta.url));
+}
 
 export function readSuiteId(argv: string[]): string {
   for (let index = 0; index < argv.length; index += 1) {
@@ -40,6 +44,7 @@ export function readSuiteId(argv: string[]): string {
 }
 
 async function writeArtifacts(filePrefix: string, payload: unknown, markdown: string): Promise<void> {
+  const outputDir = resolveOutputDir();
   await mkdir(outputDir, { recursive: true });
   await writeFile(join(outputDir, `${filePrefix}.json`), JSON.stringify(payload, null, 2), "utf8");
   await writeFile(join(outputDir, `${filePrefix}.md`), markdown, "utf8");

--- a/scripts/tests/benchmarks-workspace.test.mjs
+++ b/scripts/tests/benchmarks-workspace.test.mjs
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { readFile, rm, access } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawn } from "node:child_process";
@@ -64,30 +65,30 @@ function quoteForCmd(value) {
   return `"${value.replace(/"/g, '""')}"`;
 }
 
-test("benchmark workspace cold-builds from a fresh dependency state", async () => {
-  const pathsToReset = [
-    path.join(ROOT_DIR, "packages", "contracts", "dist"),
-    path.join(ROOT_DIR, "packages", "core", "dist"),
-    path.join(ROOT_DIR, "benchmarks", "dist"),
-  ];
+test("benchmark commands do not rebuild shared workspace artifacts implicitly", async () => {
+  const manifest = JSON.parse(await readFile(path.join(ROOT_DIR, "benchmarks", "package.json"), "utf8"));
+  const scripts = manifest.scripts ?? {};
 
-  for (const target of pathsToReset) {
-    await rm(target, { recursive: true, force: true });
-  }
-
-  await run("pnpm", ["--filter", "@martin/benchmarks", "build"]);
-
-  await access(path.join(ROOT_DIR, "packages", "contracts", "dist", "index.d.ts"));
-  await access(path.join(ROOT_DIR, "packages", "core", "dist", "index.d.ts"));
-  await access(path.join(ROOT_DIR, "benchmarks", "dist", "index.js"));
+  assert.equal(typeof scripts.build, "string");
+  assert.equal(scripts.preeval, undefined);
+  assert.equal(scripts["prereport:ralphy"], undefined);
+  assert.match(scripts.eval, /^tsx src\/eval\.ts --suite under-3-challenge$/u);
+  assert.match(scripts["report:ralphy"], /^tsx src\/eval\.ts --suite ralphy-engineering-50$/u);
 });
 
 test("benchmark eval and report commands run through public workspace commands", async () => {
-  const evalResult = await run("pnpm", ["--filter", "@martin/benchmarks", "eval"]);
-  const reportResult = await run("pnpm", ["--filter", "@martin/benchmarks", "report:ralphy"]);
+  const outputDir = await mkdtemp(path.join(tmpdir(), "martin-benchmark-output-"));
 
-  assert.match(evalResult.stdout, /Under-\$3 Challenge/u);
-  assert.match(reportResult.stdout, /Ralph Loop Stress Report/u);
+  try {
+    const env = { MARTIN_BENCHMARK_OUTPUT_DIR: outputDir };
+    const evalResult = await run("pnpm", ["--filter", "@martin/benchmarks", "eval"], { env });
+    const reportResult = await run("pnpm", ["--filter", "@martin/benchmarks", "report:ralphy"], { env });
+
+    assert.match(evalResult.stdout, /Under-\$3 Challenge/u);
+    assert.match(reportResult.stdout, /Ralph Loop Stress Report/u);
+  } finally {
+    await rm(outputDir, { recursive: true, force: true });
+  }
 });
 
 test("public benchmark docs align to the shipped benchmark commands", async () => {


### PR DESCRIPTION
## Purpose
Isolate previously uncommitted benchmark portability residue found on local main into a traceable branch.

## Changes
- benchmark scripts switch eval/report commands to 	sx src/eval.ts ...
- benchmark eval output dir can be redirected via MARTIN_BENCHMARK_OUTPUT_DIR
- workspace benchmark test updated to validate no implicit prerebuild scripts and tmp-output handling

## Note
This PR is a forensic isolation lane; merge decision should follow explicit review.