### PR TITLE
fix(cli): non-null assertions for strict TS in test files

### DIFF
--- a/packages/cli/tests/auto-governance.test.ts
+++ b/packages/cli/tests/auto-governance.test.ts
@@ -165,10 +165,10 @@ describe("governance hooks in mcp install plans", () => {
     };
 
     expect(hooks.hooks.PreToolUse).toHaveLength(1);
-    expect(hooks.hooks.PreToolUse[0].matcher).toBe("Bash|Edit|Write");
-    expect(hooks.hooks.PreToolUse[0].command).toContain("martin-loop gate");
+    expect(hooks.hooks.PreToolUse[0]!.matcher).toBe("Bash|Edit|Write");
+    expect(hooks.hooks.PreToolUse[0]!.command).toContain("martin-loop gate");
     expect(hooks.hooks.Stop).toHaveLength(1);
-    expect(hooks.hooks.Stop[0].command).toContain("martin-loop dossier");
+    expect(hooks.hooks.Stop[0]!.command).toContain("martin-loop dossier");
   });
 
   it("Codex hooks reference AGENTS.md governance", () => {

--- a/packages/cli/tests/release-hardening.test.ts
+++ b/packages/cli/tests/release-hardening.test.ts
@@ -57,10 +57,10 @@ describe("subpath exports", () => {
     for (const subpath of ["./core", "./contracts", "./adapters"]) {
       const entry = pkg.exports[subpath];
       expect(entry).toBeDefined();
-      expect(typeof entry.types).toBe("string");
-      expect(typeof entry.default).toBe("string");
-      expect(entry.types).toMatch(/\.d\.ts$/);
-      expect(entry.default).toMatch(/\.js$/);
+      expect(typeof (entry as { types?: string })?.types).toBe("string");
+      expect(typeof (entry as { default?: string })?.default).toBe("string");
+      expect((entry as { types?: string })?.types).toMatch(/\.d\.ts$/);
+      expect((entry as { default?: string })?.default).toMatch(/\.js$/);
     }
   });
 });


### PR DESCRIPTION
TS2532/TS18048 in auto-governance.test.ts and release-hardening.test.ts. Unblocks Release workflow for v0.3.16 npm publish.