### PR TITLE
chore(security): pin CI actions to commit SHAs and fix rollback dedup

### DIFF
--- a/.github/workflows/martinloop-budget-gate.yml
+++ b/.github/workflows/martinloop-budget-gate.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@b0f76dfb45f55f8421693e4803ac7bb65143bd34
         with:
           version: 10.33.0
 

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -45,7 +45,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@b0f76dfb45f55f8421693e4803ac7bb65143bd34
         with:
           version: 10.33.0
 
@@ -151,7 +151,7 @@ jobs:
           done
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b
         with:
           tag_name: ${{ steps.release-vars.outputs.tag }}
           name: "@martinloop/mcp ${{ steps.mcp-metadata.outputs.package_version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@b0f76dfb45f55f8421693e4803ac7bb65143bd34
         with:
           version: 10.33.0
 
@@ -104,7 +104,7 @@ jobs:
           exit 1
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b
         with:
           files: ${{ steps.root-pack.outputs.tarball }}
           body: ${{ steps.changelog.outputs.body }}

--- a/packages/core/src/rollback.ts
+++ b/packages/core/src/rollback.ts
@@ -55,12 +55,12 @@ export async function captureRollbackBoundary(input: {
     snapshots.push(await readRollbackSnapshot(input.repoRoot, filePath));
   }
 
+  const headRef = readGitScalar(input.repoRoot, ["rev-parse", "HEAD"]);
+
   return {
     strategy: "git_head_plus_snapshot",
     capturedAt: input.capturedAt,
-    ...(readGitScalar(input.repoRoot, ["rev-parse", "HEAD"])
-      ? { headRef: readGitScalar(input.repoRoot, ["rev-parse", "HEAD"]) }
-      : {}),
+    ...(headRef ? { headRef } : {}),
     trackedDirtyFiles: repoState.trackedDirtyFiles,
     untrackedFiles: repoState.untrackedFiles,
     snapshots

--- a/scripts/public-facade-smoke.mjs
+++ b/scripts/public-facade-smoke.mjs
@@ -125,7 +125,7 @@ export async function runPublicFacadeSmoke(options = {}) {
     const governedGroundingDir = path.join(appDir, ".martin-grounding");
     const governedIntegrityDir = path.join(appDir, ".martin-receipt-integrity");
     await mkdir(governedWorkspace, { recursive: true });
-    initializeGitRepo(governedWorkspace);
+    await initializeGitRepo(governedWorkspace);
 
     const codexAvailable = isCliCommandAvailable("codex");
     const governedEnv = {

--- a/scripts/tests/publish-mcp-workflow.test.mjs
+++ b/scripts/tests/publish-mcp-workflow.test.mjs
@@ -51,9 +51,9 @@ test("publish-mcp workflow covers trusted publishing, local-pack proof, and publ
   assert.match(workflow, /npm view "@martinloop\/mcp@\$\{\{ steps\.mcp-metadata\.outputs\.package_version \}\}" version/);
   assert.match(workflow, /pnpm --filter @martinloop\/mcp smoke:published/);
   assert.match(workflow, /actions\/checkout@v6/);
-  assert.match(workflow, /pnpm\/action-setup@v6/);
+  assert.match(workflow, /pnpm\/action-setup@b0f76dfb45f55f8421693e4803ac7bb65143bd34/);
   assert.match(workflow, /actions\/setup-node@v6/);
-  assert.match(workflow, /softprops\/action-gh-release@v3/);
+  assert.match(workflow, /softprops\/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b/);
   assert.match(workflow, /name:\s*"@martinloop\/mcp/);
   assert.match(workflow, /body_path:\s*"docs\/release\/MCP-\$\{\{\s*steps\.mcp-metadata\.outputs\.package_version\s*\}\}-RELEASE-NOTES\.md"/);
   assert.doesNotMatch(workflow, /registry-url/);

--- a/scripts/tests/root-release-workflow.test.mjs
+++ b/scripts/tests/root-release-workflow.test.mjs
@@ -18,9 +18,9 @@ test("root release workflow uses GitHub Actions trusted publishing without npm t
   assert.match(workflow, /npm publish "\$\{\{ steps\.root-pack\.outputs\.tarball \}\}" --access public --provenance/);
   assert.match(workflow, /npm view "martin-loop@\$\{\{ steps\.package-version\.outputs\.version \}\}" version/);
   assert.match(workflow, /actions\/checkout@v6/);
-  assert.match(workflow, /pnpm\/action-setup@v6/);
+  assert.match(workflow, /pnpm\/action-setup@b0f76dfb45f55f8421693e4803ac7bb65143bd34/);
   assert.match(workflow, /actions\/setup-node@v6/);
-  assert.match(workflow, /softprops\/action-gh-release@v3/);
+  assert.match(workflow, /softprops\/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b/);
 
   assert.doesNotMatch(workflow, /NODE_AUTH_TOKEN/);
   assert.doesNotMatch(workflow, /NPM_TOKEN/);

--- a/scripts/tests/workflow-action-pinning.test.mjs
+++ b/scripts/tests/workflow-action-pinning.test.mjs
@@ -19,7 +19,7 @@ for (const [actionName, shaPattern] of PINNED_ACTIONS) {
     for (const workflowName of workflowNames) {
       const workflowPath = path.join(WORKFLOWS_DIR, workflowName);
       const workflow = await readFile(workflowPath, "utf8");
-      const matches = [...workflow.matchAll(new RegExp(`${actionName.replaceAll("/", "\\/")}@([^\\s]+)`, "g"))];
+      const matches = [...workflow.matchAll(new RegExp(`uses:\\s+${actionName.replaceAll("/", "\\/")}@([^\\s#]+)`, "gm"))];
 
       for (const match of matches) {
         const ref = match[1];

--- a/scripts/tests/workflow-action-pinning.test.mjs
+++ b/scripts/tests/workflow-action-pinning.test.mjs
@@ -1,0 +1,34 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const WORKFLOWS_DIR = path.join(ROOT_DIR, ".github", "workflows");
+
+const PINNED_ACTIONS = new Map([
+  ["pnpm/action-setup", /^[a-f0-9]{40}$/],
+  ["softprops/action-gh-release", /^[a-f0-9]{40}$/],
+]);
+
+for (const [actionName, shaPattern] of PINNED_ACTIONS) {
+  test(`${actionName} is pinned by commit SHA in public workflows`, async () => {
+    const workflowNames = ["martinloop-budget-gate.yml", "publish-mcp.yml", "release.yml"];
+
+    for (const workflowName of workflowNames) {
+      const workflowPath = path.join(WORKFLOWS_DIR, workflowName);
+      const workflow = await readFile(workflowPath, "utf8");
+      const matches = [...workflow.matchAll(new RegExp(`${actionName.replaceAll("/", "\\/")}@([^\\s]+)`, "g"))];
+
+      for (const match of matches) {
+        const ref = match[1];
+        assert.match(
+          ref,
+          shaPattern,
+          `${workflowName} must pin ${actionName} with a full commit SHA, found ${ref}`,
+        );
+      }
+    }
+  });
+}


### PR DESCRIPTION
## What changed

**Action SHA pinning** — \`pnpm/action-setup\` and \`softprops/action-gh-release\` are now pinned to full commit SHAs in all three workflow files (\`release.yml\`, \`publish-mcp.yml\`, \`martinloop-budget-gate.yml\`). Mutable version tags (\`@v3\`, \`@v6\`) can be silently redirected if the upstream tag is moved or the action is compromised — SHA pinning eliminates that risk.

**Release gate for pinning** — \`scripts/tests/workflow-action-pinning.test.mjs\` is a new test that fails if any pinned action reverts to a mutable tag. Runs in the existing scripts test suite on every CI run.

**Workflow test assertions updated** — \`publish-mcp-workflow.test.mjs\` and \`root-release-workflow.test.mjs\` now assert the pinned SHAs. Both pass.

**\`rollback.ts\` dedup** — \`captureRollbackBoundary\` called \`readGitScalar\` twice for the same HEAD ref. Now captured once and reused.

## Tested

- \`node --test scripts/tests/workflow-action-pinning.test.mjs scripts/tests/root-release-workflow.test.mjs scripts/tests/publish-mcp-workflow.test.mjs\` — 6/6 pass

## Pinned SHAs

| Action | Tag | Commit SHA |
|--------|-----|------------|
| \`pnpm/action-setup\` | v6 | \`b0f76dfb45f55f8421693e4803ac7bb65143bd34\` |
| \`softprops/action-gh-release\` | v3 | \`718ea10b132b3b2eba29c1007bb80653f286566b\` |