### PR TITLE
fix(benchmarks): append-only evidence artifacts

### DIFF
--- a/benchmarks/src/eval.ts
+++ b/benchmarks/src/eval.ts
@@ -1,4 +1,4 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { access, mkdir, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -46,8 +46,41 @@ export function readSuiteId(argv: string[]): string {
 async function writeArtifacts(filePrefix: string, payload: unknown, markdown: string): Promise<void> {
   const outputDir = resolveOutputDir();
   await mkdir(outputDir, { recursive: true });
-  await writeFile(join(outputDir, `${filePrefix}.json`), JSON.stringify(payload, null, 2), "utf8");
-  await writeFile(join(outputDir, `${filePrefix}.md`), markdown, "utf8");
+  const { jsonPath, markdownPath } = await reserveArtifactPaths(outputDir, filePrefix);
+  await writeFile(jsonPath, JSON.stringify(payload, null, 2), "utf8");
+  await writeFile(markdownPath, markdown, "utf8");
+}
+
+async function reserveArtifactPaths(
+  outputDir: string,
+  filePrefix: string
+): Promise<{ jsonPath: string; markdownPath: string }> {
+  const baseJsonPath = join(outputDir, `${filePrefix}.json`);
+  const baseMarkdownPath = join(outputDir, `${filePrefix}.md`);
+
+  if (!(await pathExists(baseJsonPath)) && !(await pathExists(baseMarkdownPath))) {
+    return { jsonPath: baseJsonPath, markdownPath: baseMarkdownPath };
+  }
+
+  for (let revision = 1; revision <= 9999; revision += 1) {
+    const suffix = `.rev-${revision.toString().padStart(4, "0")}`;
+    const jsonPath = join(outputDir, `${filePrefix}${suffix}.json`);
+    const markdownPath = join(outputDir, `${filePrefix}${suffix}.md`);
+    if (!(await pathExists(jsonPath)) && !(await pathExists(markdownPath))) {
+      return { jsonPath, markdownPath };
+    }
+  }
+
+  throw new Error(`Unable to reserve artifact path for ${filePrefix}.`);
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 async function main(): Promise<void> {

--- a/benchmarks/src/ralphy-stress-report.ts
+++ b/benchmarks/src/ralphy-stress-report.ts
@@ -1,4 +1,4 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { access, mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -12,24 +12,47 @@ const outputDir = fileURLToPath(new URL("../../output/", import.meta.url));
 async function main(): Promise<void> {
   const report = await generateRalphyEngineeringStressReport();
   const markdown = renderRalphyEngineeringStressMarkdown(report);
+  const { jsonPath, markdownPath } = await reserveArtifactPaths();
 
   await mkdir(outputDir, { recursive: true });
-  await writeFile(
-    join(outputDir, "ralphy-engineering-50-report.json"),
-    JSON.stringify(report, null, 2),
-    "utf8"
-  );
-  await writeFile(
-    join(outputDir, "ralphy-engineering-50-report.md"),
-    markdown,
-    "utf8"
-  );
+  await writeFile(jsonPath, JSON.stringify(report, null, 2), "utf8");
+  await writeFile(markdownPath, markdown, "utf8");
 
   process.stdout.write(markdown + "\n");
   process.stdout.write(
-    `\nArtifacts written to ${join(outputDir, "ralphy-engineering-50-report.json")} and ${join(outputDir, "ralphy-engineering-50-report.md")}\n`
+    `\nArtifacts written to ${jsonPath} and ${markdownPath}\n`
   );
   process.exitCode = report.suite.summary.failedCases > 0 ? 1 : 0;
+}
+
+async function reserveArtifactPaths(): Promise<{ jsonPath: string; markdownPath: string }> {
+  const filePrefix = "ralphy-engineering-50-report";
+  const baseJsonPath = join(outputDir, `${filePrefix}.json`);
+  const baseMarkdownPath = join(outputDir, `${filePrefix}.md`);
+
+  if (!(await pathExists(baseJsonPath)) && !(await pathExists(baseMarkdownPath))) {
+    return { jsonPath: baseJsonPath, markdownPath: baseMarkdownPath };
+  }
+
+  for (let revision = 1; revision <= 9999; revision += 1) {
+    const suffix = `.rev-${revision.toString().padStart(4, "0")}`;
+    const jsonPath = join(outputDir, `${filePrefix}${suffix}.json`);
+    const markdownPath = join(outputDir, `${filePrefix}${suffix}.md`);
+    if (!(await pathExists(jsonPath)) && !(await pathExists(markdownPath))) {
+      return { jsonPath, markdownPath };
+    }
+  }
+
+  throw new Error(`Unable to reserve artifact path for ${filePrefix}.`);
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 main().catch((error: unknown) => {

--- a/scripts/tests/benchmarks-workspace.test.mjs
+++ b/scripts/tests/benchmarks-workspace.test.mjs
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile, readdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -86,6 +86,31 @@ test("benchmark eval and report commands run through public workspace commands",
 
     assert.match(evalResult.stdout, /Under-\$3 Challenge/u);
     assert.match(reportResult.stdout, /Ralph Loop Stress Report/u);
+  } finally {
+    await rm(outputDir, { recursive: true, force: true });
+  }
+});
+
+test("benchmark artifacts are append-only when rerunning the same suite", async () => {
+  const outputDir = await mkdtemp(path.join(tmpdir(), "martin-benchmark-output-"));
+
+  try {
+    const env = { MARTIN_BENCHMARK_OUTPUT_DIR: outputDir };
+    await run("pnpm", ["--filter", "@martin/benchmarks", "eval"], { env });
+    await run("pnpm", ["--filter", "@martin/benchmarks", "eval"], { env });
+
+    const files = await readdir(outputDir);
+    const jsonFiles = files.filter((entry) => entry.endsWith(".json")).sort();
+    const markdownFiles = files.filter((entry) => entry.endsWith(".md")).sort();
+
+    assert.deepEqual(jsonFiles, [
+      "under-3-challenge-report.json",
+      "under-3-challenge-report.rev-0001.json",
+    ]);
+    assert.deepEqual(markdownFiles, [
+      "under-3-challenge-report.md",
+      "under-3-challenge-report.rev-0001.md",
+    ]);
   } finally {
     await rm(outputDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- make benchmark artifact writes revision-safe to avoid silent overwrite
- keep suite reruns append-only with .rev-#### suffixes
- add regression coverage for rerun behavior in benchmark workspace tests

## Verification
- pnpm --filter @martin/benchmarks test -- --run
- pnpm exec node --test scripts/tests/benchmarks-workspace.test.mjs
- pnpm public:copy-scan
- node ./scripts/public-portability-guard.mjs
- pnpm release:truth-check
- pnpm public:git-surface