### PR TITLE
test(cli): normalize estimate cwd assertion across platforms

### DIFF
--- a/packages/cli/tests/auto-governance.test.ts
+++ b/packages/cli/tests/auto-governance.test.ts
@@ -26,6 +26,10 @@ import {
   type MartinMcpHost
 } from "../src/mcp-config.js";
 
+function normalizeWorkingDirectoryForExpectation(workingDirectory: string): string {
+  return process.platform === "win32" ? workingDirectory.toLowerCase() : workingDirectory;
+}
+
 // ---------------------------------------------------------------------------
 // 1. `martin estimate` CLI parsing
 // ---------------------------------------------------------------------------
@@ -169,7 +173,7 @@ describe("martin estimate command", () => {
         };
       };
 
-      expect(state.cli?.estimate?.workingDirectory).toBe(workspaceRoot.toLowerCase());
+      expect(state.cli?.estimate?.workingDirectory).toBe(normalizeWorkingDirectoryForExpectation(workspaceRoot));
     } finally {
       await rm(runsRoot, { recursive: true, force: true });
       await rm(workspaceRoot, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- normalize the new estimate receipt cwd assertion by platform
- keep Windows lowercase normalization checks
- allow Linux/macOS runners to compare the original path casing

## Verification
- `npx pnpm@10.33.0 --filter @martin/cli exec vitest run tests/auto-governance.test.ts`