### PR TITLE
fix(windows): run absolute executables without cmd re-quoting

### DIFF
--- a/scripts/public-facade-smoke.mjs
+++ b/scripts/public-facade-smoke.mjs
@@ -97,22 +97,22 @@ export async function runPublicFacadeSmoke(options = {}) {
     );
 
     await runCommand(["npm", "install", tarballPath], { cwd: appDir });
-    const installedCli = resolveInstalledCliBinary(appDir);
+    const installedCliEntry = resolveInstalledCliEntry(appDir);
 
     const sdkRun = await runCommand(["node", "sdk-smoke.mjs"], { cwd: appDir });
 
-    const cliRun = await runCommand([installedCli, "--help"], { cwd: appDir });
+    const cliRun = await runCommand([process.execPath, installedCliEntry, "--help"], { cwd: appDir });
     if (!cliRun.stdout.includes("martin-loop run") && !cliRun.stdout.includes("Martin Loop CLI")) {
       throw new Error(`Expected CLI help output to include "martin-loop run" or "Martin Loop CLI".\n${cliRun.stdout}${cliRun.stderr}`);
     }
 
-    const startRun = await runCommand([installedCli, "start"], { cwd: appDir });
+    const startRun = await runCommand([process.execPath, installedCliEntry, "start"], { cwd: appDir });
     if (!/martin-loop proofRun|martin run/iu.test(`${startRun.stdout}\n${startRun.stderr}`)) {
       throw new Error(`Expected start command to describe the first-run governed workflow.\n${startRun.stdout}${startRun.stderr}`);
     }
 
     const demoTarget = path.join(appDir, "martin-loop-demo");
-    const demoRun = await runCommand([installedCli, "demo", "--dir", demoTarget], {
+    const demoRun = await runCommand([process.execPath, installedCliEntry, "demo", "--dir", demoTarget], {
       cwd: appDir,
     });
     const demoReadme = await readFile(path.join(demoTarget, "README.md"), "utf8");
@@ -137,7 +137,8 @@ export async function runPublicFacadeSmoke(options = {}) {
     const noopVerifier = process.platform === "win32" ? "cmd /c exit 0" : "true";
     const governedRun = await runCommand(
       [
-        installedCli,
+        process.execPath,
+        installedCliEntry,
         "--json",
         "run",
         "--engine",
@@ -181,7 +182,8 @@ export async function runPublicFacadeSmoke(options = {}) {
 
     const unsafeBypassRun = await runCommand(
       [
-        installedCli,
+        process.execPath,
+        installedCliEntry,
         "run",
         "--engine",
         "codex",
@@ -379,10 +381,8 @@ function tryParseJson(value) {
   }
 }
 
-function resolveInstalledCliBinary(appDir) {
-  return process.platform === "win32"
-    ? path.join(appDir, "node_modules", ".bin", "martin-loop.cmd")
-    : path.join(appDir, "node_modules", ".bin", "martin-loop");
+function resolveInstalledCliEntry(appDir) {
+  return path.join(appDir, "node_modules", "martin-loop", "dist", "bin", "martin-loop.js");
 }
 
 async function main() {

--- a/scripts/rc-validation.mjs
+++ b/scripts/rc-validation.mjs
@@ -122,6 +122,14 @@ export function resolveRcCommandExecution(
   comSpec = process.env.ComSpec ?? "cmd.exe",
 ) {
   if (platform === "win32") {
+    const firstArg = command[0] ?? "";
+    if (/^(?:[A-Za-z]:[\\/]|\\\\)/.test(firstArg)) {
+      return {
+        command: firstArg,
+        args: command.slice(1),
+        shell: false,
+      };
+    }
     const commandLine = command.map(quoteForWindowsShell).join(" ");
     return {
       command: comSpec,

--- a/scripts/tests/rc-validation.test.mjs
+++ b/scripts/tests/rc-validation.test.mjs
@@ -57,3 +57,15 @@ test("resolveRcCommandExecution avoids shell mode on Windows by invoking cmd.exe
   assert.deepEqual(execution.args, ["/d", "/s", "/c", "pnpm --filter @martin/core test"]);
   assert.equal(execution.shell, false);
 });
+
+test("resolveRcCommandExecution runs absolute Windows executables directly", () => {
+  const execution = resolveRcCommandExecution(
+    ["C:\\Program Files\\nodejs\\node.exe", "C:\\repo\\dist\\bin\\martin-loop.js", "--help"],
+    "win32",
+    "C:\\Windows\\System32\\cmd.exe",
+  );
+
+  assert.equal(execution.command, "C:\\Program Files\\nodejs\\node.exe");
+  assert.deepEqual(execution.args, ["C:\\repo\\dist\\bin\\martin-loop.js", "--help"]);
+  assert.equal(execution.shell, false);
+});


### PR DESCRIPTION
## Summary
- run absolute Windows executables directly in the shared release-command resolver
- execute the public smoke CLI through Node + the packaged entry file for deterministic cross-platform behavior
- add resolver coverage for absolute Windows executable paths

## Verification
- node --test --test-concurrency=1 scripts/tests/rc-validation.test.mjs scripts/tests/public-facade.test.mjs
- npx pnpm@10.33.0 public:smoke