### PR TITLE
fix(adapters): bypass Windows npm-shim wrapper hop to unblock nested writes

### DIFF
--- a/.planning/phases/d-nested-write-blocked/D-LEDGER.md
+++ b/.planning/phases/d-nested-write-blocked/D-LEDGER.md
@@ -1,0 +1,83 @@
+# D-LEDGER (Execution Log)
+
+## D.0 Baseline
+
+- Confirmed branch: `claude/martinloop-hero-image-a01s2b`, clean except for unrelated in-flight
+  Routing Cost Control changes (left untouched, not regressed).
+- Read `codex-launcher.ts`, `cli-bridge.ts`, `claude-cli.ts`, `run-loop.ts`,
+  `server-validation.ts` to locate every code path involved in launching Codex/Claude on Windows.
+- Confirmed `classifyProbeFailure()` already fingerprints the exact failure class being reported
+  (`CreateProcessAsUserW failed: 5`, "windows sandbox: runner error", read-only/approval-disabled
+  sandbox) but only used it to abort with a remediation string, never to retry with a shallower
+  invocation.
+- Confirmed both `createCodexCliAdapter` and `createClaudeCliAdapter` funnel their live execution
+  through the same shared `runSubprocess`/`createSpawnPlan` chokepoint in `cli-bridge.ts` — so a
+  fix there benefits both engines without duplicating Codex-specific shim logic into
+  `claude-cli.ts`.
+- Limitation: no Windows host or VS Code process tree available in this remote Linux execution
+  environment, so the live PowerShell-vs-VS-Code repro matrix could not be run literally. Treated
+  as a documented gap, not silently skipped (see D-VERIFICATION.md).
+
+## D.1 Shallow Windows shim invocation (cli-bridge.ts)
+
+- Added `resolveNpmShimScript(shimPath)`: reads an npm-generated `.cmd`/`.bat`/`.ps1` shim file,
+  extracts the `node <script>.js` target it wraps (matches `%~dp0%`/`%dp0%`/`$basedir`-relative
+  paths), resolves it relative to the shim's own directory, and returns it only if the resolved
+  script actually exists on disk.
+- `createSpawnPlan` now calls this first for any resolved `.cmd`/`.bat`/`.ps1` command; on success
+  it returns `{ command: process.execPath, args: [scriptPath, ...args] }` — bypassing the
+  `cmd.exe /d /c` / `powershell.exe -File` wrapper hop entirely. Falls back to the prior wrapper
+  behavior unchanged when resolution fails, preserving the existing fallback paths exactly.
+- Added `packages/adapters/tests/cli-bridge.test.ts` covering: `.cmd` shim resolution, `.ps1` shim
+  resolution, missing-target-script fallback, missing-shim-file fallback, and
+  no-recognizable-script-reference fallback.
+
+## D.2 Probe/run invocation-depth parity (codex-launcher.ts)
+
+- `buildProbeCommand` (used by `probeCodexLaunch`) now reuses `resolveNpmShimScript` the same way,
+  so the live launch probe exercises the same process-nesting depth as the real run instead of
+  potentially diverging from it.
+- Updated the Windows-subprocess-launch-failure remediation text in `classifyProbeFailure` to
+  state that direct invocation was already attempted, since that's now true by construction
+  (resolution happens unconditionally on the first attempt, not as a separate retry pass).
+- Added a `probeCodexLaunch` test that builds a synthetic Windows `.cmd` shim on disk and asserts
+  `spawnSyncImpl` is invoked with `process.execPath` + the resolved script path, not `cmd.exe`.
+
+## D.3 Claude adapter
+
+- No separate shim-detection module needed: confirmed `claude-cli.ts`'s live execution already
+  routes through the same `runSubprocess`/`createSpawnPlan` chokepoint fixed in D.1, so Claude
+  gets the same shallow-invocation behavior on Windows automatically.
+
+## D.4 Silent sandbox-blocked-write classification (core)
+
+- Added `sandbox_write_blocked` to `FAILURE_CLASSES` (`packages/contracts/src/index.ts`).
+- `classifyPatchDecisionFailure` (`packages/core/src/index.ts`) now takes the adapter's
+  `MartinAdapterResult` and, for the default/no-other-violation branch, checks the adapter's
+  `summary`/`failure.message` text against the same Windows sandbox-write-blocked signatures
+  (`CreateProcessAsUserW failed`, "windows sandbox: runner error", read-only/approval-disabled
+  sandbox) — if matched, classifies as `sandbox_write_blocked` (retryable, recommends
+  `switch_adapter`) instead of generic `no_progress`.
+- Added an integration test in `packages/core/tests/runtime.test.ts`: a stub adapter reports
+  `verification.passed: true`, `execution.changedFiles: []`, and a summary containing the
+  Windows sandbox-launch-failure signature; asserts the resulting patch decision is `DISCARD`
+  with reason `no_code_change` and the attempt's `failureClass` is `sandbox_write_blocked`.
+
+## Verification
+
+- `pnpm --filter @martin/adapters test` passed (5 files, 82 tests).
+- `pnpm --filter @martin/core test` passed (17 files, 198 tests).
+- `pnpm --filter @martin/adapters lint` passed; `pnpm --filter @martin/contracts lint` passed.
+- `pnpm -r build` passed across `contracts`, `core`, `mcp`, `adapters`, `benchmarks`, `cli`.
+- Confirmed (via `git stash` + rerun) that the one failing lint target,
+  `@martin/core lint` on `tests/trace-store.test.ts`, fails identically on the pre-existing base
+  commit — not a regression introduced by this slice.
+
+## Remaining D-slice status
+
+- D.0 hypothesis confirmation: closed via static analysis; live Windows/VS Code field repro still
+  recommended as a follow-up to close the loop with direct evidence.
+- D.1 shallow Windows shim invocation: closed in code + tests.
+- D.2 probe/run invocation-depth parity: closed in code + tests.
+- D.3 Claude adapter parity: closed — no separate code needed, inherited from D.1.
+- D.4 sandbox-write-blocked failure classification: closed in code + tests.

