### PR TITLE
chore(public): normalize workflow validation copy surfaces

### DIFF
--- a/.github/workflows/platform-release-validation.yml
+++ b/.github/workflows/platform-release-validation.yml
@@ -1,4 +1,4 @@
-name: phase13-release-matrix
+name: platform-release-validation
 
 on:
   workflow_dispatch:
@@ -14,7 +14,7 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  release-matrix:
+  platform-release-validation:
     strategy:
       fail-fast: false
       matrix:
@@ -38,16 +38,16 @@ jobs:
           node-version: 22
           cache: pnpm
 
-      - name: Run OSS release matrix lane
+      - name: Run multi-platform release validation
         env:
           MARTIN_RELEASE_MATRIX_OUTDIR: .artifacts/release-matrix/${{ matrix.os }}
         run: |
           node ./scripts/release-truth-check.mjs --allow-divergence-marker=[sync-parity]
           node ./scripts/release-matrix.mjs
 
-      - name: Upload release matrix artifacts
+      - name: Upload platform validation artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: phase13-release-matrix-${{ matrix.os }}
+          name: platform-release-validation-${{ matrix.os }}
           path: .artifacts/release-matrix/${{ matrix.os }}

--- a/scripts/public-copy-scan.mjs
+++ b/scripts/public-copy-scan.mjs
@@ -119,6 +119,10 @@ function normalizePublicCopyContents(contents, relativePath) {
     return normalizePackageMetadata(contents);
   }
 
+  if (relativePath.startsWith(".github/workflows/") && /\.(ya?ml)$/iu.test(relativePath)) {
+    return normalizeWorkflowMetadata(contents);
+  }
+
   if (/\.(md|markdown|ya?ml)$/iu.test(relativePath)) {
     return contents
       .replace(/```[\s\S]*?```/gu, "\n")
@@ -150,6 +154,13 @@ function normalizePackageMetadata(contents) {
   } catch {
     return contents;
   }
+}
+
+function normalizeWorkflowMetadata(contents) {
+  return contents
+    .replace(/(^|\n)(\s*)run:\s*\|[\s\S]*?(?=\n[^\s]|\n\s*-\s+name:|\n\s*[A-Za-z0-9_-]+:|$)/gu, "\n")
+    .replace(/(^|\n)(\s*)run:\s*[^\r\n]+/gu, "\n")
+    .replace(/`[^`\r\n]+`/gu, " ");
 }
 
 function isAllowedPublicCopyPattern(pattern, relativePath) {

--- a/scripts/tests/public-copy-scan.test.mjs
+++ b/scripts/tests/public-copy-scan.test.mjs
@@ -64,6 +64,30 @@ test("findPublicCopyViolations ignores fenced command blocks and package scripts
   assert.equal(manifestViolations.length, 0);
 });
 
+test("findPublicCopyViolations ignores workflow run commands but still scans public workflow labels", () => {
+  const workflowViolations = findPublicCopyViolations(
+    [
+      "name: platform-release-validation",
+      "jobs:",
+      "  validate:",
+      "    steps:",
+      "      - name: Run release validation",
+      "        run: |",
+      "          pnpm release:truth-check",
+      "          pnpm release:matrix:local",
+    ].join("\n"),
+    ".github/workflows/platform-release-validation.yml",
+  );
+  const labelViolations = findPublicCopyViolations(
+    "name: private beta release validation\n",
+    ".github/workflows/platform-release-validation.yml",
+  );
+
+  assert.equal(workflowViolations.length, 0);
+  assert.equal(labelViolations.length, 1);
+  assert.match(String(labelViolations[0]?.pattern), /private beta/i);
+});
+
 test("findPublicCopyViolations allows release packet wording inside release docs", () => {
   const violations = findPublicCopyViolations(
     "# Martin MCP 0.2.7 Release Packet\n",


### PR DESCRIPTION
## Summary
- rename the workflow surface to public-safe technical wording
- normalize workflow run blocks in the public copy scan
- add regression coverage for workflow label scanning

## Verification
- pnpm test
- pnpm public:copy-scan
- pnpm public:portability-guard
- pnpm release:truth-check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Reorganized and renamed release validation workflow for improved clarity and identification.
  * Enhanced workflow file scanning with improved content normalization and validation logic.

* **Tests**
  * Added test coverage for workflow validation scanning to ensure accuracy of content checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->