### PR TITLE
fix(core): non-null assertions for strict TS in test files

### DIFF
--- a/packages/core/tests/memory-store.test.ts
+++ b/packages/core/tests/memory-store.test.ts
@@ -44,8 +44,8 @@ describe("appendMemory", () => {
     await appendMemory(tempDir, entry);
     const entries = await readMemoryEntries(tempDir);
     expect(entries).toHaveLength(1);
-    expect(entries[0].key).toBe("budget.default");
-    expect(entries[0].value).toBe(5);
+    expect(entries[0]!.key).toBe("budget.default");
+    expect(entries[0]!.value).toBe(5);
   });
 
   it("appends multiple entries without overwriting — order preserved", async () => {
@@ -79,9 +79,9 @@ describe("appendMemory", () => {
     const entries = await readMemoryEntries(tempDir);
     expect(entries).toHaveLength(3);
     // Order preserved — first appended is first
-    expect(entries[0].value).toBe("haiku");
-    expect(entries[1].value).toBe("sonnet");
-    expect(entries[2].kind).toBe("consent");
+    expect(entries[0]!.value).toBe("haiku");
+    expect(entries[1]!.value).toBe("sonnet");
+    expect(entries[2]!.kind).toBe("consent");
   });
 });
 
@@ -157,8 +157,8 @@ describe("buildMemorySummary", () => {
     const summary = buildMemorySummary(entries);
     expect(summary.byKind.preference?.length).toBe(20); // capped at 20
     // Most recent 20 (indices 10-29) are kept
-    expect(summary.byKind.preference?.[0].value).toBe(10);
-    expect(summary.byKind.preference?.[19].value).toBe(29);
+    expect(summary.byKind.preference?.[0]?.value).toBe(10);
+    expect(summary.byKind.preference?.[19]?.value).toBe(29);
   });
 });
 
@@ -191,10 +191,10 @@ describe("recordConsent", () => {
 
     const entries = await readMemoryEntries(tempDir);
     expect(entries).toHaveLength(1);
-    expect(entries[0].kind).toBe("consent");
-    expect(entries[0].key).toBe("consent.auto.model.select");
-    expect(entries[0].confidence).toBe(1.0);
-    const val = entries[0].value as { approved: boolean; context: { engine: string } };
+    expect(entries[0]!.kind).toBe("consent");
+    expect(entries[0]!.key).toBe("consent.auto.model.select");
+    expect(entries[0]!.confidence).toBe(1.0);
+    const val = entries[0]!.value as { approved: boolean; context: { engine: string } };
     expect(val.approved).toBe(true);
     expect(val.context.engine).toBe("claude");
   });

--- a/packages/core/tests/trace-store.test.ts
+++ b/packages/core/tests/trace-store.test.ts
@@ -57,7 +57,7 @@ describe("appendTraceEntry", () => {
     const raw = await readFile(join(tempDir, "_martin", "trace-log.jsonl"), "utf8");
     const lines = raw.trim().split("\n");
     expect(lines).toHaveLength(1);
-    expect(JSON.parse(lines[0]).loopId).toBe(entry.loopId);
+    expect(JSON.parse(lines[0]!).loopId).toBe(entry.loopId);
   });
 
   it("appends multiple entries without overwriting", async () => {
@@ -70,9 +70,9 @@ describe("appendTraceEntry", () => {
     const raw = await readFile(join(tempDir, "_martin", "trace-log.jsonl"), "utf8");
     const lines = raw.trim().split("\n");
     expect(lines).toHaveLength(3);
-    expect(JSON.parse(lines[0]).loopId).toBe("loop_first");
-    expect(JSON.parse(lines[1]).loopId).toBe("loop_second");
-    expect(JSON.parse(lines[2]).loopId).toBe("loop_third");
+    expect(JSON.parse(lines[0]!).loopId).toBe("loop_first");
+    expect(JSON.parse(lines[1]!).loopId).toBe("loop_second");
+    expect(JSON.parse(lines[2]!).loopId).toBe("loop_third");
   });
 });
 
@@ -90,8 +90,8 @@ describe("readTraceEntries", () => {
 
     const entries = await readTraceEntries(tempDir);
     expect(entries).toHaveLength(2);
-    expect(entries[0].actualCostUsd).toBe(1.00);
-    expect(entries[1].actualCostUsd).toBe(2.50);
+    expect(entries[0]!.actualCostUsd).toBe(1.00);
+    expect(entries[1]!.actualCostUsd).toBe(2.50);
   });
 });
 
@@ -141,8 +141,8 @@ describe("aggregateTraces", () => {
     ];
 
     const agg = aggregateTraces(entries);
-    expect(agg.topFailureClasses[0].failureClass).toBe("verification_failure");
-    expect(agg.topFailureClasses[0].count).toBe(3);
+    expect(agg.topFailureClasses[0]!.failureClass).toBe("verification_failure");
+    expect(agg.topFailureClasses[0]!.count).toBe(3);
   });
 });
 


### PR DESCRIPTION
TS2532/TS2345 in memory-store.test.ts and trace-store.test.ts — add non-null assertions on array elements where length is already asserted. Unblocks the Release workflow for v0.3.16 npm publish.