--- a/.planning/phases/d-nested-write-blocked/D-PLAN.md
+++ b/.planning/phases/d-nested-write-blocked/D-PLAN.md
@@ -1,0 +1,71 @@
+# D.0-D.4 Nested Write Path Blocked in VS Code (Windows)
+
+Date: 2026-06-26
+Repo: `martin-loop`
+Branch: `claude/martinloop-hero-image-a01s2b`
+Trigger: field report (relayed via Gobi S) — "Martin's nested write path is still blocked, so
+it cannot actually persist the edit from inside that governed run. Both Codex and Claude can
+reason about the fix, but Martin's nested agent session is what's blocked from writing." User
+clarified the failure is environment-specific: reproduces when MartinLoop runs nested inside
+**VS Code** (Claude and Codex CLIs), not from a plain top-level **PowerShell** window, on
+Windows.
+
+## Hard constraints
+
+- Do not regress the working PowerShell case.
+- Do not regress non-Windows invocation paths (`linux`/`wsl`/`macos`).
+- Do not touch any in-flight Routing Cost Control work in this branch.
+
+## Root cause
+
+On Windows, an npm-installed CLI (`codex`, `claude`) resolves to a generated `.cmd`/`.ps1` shim.
+Both adapters' live execution funnels through the shared `createSpawnPlan()` in
+`packages/adapters/src/cli-bridge.ts`, which previously always wrapped that shim through an
+extra `cmd.exe /d /c` or `powershell.exe -File` hop before reaching the real Node process. Each
+extra process hop is a place where the OS-level "workspace-write" sandbox permission can fail to
+propagate to the grandchild process that performs the actual file write — a failure class the
+codebase already fingerprints (`classifyProbeFailure` in `codex-launcher.ts`, signatures for
+`CreateProcessAsUserW failed: 5`, "windows sandbox: runner error", read-only/approval-disabled
+sandbox) but, until this fix, only used to abort a run with a remediation message rather than
+work around it.
+
+A bare top-level PowerShell window is a single, full-privilege process. Running the same shim
+from inside VS Code adds at least one more process layer (VS Code → extension host / integrated
+terminal → shim wrapper → real binary) on top of an already different security/job-object
+context — consistent with the user's "works in PowerShell, not in VS Code" report and with the
+sandbox-launch failure signatures already encoded in `classifyProbeFailure`.
+
+## Slice plan
+
+- D.0 Confirm the hypothesis via static analysis of the live execution path (`createSpawnPlan`,
+  `buildProbeCommand`, `probeCodexLaunch`, `run-loop.ts`) — live Windows/VS Code repro is not
+  possible from this remote Linux execution environment, so this is a documented limitation, not
+  a skipped step.
+- D.1 `createSpawnPlan` (`cli-bridge.ts`): when a Windows shim (`.cmd`/`.bat`/`.ps1`) would
+  otherwise be wrapped through `cmd.exe`/`powershell.exe`, first try to statically resolve the
+  shim's wrapped `node <script>.js` target (`resolveNpmShimScript`) and invoke that directly
+  (`process.execPath` + script path). This removes one full process hop on every Windows launch
+  for both adapters at once, since both funnel through this single chokepoint. Falls back to the
+  existing wrapper behavior unchanged whenever shim parsing fails — no regression for shim
+  formats this can't resolve.
+- D.2 `codex-launcher.ts`'s `buildProbeCommand` (used by `probeCodexLaunch`) reuses the same
+  `resolveNpmShimScript` helper so the *probe* exercises the same invocation depth as the real
+  run. This keeps the probe and the real attempt's process-nesting shape consistent (previously
+  the probe and run could diverge silently).
+- D.3 Claude's adapter needed no separate shim-detection module: it already funnels through the
+  same `createSpawnPlan`/`runSubprocess` chokepoint as Codex's adapter, so D.1 benefits both
+  engines without duplicating Codex-specific logic into `claude-cli.ts`.
+- D.4 `packages/core/src/index.ts`: add a new `sandbox_write_blocked` failure class
+  (`packages/contracts/src/index.ts`) and classify an attempt as such when the adapter reports a
+  completed patch with verification passed but zero changed files (`no_code_change`) *and* the
+  adapter's own summary/failure text carries one of the known Windows sandbox-write-blocked
+  signatures — instead of letting it silently fall through to the generic `no_progress` class.
+
+## Verification minimums
+
+- Targeted unit tests added for: `resolveNpmShimScript` shim-to-script resolution (`.cmd`/`.ps1`,
+  unresolvable/missing-file fallback), `probeCodexLaunch` invoking the resolved script directly
+  on a synthetic Windows shim, and the new `sandbox_write_blocked` classification path in core.
+- Existing `@martin/adapters` and `@martin/core` suites pass with no regressions.
+- Explicit non-regression check: non-`win32` platforms and unresolvable shims keep the exact
+  prior behavior (`createSpawnPlan`/`buildProbeCommand` unchanged on those paths).

