### PR TITLE
fix(mcp): persist estimate receipts for published smoke

### DIFF
--- a/packages/mcp/scripts/smoke-published-package.mjs
+++ b/packages/mcp/scripts/smoke-published-package.mjs
@@ -19,6 +19,7 @@ import {
 
 const REQUIRED_TOOLS = [
   "martin_doctor",
+  "martin_estimate",
   "martin_plan",
   "martin_preflight",
   "martin_run",
@@ -257,6 +258,15 @@ export async function runPublishedMcpSmoke(options = {}) {
         engine: "claude",
       },
     });
+    const estimateResult = await client.callTool({
+      name: "martin_estimate",
+      arguments: {
+        objective: "Summarize the current runtime state",
+        engine: "claude",
+        budgetUsd: 1,
+        fileScope: ["src/**"],
+      },
+    });
     const planResult = await client.callTool({
       name: "martin_plan",
       arguments: {
@@ -374,6 +384,7 @@ export async function runPublishedMcpSmoke(options = {}) {
     });
 
     const publishedUserJourney = {
+      estimateResult: JSON.parse(readTextContent(estimateResult)),
       planResult: JSON.parse(readTextContent(planResult)),
       preflightResult: JSON.parse(readTextContent(preflightResult)),
       listRuns: JSON.parse(readTextContent(listRuns)),
@@ -624,6 +635,7 @@ function readResourceText(result) {
 
 function assertPublishedUserJourneyEvidence(journey, expected) {
   const requiredKeys = [
+    "estimateResult",
     "preflightResult",
     "listRuns",
     "getRun",

--- a/packages/mcp/src/resources.ts
+++ b/packages/mcp/src/resources.ts
@@ -706,9 +706,10 @@ async function buildGovernanceStatusResource(runsRoot: string, workingDirectory:
   const state = await readWorkflowState(runsRoot);
   const mcpState = state.mcp ?? {};
   const hasDoctor = Boolean(mcpState.doctor);
+  const hasEstimate = Boolean(mcpState.estimate);
   const hasPlan = Boolean(mcpState.plan);
   const hasPreflight = Boolean(mcpState.preflight);
-  const governed = hasDoctor && hasPlan && hasPreflight;
+  const governed = hasDoctor && hasEstimate && hasPlan && hasPreflight;
 
   const latest = await loadLatestRunForCompactResource(runsRoot);
   const budgetRemaining = (!latest.empty && latest.detail)
@@ -727,11 +728,14 @@ async function buildGovernanceStatusResource(runsRoot: string, workingDirectory:
 
   const missingSteps: string[] = [];
   if (!hasDoctor) missingSteps.push("martin_doctor");
+  if (!hasEstimate) missingSteps.push("martin_estimate");
   if (!hasPlan) missingSteps.push("martin_plan");
   if (!hasPreflight) missingSteps.push("martin_preflight");
 
   const recommendedAction = !hasDoctor
     ? "Run martin_doctor to confirm environment before any work."
+    : !hasEstimate
+      ? "Run martin_estimate to preview cost and route before spending."
     : !hasPlan
       ? "Run martin_plan with your objective to scope the task."
       : !hasPreflight
@@ -743,6 +747,7 @@ async function buildGovernanceStatusResource(runsRoot: string, workingDirectory:
     governed,
     workflowReceipts: {
       doctor: hasDoctor ? { recordedAt: mcpState.doctor!.recordedAt } : null,
+      estimate: hasEstimate ? { recordedAt: mcpState.estimate!.recordedAt } : null,
       plan: hasPlan ? { recordedAt: mcpState.plan!.recordedAt } : null,
       preflight: hasPreflight ? { recordedAt: mcpState.preflight!.recordedAt } : null
     },
@@ -750,7 +755,7 @@ async function buildGovernanceStatusResource(runsRoot: string, workingDirectory:
     budgetRemaining,
     unreceiptedRuns,
     recommendedAction,
-    requiredSequence: ["martin_doctor", "martin_plan", "martin_preflight", "martin_run", "martin_dossier"],
+    requiredSequence: ["martin_doctor", "martin_estimate", "martin_plan", "martin_preflight", "martin_run", "martin_dossier"],
     warning: governed ? undefined : "This session is NOT governed. Complete the required sequence before making changes."
   };
 }

--- a/packages/mcp/src/server-validation.ts
+++ b/packages/mcp/src/server-validation.ts
@@ -31,6 +31,7 @@ type ToolName =
   | "martin_inspect"
   | "martin_status"
   | "martin_doctor"
+  | "martin_estimate"
   | "martin_plan"
   | "martin_preflight"
   | "martin_logs"
@@ -61,6 +62,8 @@ export function validateToolInput(name: ToolName, args: unknown): unknown {
       return validateStatusInput(args);
     case "martin_doctor":
       return validateDoctorInput(args);
+    case "martin_estimate":
+      return validateEstimateInput(args);
     case "martin_plan":
       return validatePlanInput(args);
     case "martin_preflight":
@@ -358,6 +361,23 @@ function validateDoctorInput(args: unknown): MartinDoctorInput {
       ? { runsDir: resolveSafeRunsRootPath(requireString(record.runsDir, "runsDir")) }
       : {}),
     ...optionalEnumAsObject(record.engine, "engine", MARTIN_ENGINE_VALUES)
+  };
+}
+
+function validateEstimateInput(args: unknown): {
+  objective: string;
+  engine?: (typeof MARTIN_ENGINE_VALUES)[number];
+  budgetUsd?: number;
+  fileScope?: string[];
+} {
+  const record = requireObject(args);
+  assertAllowedKeys(record, ["objective", "engine", "budgetUsd", "fileScope"]);
+
+  return {
+    objective: requireString(record.objective, "objective"),
+    ...optionalEnumAsObject(record.engine, "engine", MARTIN_ENGINE_VALUES),
+    ...optionalPositiveNumber(record.budgetUsd, "budgetUsd"),
+    ...optionalStringArrayAsObject(record.fileScope, "fileScope")
   };
 }
 

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -776,7 +776,7 @@ export function createMartinMcpServer(serverInfo?: {
     {
       name: "martin_run",
       description:
-        "Execute a governed Martin Loop run on a coding task and return the run summary, spend, artifact rollup, and verification state. This hard-blocks until martin_doctor, martin_plan, and martin_preflight receipts exist for the same task.",
+        "Execute a governed Martin Loop run on a coding task and return the run summary, spend, artifact rollup, and verification state. This hard-blocks until martin_doctor, martin_estimate, martin_plan, and martin_preflight receipts exist for the same task.",
       annotations: {
         destructiveHint: true,
         idempotentHint: false,
@@ -1615,7 +1615,7 @@ export function createMartinMcpServer(serverInfo?: {
         workingDirectory: output.environment.workingDirectory,
         engine: input.engine,
         receiptScope: output.receiptScope
-      }).catch(() => {});
+      });
       return createToolSuccessResult(output, output.summary);
     }
 
@@ -1633,7 +1633,7 @@ export function createMartinMcpServer(serverInfo?: {
           repoRoot: output.workingDirectory,
           runsRoot: resolveRunsRoot(process.env)
         }
-      }).catch(() => {});
+      });
       return createToolSuccessResult(
         output,
         `Plan ready for ${output.objective} with ${output.risk.level} risk and ${output.approvalRecommendation.replace(/_/gu, " ")} approval.`
@@ -1655,7 +1655,7 @@ export function createMartinMcpServer(serverInfo?: {
           allowedPaths: output.normalized.allowedPaths,
           deniedPaths: output.normalized.deniedPaths,
           budget: output.normalized.budget
-        }).catch(() => {});
+        });
       }
       return createToolSuccessResult(output, output.summary);
     }
@@ -1789,11 +1789,18 @@ export function createMartinMcpServer(serverInfo?: {
     }
 
     if (name === "martin_estimate") {
-      const input = args as { objective: string; engine?: string; budgetUsd?: number; fileScope?: string[] };
+      const input = validateToolInput("martin_estimate", args) as {
+        objective: string;
+        engine?: MartinEngine;
+        budgetUsd?: number;
+        fileScope?: string[];
+      };
       const objective = input.objective;
       const engine = input.engine ?? "claude";
       const budgetUsd = input.budgetUsd ?? 5;
       const fileScope = input.fileScope ?? [];
+      const workingDirectory = resolveSafeRepoRoot();
+      const runsRoot = resolveRunsRoot(process.env);
       const route = classifyRoute({
         objective,
         verificationPlan: [],
@@ -1820,6 +1827,13 @@ export function createMartinMcpServer(serverInfo?: {
         recommendedModelTier: route.recommendedModelTier,
         estimatedSavingVsSonnetUsd: route.estimatedSavingVsSonnetUsd
       };
+      await recordMcpWorkflowStep({
+        runsRoot,
+        step: "estimate",
+        workingDirectory,
+        objective,
+        engine
+      });
       return createToolSuccessResult(
         output,
         `Estimate: ${route.selectedMode} route (${route.recommendedModelTier}), ~$${route.expectedCostUsd.toFixed(2)} expected cost, ${route.expectedPreworkBurnPct}% pre-work burn. Recommended budget: $${recommendedBudgetUsd.toFixed(2)}.`

--- a/packages/mcp/tests/server-validation.test.ts
+++ b/packages/mcp/tests/server-validation.test.ts
@@ -392,13 +392,25 @@ describe("server validation", () => {
     });
   });
 
-  it("validates doctor and preflight public tool shapes", () => {
+  it("validates doctor, estimate, and preflight public tool shapes", () => {
     expect(
       validateToolInput("martin_doctor", {
         engine: "codex"
       })
     ).toEqual({
       engine: "codex"
+    });
+
+    expect(
+      validateToolInput("martin_estimate", {
+        objective: "Fix the bug",
+        budgetUsd: 5,
+        fileScope: ["src/**"]
+      })
+    ).toEqual({
+      objective: "Fix the bug",
+      budgetUsd: 5,
+      fileScope: ["src/**"]
     });
 
     expect(
@@ -569,7 +581,7 @@ describe("server validation", () => {
     });
   });
 
-  it("accepts a matching doctor-plan-preflight receipt chain for martin_run when maxUsd is below the default soft limit", async () => {
+  it("accepts a matching doctor-estimate-plan-preflight receipt chain for martin_run when maxUsd is below the default soft limit", async () => {
     await withValidationRunsRoot(async () => {
       await withValidationWorkspaceRoot(async (workspaceRoot) => {
         const previousLive = process.env.MARTIN_LIVE;
@@ -601,6 +613,23 @@ describe("server validation", () => {
               {}
             );
             expect((doctorResult as { isError?: boolean }).isError).not.toBe(true);
+
+            const estimateResult = await callTool(
+              {
+                method: "tools/call",
+                params: {
+                  name: "martin_estimate",
+                  arguments: {
+                    objective: "Summarize the current runtime state",
+                    engine: "claude",
+                    budgetUsd: 1,
+                    fileScope: ["src/**"]
+                  }
+                }
+              },
+              {}
+            );
+            expect((estimateResult as { isError?: boolean }).isError).not.toBe(true);
 
             const planResult = await callTool(
               {
@@ -683,7 +712,7 @@ describe("server validation", () => {
     });
   });
 
-  it("accepts a matching doctor-plan-preflight receipt chain when no path allow/deny filters are provided", async () => {
+  it("accepts a matching doctor-estimate-plan-preflight receipt chain when no path allow/deny filters are provided", async () => {
     await withValidationRunsRoot(async () => {
       await withValidationWorkspaceRoot(async (workspaceRoot) => {
         const previousLive = process.env.MARTIN_LIVE;
@@ -710,6 +739,20 @@ describe("server validation", () => {
                 params: {
                   name: "martin_doctor",
                   arguments: { workingDirectory: workspaceRoot, engine: "claude" }
+                }
+              },
+              {}
+            );
+            await callTool(
+              {
+                method: "tools/call",
+                params: {
+                  name: "martin_estimate",
+                  arguments: {
+                    objective,
+                    engine: "claude",
+                    budgetUsd: 1
+                  }
                 }
               },
               {}


### PR DESCRIPTION
## Summary
- persist `martin_estimate` workflow receipts on the governed MCP path
- require the published MCP smoke journey to execute `doctor -> estimate -> plan -> preflight -> run`
- surface `estimate` in governance status and validation coverage

## Verification
- `npx pnpm@10.33.0 install --frozen-lockfile`
- `npx pnpm@10.33.0 build`
- `npx pnpm@10.33.0 test`
- `npx pnpm@10.33.0 public:smoke`
- `npx pnpm@10.33.0 public:copy-scan`
- `npx pnpm@10.33.0 public:portability-guard`
- `npx pnpm@10.33.0 public:git-surface`
- `npx pnpm@10.33.0 oss:validate`
- `npx vitest run tests/server-validation.test.ts --reporter=verbose`
- `npx tsc -p tsconfig.json --noEmit`
- `npx pnpm@10.33.0 --filter @martinloop/mcp build`

## Notes
- Local `smoke:pack` and `smoke:published:pack` remain blocked by an environment-specific `pnpm.cmd` resolution mismatch outside the repo-pinned `pnpm@10.33.0` toolchain.
- GitHub Actions should be treated as release truth for the packaged MCP smoke lanes on this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an estimate step in the MCP workflow, including validation for its inputs and recorded progress in the workflow status.
  * Updated the published smoke check to exercise the new estimate path and verify its output.

* **Bug Fixes**
  * Improved workflow gating so runs now properly recognize when estimate information is missing.
  * Made tool-step recording failures surface as errors instead of being silently ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->