### PR TITLE
chore(public): isolate matrix portability residue lane

### DIFF
--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -9,11 +9,9 @@
     "build": "tsc -p tsconfig.build.json",
     "test": "vitest run",
     "lint": "tsc -p tsconfig.json --noEmit",
-    "preeval": "pnpm build",
-    "eval": "node dist/eval.js --suite under-3-challenge",
-    "eval:phase12": "node dist/eval.js --suite under-3-challenge",
-    "prereport:ralphy": "pnpm build",
-    "report:ralphy": "node dist/eval.js --suite ralphy-engineering-50"
+    "eval": "tsx src/eval.ts --suite under-3-challenge",
+    "eval:phase12": "tsx src/eval.ts --suite under-3-challenge",
+    "report:ralphy": "tsx src/eval.ts --suite ralphy-engineering-50"
   },
   "dependencies": {
     "@martin/contracts": "workspace:*",

--- a/benchmarks/src/eval.ts
+++ b/benchmarks/src/eval.ts
@@ -11,8 +11,12 @@ import {
   renderUnder3ChallengeMarkdown
 } from "./challenge.js";
 
-const outputDir = fileURLToPath(new URL("../output/", import.meta.url));
 const entryFilePath = fileURLToPath(import.meta.url);
+
+function resolveOutputDir(): string {
+  const configured = process.env.MARTIN_BENCHMARK_OUTPUT_DIR?.trim();
+  return configured && configured.length > 0 ? resolve(configured) : fileURLToPath(new URL("../output/", import.meta.url));
+}
 
 export function readSuiteId(argv: string[]): string {
   for (let index = 0; index < argv.length; index += 1) {
@@ -40,6 +44,7 @@ export function readSuiteId(argv: string[]): string {
 }
 
 async function writeArtifacts(filePrefix: string, payload: unknown, markdown: string): Promise<void> {
+  const outputDir = resolveOutputDir();
   await mkdir(outputDir, { recursive: true });
   await writeFile(join(outputDir, `${filePrefix}.json`), JSON.stringify(payload, null, 2), "utf8");
   await writeFile(join(outputDir, `${filePrefix}.md`), markdown, "utf8");

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -10,7 +10,6 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "prebuild": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\"",
     "build": "pnpm --filter @martin/contracts build && pnpm --filter @martin/core build && pnpm --filter @martin/adapters build && tsc -p tsconfig.build.json",
     "test": "vitest run",
     "lint": "tsc -p tsconfig.json --noEmit",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1580,7 +1580,8 @@ async function executePreflightCommand(
   const environment = resolveCliEnvironment({
     cwd: request.cwd,
     runsDir: request.runsDir,
-    engine: request.engine
+    engine: request.engine,
+    liveMode: request.liveMode
   });
   const warnings: string[] = [];
   const blockingIssues: string[] = [];

--- a/packages/cli/src/run-store.ts
+++ b/packages/cli/src/run-store.ts
@@ -203,6 +203,19 @@ export function resolveInvocationRoot(env: NodeJS.ProcessEnv = process.env): str
   return initCwd && initCwd.length > 0 ? initCwd : process.cwd();
 }
 
+function readEnvironmentValue(env: NodeJS.ProcessEnv, key: string): string | undefined {
+  const direct = env[key];
+  if (typeof direct === "string") return direct;
+
+  const matchedKey = Object.keys(env).find((candidate) => candidate.toLowerCase() === key.toLowerCase());
+  const value = matchedKey ? env[matchedKey] : undefined;
+  return typeof value === "string" ? value : undefined;
+}
+
+function resolveLiveModeFromEnvironment(env: NodeJS.ProcessEnv): CliEnvironment["liveMode"] {
+  return readEnvironmentValue(env, "MARTIN_LIVE")?.trim().toLowerCase() === "false" ? "proof" : "live";
+}
+
 export function resolveCliEnvironment(input: {
   cwd?: string;
   runsDir?: string;
@@ -228,7 +241,7 @@ export function resolveCliEnvironment(input: {
     workingDirectory,
     runsRoot,
     engine,
-    liveMode: input.liveMode ?? "live"
+    liveMode: input.liveMode ?? resolveLiveModeFromEnvironment(env)
   };
 }
 

--- a/packages/cli/tests/run-store.test.ts
+++ b/packages/cli/tests/run-store.test.ts
@@ -51,8 +51,17 @@ describe("resolveCliEnvironment", () => {
     expect(environment.engine).toBe("openai");
   });
 
-  it("defaults to live mode even when MARTIN_LIVE is false", () => {
+  it("uses proof mode when MARTIN_LIVE is false", () => {
     const environment = resolveCliEnvironment({ env: { ...process.env, MARTIN_LIVE: "false" } });
+
+    expect(environment.liveMode).toBe("proof");
+  });
+
+  it("lets explicit live mode override MARTIN_LIVE proof mode", () => {
+    const environment = resolveCliEnvironment({
+      env: { ...process.env, MARTIN_LIVE: "false" },
+      liveMode: "live",
+    });
 
     expect(environment.liveMode).toBe("live");
   });

--- a/packages/mcp/scripts/build-package-lib.mjs
+++ b/packages/mcp/scripts/build-package-lib.mjs
@@ -91,12 +91,6 @@ export async function buildStandaloneMcpPackage(options = {}) {
 
 async function ensureWorkspaceArtifacts(rootDir) {
   for (const facade of PACKAGE_FACADES.filter((candidate) => ROOT_FACADE_PACKAGES.includes(candidate.packageName))) {
-    await rm(path.join(rootDir, ...facade.sourceDir), {
-      force: true,
-      recursive: true,
-      maxRetries: 10,
-      retryDelay: 100,
-    });
     await runCommand(
       pnpmCommand(),
       workspaceBuildCommandArgs(facade.packageName),

--- a/scripts/oss-boundary.mjs
+++ b/scripts/oss-boundary.mjs
@@ -44,6 +44,7 @@ const IGNORED_TOP_LEVEL_ENTRIES = [
   ".artifacts",
   ".cache",
   ".git",
+  ".worktrees",
   ".npm-cache",
   ".planning",
   "dist",

--- a/scripts/release-truth-check.mjs
+++ b/scripts/release-truth-check.mjs
@@ -9,9 +9,7 @@ import { fileURLToPath } from "node:url";
 const repoRoot = resolve(fileURLToPath(new URL("..", import.meta.url)));
 const markerFlag = process.argv.find((arg) => arg.startsWith("--allow-divergence-marker="));
 const allowedMarker = markerFlag ? markerFlag.slice("--allow-divergence-marker=".length) : undefined;
-const mirrorRoot = process.env.MARTIN_MAIN_REPO_PATH
-  ? resolve(process.env.MARTIN_MAIN_REPO_PATH, "oss-core")
-  : null;
+const mirrorRoot = resolveMirrorRoot();
 
 const CRITICAL_FILES = [
   "packages/mcp/src/tools/tool-support.ts",
@@ -25,7 +23,7 @@ const divergences = [];
 for (const relativePath of CRITICAL_FILES) {
   const local = safeReadLocal(relativePath);
   if (!local.ok) {
-    fail(`Missing critical file in internal OSS source: ${relativePath}`);
+    fail(`Missing critical file in local source: ${relativePath}`);
   }
 
   const publicFile = safeReadGitRef("public/main", relativePath);
@@ -161,6 +159,18 @@ function safeReadGitRef(ref, relativePath) {
 
 function sha(text) {
   return createHash("sha256").update(text).digest("hex");
+}
+
+function resolveMirrorRoot() {
+  if (process.env.MARTIN_OSS_MIRROR_PATH) {
+    return resolve(process.env.MARTIN_OSS_MIRROR_PATH);
+  }
+
+  if (process.env.MARTIN_MAIN_REPO_PATH) {
+    return resolve(process.env.MARTIN_MAIN_REPO_PATH, "oss-core");
+  }
+
+  return null;
 }
 
 function fail(message) {

--- a/scripts/tests/benchmarks-workspace.test.mjs
+++ b/scripts/tests/benchmarks-workspace.test.mjs
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { readFile, rm, access } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawn } from "node:child_process";
@@ -64,30 +65,30 @@ function quoteForCmd(value) {
   return `"${value.replace(/"/g, '""')}"`;
 }
 
-test("benchmark workspace cold-builds from a fresh dependency state", async () => {
-  const pathsToReset = [
-    path.join(ROOT_DIR, "packages", "contracts", "dist"),
-    path.join(ROOT_DIR, "packages", "core", "dist"),
-    path.join(ROOT_DIR, "benchmarks", "dist"),
-  ];
+test("benchmark commands do not rebuild shared workspace artifacts implicitly", async () => {
+  const manifest = JSON.parse(await readFile(path.join(ROOT_DIR, "benchmarks", "package.json"), "utf8"));
+  const scripts = manifest.scripts ?? {};
 
-  for (const target of pathsToReset) {
-    await rm(target, { recursive: true, force: true });
-  }
-
-  await run("pnpm", ["--filter", "@martin/benchmarks", "build"]);
-
-  await access(path.join(ROOT_DIR, "packages", "contracts", "dist", "index.d.ts"));
-  await access(path.join(ROOT_DIR, "packages", "core", "dist", "index.d.ts"));
-  await access(path.join(ROOT_DIR, "benchmarks", "dist", "index.js"));
+  assert.equal(typeof scripts.build, "string");
+  assert.equal(scripts.preeval, undefined);
+  assert.equal(scripts["prereport:ralphy"], undefined);
+  assert.match(scripts.eval, /^tsx src\/eval\.ts --suite under-3-challenge$/u);
+  assert.match(scripts["report:ralphy"], /^tsx src\/eval\.ts --suite ralphy-engineering-50$/u);
 });
 
 test("benchmark eval and report commands run through public workspace commands", async () => {
-  const evalResult = await run("pnpm", ["--filter", "@martin/benchmarks", "eval"]);
-  const reportResult = await run("pnpm", ["--filter", "@martin/benchmarks", "report:ralphy"]);
+  const outputDir = await mkdtemp(path.join(tmpdir(), "martin-benchmark-output-"));
 
-  assert.match(evalResult.stdout, /Under-\$3 Challenge/u);
-  assert.match(reportResult.stdout, /Ralph Loop Stress Report/u);
+  try {
+    const env = { MARTIN_BENCHMARK_OUTPUT_DIR: outputDir };
+    const evalResult = await run("pnpm", ["--filter", "@martin/benchmarks", "eval"], { env });
+    const reportResult = await run("pnpm", ["--filter", "@martin/benchmarks", "report:ralphy"], { env });
+
+    assert.match(evalResult.stdout, /Under-\$3 Challenge/u);
+    assert.match(reportResult.stdout, /Ralph Loop Stress Report/u);
+  } finally {
+    await rm(outputDir, { recursive: true, force: true });
+  }
 });
 
 test("public benchmark docs align to the shipped benchmark commands", async () => {


### PR DESCRIPTION
## Purpose
Forensic isolation of previously uncommitted matrix/portability residue discovered during cleanup.

## Scope
- benchmark command/output portability adjustments
- package build-step cleanup for matrix lane
- OSS boundary ignore update for .worktrees

## Note
This is an isolation PR for review and disposition; not auto-merged.