--- a/.planning/phases/d-nested-write-blocked/D-VERIFICATION.md
+++ b/.planning/phases/d-nested-write-blocked/D-VERIFICATION.md
@@ -1,0 +1,55 @@
+# D.0-D.4 Verification Snapshot
+
+Date: 2026-06-26
+Repo: `martin-loop`
+Branch: `claude/martinloop-hero-image-a01s2b`
+Base commit before this slice: `5117669` (chore(release): 0.3.12)
+
+## Files touched in this slice
+
+- `packages/adapters/src/cli-bridge.ts` — `createSpawnPlan` now tries direct shim-script
+  invocation before falling back to `cmd.exe`/`powershell.exe`; new exported
+  `resolveNpmShimScript` helper.
+- `packages/adapters/src/codex-launcher.ts` — `buildProbeCommand` reuses
+  `resolveNpmShimScript` so the launch probe matches the real run's invocation depth; updated
+  remediation text for the Windows sandbox-launch-failure signature to reflect that direct
+  invocation is already attempted.
+- `packages/contracts/src/index.ts` — added `sandbox_write_blocked` to `FAILURE_CLASSES`.
+- `packages/core/src/index.ts` — `classifyPatchDecisionFailure` now detects known sandbox-write
+  -blocked signatures in the adapter's reported summary/failure text and classifies a
+  no-code-change attempt as `sandbox_write_blocked` instead of generic `no_progress`.
+- New tests: `packages/adapters/tests/cli-bridge.test.ts`,
+  additions to `packages/adapters/tests/codex-launcher.test.ts` and
+  `packages/core/tests/runtime.test.ts`.
+
+## Targeted test gates
+
+- `pnpm --filter @martin/adapters test` -> PASS (5 files, 82 tests)
+- `pnpm --filter @martin/core test` -> PASS (17 files, 198 tests)
+- `pnpm --filter @martin/adapters lint` -> PASS
+- `pnpm --filter @martin/contracts lint` -> PASS
+
+## Repo-level build gates
+
+- `pnpm -r build` -> PASS (contracts, core, mcp, adapters, benchmarks, cli)
+
+## Known pre-existing, unrelated issue (not introduced by this slice)
+
+- `pnpm --filter @martin/core lint` fails on `tests/trace-store.test.ts` (TS2345/TS2532, strict
+  `undefined` narrowing). Confirmed via `git stash` + rerun that this failure exists identically
+  on the base commit before any D-slice changes — out of scope for this fix, not touched.
+
+## Live-repro limitation (explicit, not silently skipped)
+
+- This session runs in a remote Linux execution environment with no Windows host and no VS Code
+  process tree available, so the PowerShell-vs-VS-Code repro matrix called for in D.0 could not
+  be executed literally. The fix instead targets the exact mechanism already evidenced in code
+  (`classifyProbeFailure`'s Windows sandbox/process-launch signatures) and was validated via:
+  - unit tests that construct a synthetic npm Windows `.cmd`/`.ps1` shim on disk and confirm
+    `resolveNpmShimScript`/`buildProbeCommand`/`createSpawnPlan` resolve and invoke the wrapped
+    script directly instead of through `cmd.exe`/`powershell.exe`;
+  - confirming `process.platform !== "win32"` and unresolvable-shim paths are untouched (existing
+    `codex-launcher.test.ts` cases for Linux/WSL/native Windows binaries still pass unchanged).
+- Recommend the next Windows/VS Code repro (PowerShell vs. VS Code integrated terminal vs. VS
+  Code agent panel, both `claude` and `codex` engines) be captured on an actual Windows host to
+  close out D.0 with field evidence.

--- a/packages/adapters/src/cli-bridge.ts
+++ b/packages/adapters/src/cli-bridge.ts
@@ -1,6 +1,6 @@
 import { spawn, type ChildProcess, type SpawnOptions } from "node:child_process";
 import { delimiter, dirname, extname, isAbsolute, join, resolve } from "node:path";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 
 import { diffStatsFromNumstat } from "./runtime-support.js";
 
@@ -491,21 +491,66 @@ export function createSpawnPlan(
   }
 
   const extension = extname(resolvedOrUndefined).toLowerCase();
-  if (extension === ".cmd" || extension === ".bat") {
+  if (extension === ".cmd" || extension === ".bat" || extension === ".ps1") {
+    // npm-installed CLIs resolve to a generated shim on Windows. Wrapping that shim through an
+    // extra cmd.exe/powershell.exe hop adds a process layer that can lose the OS-level
+    // workspace-write sandbox permission when the whole tree is already nested inside another
+    // restricted parent process (e.g. VS Code's extension host), even though the same shim works
+    // fine from a top-level PowerShell window. When we can statically resolve the shim's real
+    // wrapped `node <script>` target, invoke that directly instead — this removes the extra hop
+    // for every Windows launch, nested or not, with no behavior change when resolution fails.
+    const directScript = resolveNpmShimScript(resolvedOrUndefined);
+    if (directScript !== undefined) {
+      return { command: process.execPath, args: [directScript, ...args] };
+    }
+
+    if (extension === ".ps1") {
+      return {
+        command: "powershell.exe",
+        args: ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", resolvedOrUndefined, ...args]
+      };
+    }
+
     return {
       command: process.env.ComSpec || "cmd.exe",
       args: ["/d", "/c", resolvedOrUndefined, ...args]
     };
   }
 
-  if (extension === ".ps1") {
-    return {
-      command: "powershell.exe",
-      args: ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", resolvedOrUndefined, ...args]
-    };
+  return { command: resolvedOrUndefined, args };
+}
+
+/**
+ * npm generates Windows shims (.cmd/.ps1, occasionally .bat) that ultimately just exec
+ * `node <real-cli-script>.js <args>` relative to the shim's own directory. Parse the shim text to
+ * find that real script path and return it if it resolves to a file that actually exists on disk;
+ * otherwise return undefined so callers fall back to the existing wrapper-shell behavior unchanged.
+ */
+export function resolveNpmShimScript(shimPath: string): string | undefined {
+  let contents: string;
+  try {
+    contents = readFileSync(shimPath, "utf8");
+  } catch {
+    return undefined;
   }
 
-  return { command: resolvedOrUndefined, args };
+  const shimDir = dirname(shimPath);
+  const scriptPathPattern = /["']?(?:%~?dp0%?|\$basedir)[\\/]([^"'\s]+\.[cm]?js)["']?/gi;
+  const matches = contents.matchAll(scriptPathPattern);
+
+  for (const match of matches) {
+    const relativeScript = match[1];
+    if (!relativeScript) {
+      continue;
+    }
+    const segments = relativeScript.split(/[\\/]+/u).filter(Boolean);
+    const resolvedScript = resolve(shimDir, ...segments);
+    if (existsSync(resolvedScript)) {
+      return resolvedScript;
+    }
+  }
+
+  return undefined;
 }
 
 function resolveWindowsCommand(command: string, cwd: string): string | undefined {

--- a/packages/adapters/src/codex-launcher.ts
+++ b/packages/adapters/src/codex-launcher.ts
@@ -2,6 +2,8 @@ import { spawnSync } from "node:child_process";
 import { existsSync, readdirSync, statSync } from "node:fs";
 import { dirname, extname, join, resolve } from "node:path";
 
+import { resolveNpmShimScript } from "./cli-bridge.js";
+
 export interface CliCommandAvailability {
   command: string;
   available: boolean;
@@ -255,17 +257,27 @@ function buildProbeCommand(
   switch (extension) {
     case ".cmd":
     case ".bat":
+    case ".ps1": {
+      // Bypass the npm shim's cmd.exe/powershell.exe wrapper hop when we can statically resolve
+      // the real `node <script>` target it wraps — keeps the live probe's process-nesting depth
+      // consistent with the real run's invocation (see createSpawnPlan in cli-bridge.ts).
+      const directScript = resolveNpmShimScript(command);
+      if (directScript !== undefined) {
+        return { command: process.execPath, args: [directScript, ...args], invocationMode: "direct" };
+      }
+      if (extension === ".ps1") {
+        return {
+          command: "powershell.exe",
+          args: ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", command, ...args],
+          invocationMode: "powershell"
+        };
+      }
       return {
         command: process.env.ComSpec || "cmd.exe",
         args: ["/d", "/c", command, ...args],
         invocationMode: "cmd_shell"
       };
-    case ".ps1":
-      return {
-        command: "powershell.exe",
-        args: ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", command, ...args],
-        invocationMode: "powershell"
-      };
+    }
     default:
       return { command, args, invocationMode: "direct" };
   }
@@ -410,7 +422,7 @@ function classifyProbeFailure(
         sandboxCompatible: false,
         warnings,
         remediation:
-          "Update or reinstall Codex on this Windows host until `codex exec --sandbox workspace-write` can launch a simple shell command before running governed Codex work."
+          "MartinLoop already invokes Codex's underlying binary directly when it can resolve the npm shim (bypassing the cmd.exe/PowerShell wrapper hop), so this failure persisted even at the shallowest invocation depth available. Update or reinstall Codex on this Windows host until `codex exec --sandbox workspace-write` can launch a simple shell command before running governed Codex work."
       }
     };
   }

--- a/packages/adapters/tests/cli-bridge.test.ts
+++ b/packages/adapters/tests/cli-bridge.test.ts
@@ -1,0 +1,76 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { resolveNpmShimScript } from "../src/cli-bridge.js";
+
+describe("resolveNpmShimScript", () => {
+  let dir: string | undefined;
+
+  afterEach(() => {
+    if (dir) {
+      rmSync(dir, { recursive: true, force: true });
+      dir = undefined;
+    }
+  });
+
+  it("resolves the real script wrapped by an npm-generated .cmd shim", () => {
+    dir = mkdtempSync(join(tmpdir(), "martin-shim-test-"));
+    const scriptPath = join(dir, "cli.js");
+    writeFileSync(scriptPath, "// stub cli entrypoint\n");
+
+    const shimPath = join(dir, "codex.cmd");
+    writeFileSync(
+      shimPath,
+      [
+        "@ECHO off",
+        "SETLOCAL",
+        'IF EXIST "%~dp0\\node.exe" (',
+        '  "%~dp0\\node.exe"  "%~dp0\\cli.js" %*',
+        ") ELSE (",
+        '  node  "%~dp0\\cli.js" %*',
+        ")"
+      ].join("\r\n")
+    );
+
+    expect(resolveNpmShimScript(shimPath)).toBe(scriptPath);
+  });
+
+  it("resolves the real script wrapped by an npm-generated .ps1 shim", () => {
+    dir = mkdtempSync(join(tmpdir(), "martin-shim-test-"));
+    const scriptPath = join(dir, "cli.js");
+    writeFileSync(scriptPath, "// stub cli entrypoint\n");
+
+    const shimPath = join(dir, "claude.ps1");
+    writeFileSync(
+      shimPath,
+      ['#!/usr/bin/env pwsh', '$basedir = Split-Path $MyInvocation.MyCommand.Definition -Parent', '& "$basedir/cli.js" $args'].join(
+        "\n"
+      )
+    );
+
+    expect(resolveNpmShimScript(shimPath)).toBe(scriptPath);
+  });
+
+  it("returns undefined when the shim references a script that does not exist on disk", () => {
+    dir = mkdtempSync(join(tmpdir(), "martin-shim-test-"));
+    const shimPath = join(dir, "codex.cmd");
+    writeFileSync(shimPath, '@ECHO off\n"%~dp0\\node.exe" "%~dp0\\missing-cli.js" %*\n');
+
+    expect(resolveNpmShimScript(shimPath)).toBeUndefined();
+  });
+
+  it("returns undefined when the shim file does not exist", () => {
+    expect(resolveNpmShimScript("/nonexistent/path/codex.cmd")).toBeUndefined();
+  });
+
+  it("returns undefined for shim content with no recognizable node script reference", () => {
+    dir = mkdtempSync(join(tmpdir(), "martin-shim-test-"));
+    const shimPath = join(dir, "weird.cmd");
+    writeFileSync(shimPath, "@ECHO off\necho hello world\n");
+
+    expect(resolveNpmShimScript(shimPath)).toBeUndefined();
+  });
+});

--- a/packages/adapters/tests/codex-launcher.test.ts
+++ b/packages/adapters/tests/codex-launcher.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -199,6 +199,55 @@ describe("probeCodexLaunch", () => {
       })
     );
     expect(result.summary).toContain("prompt-and-shell probe passed");
+  });
+
+  it("invokes the resolved npm shim's wrapped script directly instead of through cmd.exe", () => {
+    const shimDir = mkdtempSync(join(tmpdir(), "martin-codex-shim-probe-"));
+    const scriptPath = join(shimDir, "cli.js");
+    writeFileSync(scriptPath, "// stub codex cli entrypoint\n");
+    const shimPath = join(shimDir, "codex.cmd");
+    writeFileSync(shimPath, '@ECHO off\n"%~dp0\\node.exe"  "%~dp0\\cli.js" %*\n');
+
+    try {
+      const spawnSyncImpl = vi.fn(() => ({
+        status: 0,
+        stdout: JSON.stringify({
+          type: "item.completed",
+          item: {
+            id: "item_1",
+            type: "command_execution",
+            command: "git status --short -- .",
+            aggregated_output: "",
+            exit_code: 0,
+            status: "completed"
+          }
+        }),
+        stderr: ""
+      }));
+
+      const result = probeCodexLaunch({
+        workingDirectory: process.cwd(),
+        platform: "win32",
+        availability: {
+          command: "codex",
+          available: true,
+          locator: "where.exe",
+          detail: "codex is available on PATH.",
+          resolvedPath: shimPath,
+          candidatePaths: [shimPath]
+        },
+        spawnSyncImpl: spawnSyncImpl as never
+      });
+
+      expect(result.ok).toBe(true);
+      expect(spawnSyncImpl).toHaveBeenCalledWith(
+        process.execPath,
+        [scriptPath, ...result.args],
+        expect.objectContaining({ cwd: process.cwd() })
+      );
+    } finally {
+      rmSync(shimDir, { recursive: true, force: true });
+    }
   });
 
   it("fails closed when Codex resolves to a Windows shim in WSL", () => {

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -29,6 +29,7 @@ export const FAILURE_CLASSES = [
   "environment_mismatch",
   "budget_pressure",
   "safety_leash_blocked",
+  "sandbox_write_blocked",
 ] as const;
 
 export type FailureClass = (typeof FAILURE_CLASSES)[number];

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1594,7 +1594,7 @@ export async function runMartin(input: RunMartinInput): Promise<RunMartinResult>
     }
 
     if (patchDecision && patchDecision.decision !== "KEEP" && !failure) {
-      failure = classifyPatchDecisionFailure(patchDecision);
+      failure = classifyPatchDecisionFailure(patchDecision, result);
       loop = applyPatchFailureToLoop(loop, {
         attemptId,
         summary: patchDecision.summary,
@@ -2123,7 +2123,24 @@ function toPatchDecisionArtifact(decision: EvaluatedPatchDecision): PatchDecisio
   };
 }
 
-function classifyPatchDecisionFailure(decision: EvaluatedPatchDecision): FailureAssessment {
+const SANDBOX_WRITE_BLOCKED_PATTERNS = [
+  /createprocessasuserw failed:\s*\d+/iu,
+  /windows sandbox: runner error/iu,
+  /writing is blocked by read-only sandbox/iu,
+  /read-only filesystem sandbox/iu,
+  /approval is disabled/iu
+];
+
+function detectSandboxWriteBlocked(result: MartinAdapterResult): boolean {
+  const sources = [result.summary, result.failure?.message]
+    .filter((value): value is string => typeof value === "string" && value.trim().length > 0);
+  return sources.some((source) => SANDBOX_WRITE_BLOCKED_PATTERNS.some((pattern) => pattern.test(source)));
+}
+
+function classifyPatchDecisionFailure(
+  decision: EvaluatedPatchDecision,
+  result?: MartinAdapterResult
+): FailureAssessment {
   if (decision.reasonCodes.includes("grounding_failure")) {
     return {
       failureClass: "repo_grounding_failure",
@@ -2169,6 +2186,16 @@ function classifyPatchDecisionFailure(decision: EvaluatedPatchDecision): Failure
       rationale: "Patch truth escalated the attempt because safety evidence blocked it.",
       retryable: false,
       recommendedIntervention: "escalate_human"
+    };
+  }
+
+  if (result && detectSandboxWriteBlocked(result)) {
+    return {
+      failureClass: "sandbox_write_blocked",
+      rationale:
+        "The adapter reported a completed patch but the workspace-write sandbox blocked the underlying file write, so no trustworthy code change landed on disk.",
+      retryable: true,
+      recommendedIntervention: "switch_adapter"
     };
   }
 

--- a/packages/core/tests/runtime.test.ts
+++ b/packages/core/tests/runtime.test.ts
@@ -1823,6 +1823,88 @@ const store: import("../src/index").RunStore = {
     expect(patchDecision.reasonCodes).toContain("grounding_failure");
   });
 
+  it("classifies a no-code-change attempt as sandbox_write_blocked when the adapter reports a Windows sandbox write failure", async () => {
+    const runsRoot = await mkdtemp(join(tmpdir(), "martin-patch-sandbox-blocked-"));
+    const repoRoot = join(runsRoot, "repo");
+    await mkdir(join(repoRoot, "src"), { recursive: true });
+    await writeFile(join(repoRoot, "src", "real.ts"), "export const real = 1;\n", "utf8");
+    const store = createFileRunStore({ runsRoot });
+
+    const adapter: MartinAdapter = {
+      adapterId: "direct:patch-sandbox-blocked",
+      kind: "direct-provider",
+      label: "Sandbox-blocked patch adapter",
+      metadata: {
+        providerId: "openai",
+        model: "gpt-5-mini"
+      },
+      async execute() {
+        return {
+          status: "completed",
+          summary:
+            "Reasoned through the fix and attempted the write, but the host reported: windows sandbox: runner error: CreateProcessAsUserW failed: 5.",
+          usage: {
+            actualUsd: 0.18,
+            tokensIn: 64,
+            tokensOut: 30
+          },
+          verification: {
+            passed: true,
+            summary: "pnpm --filter @martin/core test passed"
+          },
+          execution: {
+            changedFiles: []
+          }
+        };
+      }
+    };
+
+    const result = await runMartin({
+      workspaceId: "ws_patch",
+      projectId: "proj_patch",
+      task: {
+        title: "Sandbox-blocked write",
+        objective: "Classify a write blocked by a nested Windows sandbox as a distinct failure class.",
+        verificationPlan: ["pnpm --filter @martin/core test"],
+        repoRoot,
+        allowedPaths: ["src/**"]
+      },
+      budget: {
+        maxUsd: 10,
+        softLimitUsd: 8,
+        maxIterations: 1,
+        maxTokens: 2_000
+      },
+      adapter,
+      store,
+      now: createTimestampSource([
+        "2026-04-03T11:20:00.000Z",
+        "2026-04-03T11:20:01.000Z",
+        "2026-04-03T11:20:02.000Z",
+        "2026-04-03T11:20:03.000Z",
+        "2026-04-03T11:20:04.000Z",
+        "2026-04-03T11:20:05.000Z",
+        "2026-04-03T11:20:06.000Z"
+      ]),
+      idFactory: createIdFactory()
+    });
+
+    const patchDecision = JSON.parse(
+      await readFile(
+        join(runsRoot, result.loop.loopId, "artifacts", "attempt-001", "patch-decision.json"),
+        "utf8"
+      )
+    );
+    const classifiedEvent = result.loop.events.find((event) => event.type === "failure.classified");
+
+    expect(patchDecision.decision).toBe("DISCARD");
+    expect(patchDecision.reasonCodes).toContain("no_code_change");
+    expect(classifiedEvent?.payload).toMatchObject({
+      failureClass: "sandbox_write_blocked"
+    });
+    expect(result.loop.attempts[0]?.failureClass).toBe("sandbox_write_blocked");
+  });
+
   it("restores the pre-attempt repo boundary for discarded verifier regressions and preserves pre-existing dirty files", async () => {
     const runsRoot = await mkdtemp(join(tmpdir(), "martin-patch-rollback-"));
     const repoRoot = join(runsRoot, "repo");


### PR DESCRIPTION
## Summary

- MartinLoop's nested write path was reported blocked when running inside VS Code (Claude/Codex CLIs) on Windows, while a plain top-level PowerShell window worked fine.
- Root cause: npm-installed CLIs resolve to a generated `.cmd`/`.ps1` shim on Windows, and the shared spawn chokepoint in `cli-bridge.ts` always wrapped that shim through an extra `cmd.exe`/`powershell.exe` hop. Each extra process hop is a place where the OS-level workspace-write sandbox permission can fail to propagate to the grandchild process that performs the actual file write — worse the deeper the host process tree is nested (VS Code adds more nesting than a bare PowerShell window).
- `createSpawnPlan` now statically resolves the shim's wrapped `node <script>.js` target and invokes it directly via `process.execPath`, removing the extra hop for both adapters (they share this chokepoint). Falls back to the prior wrapper behavior unchanged whenever resolution fails — no regression for unresolvable shim formats, non-Windows platforms untouched.
- `codex-launcher.ts`'s probe path reuses the same resolution so the launch probe matches the real run's invocation depth.
- Added a `sandbox_write_blocked` failure class so a no-code-change attempt whose adapter output carries a known Windows sandbox-write-blocked signature is surfaced distinctly instead of falling through to generic `no_progress`.
- Documented under `.planning/phases/d-nested-write-blocked/` (PLAN/VERIFICATION/LEDGER).

## Test plan

- [x] `pnpm --filter @martin/adapters test` — 82/82 passed
- [x] `pnpm --filter @martin/core test` — 198/198 passed
- [x] `pnpm --filter @martin/adapters lint` / `pnpm --filter @martin/contracts lint` — passed
- [x] `pnpm -r build` — passed across contracts, core, mcp, adapters, benchmarks, cli
- [x] Confirmed non-`win32` platforms and unresolvable shim paths keep prior behavior unchanged (existing Linux/WSL/macOS test cases pass unmodified)
- [ ] Live Windows + VS Code repro (PowerShell vs VS Code terminal vs VS Code agent panel, `claude` and `codex` engines) — not possible from this remote Linux execution environment; recommended as a follow-up on an actual Windows host to close the loop with direct field evidence.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UwpwDNh6AsBxBL18LiqiYV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows command launching so supported shims can run more directly, reducing extra wrapper steps in some cases.
  * Better handles Windows sandbox write failures by classifying them more accurately and surfacing clearer recovery guidance.
  * Fixed probe behavior so command checks match real execution more closely on Windows.

* **Tests**
  * Added coverage for Windows shim resolution and sandbox write failure detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->