### PR TITLE
test(release): self-build public smoke only when dist is missing

### DIFF
--- a/scripts/public-facade-smoke.mjs
+++ b/scripts/public-facade-smoke.mjs
@@ -297,11 +297,26 @@ async function ensureBuiltPublicFacade(rootDir) {
     path.join(rootDir, "dist", "index.d.ts"),
     path.join(rootDir, "dist", "bin", "martin-loop.js"),
   ];
-  const allPresent = await Promise.all(
-    requiredFiles.map((filePath) => access(filePath).then(() => true).catch(() => false)),
-  );
+  const areAllPresent = async () => {
+    const allPresent = await Promise.all(
+      requiredFiles.map((filePath) => access(filePath).then(() => true).catch(() => false)),
+    );
+    return allPresent.every(Boolean);
+  };
 
-  if (!allPresent.every(Boolean)) {
+  if (await areAllPresent()) {
+    return;
+  }
+
+  await runCommand(["pnpm", "build"], {
+    cwd: rootDir,
+    env: {
+      ...process.env,
+      CI: process.env.CI ?? "true",
+    },
+  });
+
+  if (!(await areAllPresent())) {
     throw new Error("Public facade build is incomplete; run `pnpm build` before `pnpm public:smoke`.");
   }
 }


### PR DESCRIPTION
## Summary
- let public facade smoke rebuild only when the packed dist artifacts are absent
- keep the release workflow's pnpm test lane independent from pnpm build ordering
- preserve truthful live Codex availability behavior from the earlier fix

## Verification
- node --test --test-concurrency=1 scripts/tests/public-facade.test.mjs
- npx pnpm@10.33.0 public:smoke