### PR TITLE
feat: remove --verify-only from public CLI

### DIFF
--- a/packages/adapters/src/claude-cli.ts
+++ b/packages/adapters/src/claude-cli.ts
@@ -1251,24 +1251,15 @@ function buildPrompt(request: MartinAdapterRequest): string {
   const mutationMode = request.context.mutationMode ?? "edit";
 
   lines.push("You are running in autonomous agentic mode.");
-  if (mutationMode === "verify_only") {
-    lines.push("DO NOT EDIT FILES. Run the verifier only and report whether it passes.");
-    lines.push("Do not ask for confirmation. Do not ask clarifying questions.");
-  } else {
-    lines.push("MAKE ALL REQUIRED FILE EDITS NOW. Do not ask for confirmation. Do not ask clarifying questions.");
-    lines.push("Do not explain what you found without also making the changes. Edit the files and complete the task.");
-  }
+  lines.push("MAKE ALL REQUIRED FILE EDITS NOW. Do not ask for confirmation. Do not ask clarifying questions.");
+  lines.push("Do not explain what you found without also making the changes. Edit the files and complete the task.");
   lines.push("");
 
   lines.push("If PROGRESS.md exists in your working directory, read it first for context from prior attempts.");
   lines.push("If it does not exist, proceed with the objective below.");
   lines.push("");
 
-  lines.push(
-    mutationMode === "verify_only"
-      ? "Complete the following verification-only task without making file changes."
-      : "Complete the following coding task. Make all necessary file changes."
-  );
+  lines.push("Complete the following coding task. Make all necessary file changes.");
   lines.push("When you are done, the verification commands listed below must pass.");
   lines.push("");
 
@@ -1311,11 +1302,7 @@ function buildPrompt(request: MartinAdapterRequest): string {
   lines.push(`  Attempt ${String(attemptNumber)}`);
   lines.push(`  Remaining budget: $${String(request.context.remainingBudgetUsd)} USD`);
   lines.push(`  Remaining iterations: ${String(request.context.remainingIterations)}`);
-  lines.push(
-    mutationMode === "verify_only"
-      ? "  Do not modify files; only run verification."
-      : "  Do not expand scope beyond what is needed to pass verification."
-  );
+  lines.push("  Do not expand scope beyond what is needed to pass verification.");
   lines.push("");
 
   if (request.previousAttempts.length > 0) {

--- a/packages/adapters/tests/claude-cli.test.ts
+++ b/packages/adapters/tests/claude-cli.test.ts
@@ -630,7 +630,6 @@ describe("createVerifierOnlyAdapter", () => {
             objective: "Run verification only",
             verificationPlan: [],
             verificationStack: [],
-            mutationMode: "verify_only",
             focus: "verify only",
             remainingBudgetUsd: 8,
             remainingIterations: 1,
@@ -676,7 +675,6 @@ describe("createVerifierOnlyAdapter", () => {
             verificationPlan: [
               `"${process.execPath}" -e "require('node:fs').writeFileSync('tracked.txt','changed')"`
             ],
-            mutationMode: "verify_only",
             focus: "verify only",
             remainingBudgetUsd: 8,
             remainingIterations: 1,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -15,7 +15,6 @@ import {
   probeCodexLaunch,
   resolveCliCommandAvailability,
   createStubDirectProviderAdapter,
-  createVerifierOnlyAdapter
 } from "@martin/adapters";
 import { runMartin, classifyRoute, resolveModelForTier, getHistoricalDirectSuccessRate, getPreference, recordPreference, type MartinAdapter } from "@martin/core";
 import {
@@ -1015,7 +1014,6 @@ export function renderCliHelp(): string {
     "  --verify <cmd>           Shell command to run as the verifier after each attempt.",
     "  --verify-timeout-ms <n>  Verifier timeout in milliseconds.",
     "  --proof                  Run in no-spend proof mode (explicit opt-in).",
-    "  --verify-only            Skip the coding adapter and run the verifier only.",
     "  --unsafe-allow-unguarded-run",
     "                           Bypass doctor/preflight run-gate checks for this invocation only.",
     "  --allow-path <glob>      Restrict agent writes to this path pattern (repeatable).",
@@ -1064,8 +1062,7 @@ async function executeRunCommand(
   });
   const effectiveMutationMode = resolvedRequest.mutationMode;
   const receiptScope = buildCliReceiptScope(cliEnvironment);
-  const engineRequired =
-    effectiveMutationMode !== "verify_only" && cliEnvironment.liveMode === "live";
+  const engineRequired = cliEnvironment.liveMode === "live";
   const preRunWarnings: string[] = [];
 
   if (engineRequired && !resolvedRequest.unsafeAllowUnguardedRun) {
@@ -2445,7 +2442,7 @@ async function executePreflightCommand(
     request.verificationPlan.length > 0
       ? request.verificationPlan
       : resolvedGuardrails.verifierRules;
-  const engineRequired = request.mutationMode !== "verify_only" && environment.liveMode === "live";
+  const engineRequired = environment.liveMode === "live";
   const receiptScope = buildCliReceiptScope(environment);
 
   const workingDirectoryExists = await stat(environment.workingDirectory).then(() => true).catch(() => false);
@@ -3339,9 +3336,6 @@ function parseRunRequest(rest: string[]): RunCommandRequest {
         request.runsDir = next;
         index += 1;
         break;
-      case "--verify-only":
-        request.mutationMode = "verify_only";
-        break;
       case "--proof":
         request.liveMode = "proof";
         break;
@@ -3962,13 +3956,6 @@ function selectAdapter(
   // Use auto-selected model when no explicit --model flag was given.
   // autoSelectModel comes from resolveModelForTier(route.recommendedModelTier, engine).
   const effectiveModel = modelOverride ?? autoSelectModel;
-
-  if (mutationMode === "verify_only") {
-    return createVerifierOnlyAdapter({
-      workingDirectory,
-      ...(verifyTimeoutMs !== undefined ? { verifyTimeoutMs } : {})
-    });
-  }
 
   if (liveMode === "proof") {
     return createStubDirectProviderAdapter({

--- a/packages/cli/src/workflow-state.ts
+++ b/packages/cli/src/workflow-state.ts
@@ -109,14 +109,7 @@ export async function recordCliWorkflowStep(input: CliWorkflowStepInput): Promis
 }
 
 export async function evaluateCliRunGate(input: CliRunGateInput): Promise<CliRunGateResult> {
-  if (input.mutationMode === "verify_only") {
-    return {
-      allowed: true,
-      nextCommand: "martin-loop run --verify-only",
-      message: "verify_only mode does not require a governed coding receipt chain.",
-      missingSteps: []
-    };
-  }
+
 
   const state = await readWorkflowState(input.runsRoot);
   const cliState = state.cli ?? {};

--- a/packages/cli/tests/cli.test.ts
+++ b/packages/cli/tests/cli.test.ts
@@ -448,72 +448,6 @@ describe("executeCli", () => {
     }
   });
 
-  it("supports verify-only runs without invoking a coding adapter", { timeout: 30_000 }, async () => {
-    const directory = await mkdtemp(join(tmpdir(), "martin-cli-verify-only-"));
-
-    try {
-      const result = await withIsolatedRunsEnv(directory, () =>
-        executeCli([
-          "--json",
-          "run",
-          "--objective",
-          "Verify the contracts package without edits",
-          "--engine",
-          "codex",
-          "--verify-only",
-          "--verify",
-          `"${process.execPath}" -e "process.exit(0)"`,
-          "--cwd",
-          directory,
-          "--allow-path",
-          "packages/contracts/**"
-        ])
-      );
-
-      expect(result.exitCode).toBe(0);
-
-      const payload = JSON.parse(result.stdout);
-
-      expect(payload.decision.lifecycleState).toBe("completed");
-      expect(payload.loop.lifecycleState).toBe("completed");
-      expect(payload.loop.task.mutationMode).toBe("verify_only");
-      expect(payload.loop.cost.actualUsd).toBe(0);
-    } finally {
-      await rm(directory, { force: true, recursive: true });
-    }
-  });
-
-  it("persists verifier timeout on governed runs", { timeout: 30_000 }, async () => {
-    const directory = await mkdtemp(join(tmpdir(), "martin-cli-verify-timeout-"));
-
-    try {
-      const result = await withIsolatedRunsEnv(directory, () =>
-        executeCli([
-          "--json",
-          "run",
-          "--objective",
-          "Verify timeout persistence",
-          "--engine",
-          "codex",
-          "--verify-only",
-          "--verify",
-          `"${process.execPath}" -e "process.exit(0)"`,
-          "--verify-timeout-ms",
-          "240000",
-          "--cwd",
-          directory
-        ])
-      );
-
-      expect(result.exitCode).toBe(0);
-
-      const payload = JSON.parse(result.stdout);
-      expect(payload.loop.task.verificationTimeoutMs).toBe(240000);
-    } finally {
-      await rm(directory, { force: true, recursive: true });
-    }
-  });
-
   it("supports --proof runs as no-spend proof executions without rewriting mutation mode", { timeout: 30_000 }, async () => {
     const directory = await mkdtemp(join(tmpdir(), "martin-cli-proof-mode-"));
 
@@ -538,7 +472,6 @@ describe("executeCli", () => {
       expect(payload.environment.liveMode).toBe("proof");
       expect(payload.loop.cost.actualUsd).toBe(0);
       expect(payload.loop.task.mutationMode).toBeUndefined();
-      expect(payload.loop.attempts[0]?.adapterId).not.toBe("direct:verifier:verify-only");
       expect(["completed", "diminishing_returns"]).toContain(payload.loop.lifecycleState);
     } finally {
       await rm(directory, { force: true, recursive: true });

--- a/packages/cli/tests/proof-card.test.ts
+++ b/packages/cli/tests/proof-card.test.ts
@@ -55,24 +55,16 @@ describe("Martin proof cards", () => {
     expect(markdown).not.toContain("Martin stopped Ralph here.");
   });
 
-  it("fails closed for proof and verifier-only runs", () => {
+  it("fails closed for proof runs", () => {
     const proofCard = buildMartinProofCard({
       ...completeInput(),
       runMode: "proof"
-    });
-    const verifyOnlyCard = buildMartinProofCard({
-      ...completeInput(),
-      runMode: "verify_only"
     });
 
     expect(renderMartinProofCardMarkdown(proofCard)).toContain(
       "Proof or verifier-only runs are evidence boundaries, not real Martin mutation receipts."
     );
-    expect(renderMartinProofCardMarkdown(verifyOnlyCard)).toContain(
-      "Proof or verifier-only runs are evidence boundaries, not real Martin mutation receipts."
-    );
     expect(proofCard.proofVerdict).toBe("EVIDENCE_BOUNDARY");
-    expect(verifyOnlyCard.proofVerdict).toBe("EVIDENCE_BOUNDARY");
   });
 
   it("fails closed when receipt integrity is unavailable", () => {

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -78,7 +78,7 @@ export type ExecutionProfile =
   | "staging_controlled"
   | "research_untrusted";
 
-export type MutationMode = "edit" | "verify_only";
+export type MutationMode = "edit";
 
 export interface ApprovalPolicy {
   dependencyAdds?: boolean;

--- a/packages/core/src/compiler.ts
+++ b/packages/core/src/compiler.ts
@@ -62,16 +62,10 @@ export function compilePromptPacket(request: CompilerAdapterRequest): PromptPack
     .filter((a) => a.failureClass && a.intervention)
     .map((a) => `${a.failureClass}:${a.intervention}`);
 
-  const guidanceParts: string[] =
-    request.context.mutationMode === "verify_only"
-      ? [
-          "Do not modify files.",
-          "Run the verifier only and report whether it passed."
-        ]
-      : [
-          "Only modify files directly required to satisfy the contract.",
-          "Do not touch files outside the allowed paths."
-        ];
+  const guidanceParts: string[] = [
+    "Only modify files directly required to satisfy the contract.",
+    "Do not touch files outside the allowed paths."
+  ];
 
   if (request.context.allowedPaths && request.context.allowedPaths.length > 0) {
     guidanceParts.push(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -583,7 +583,6 @@ export async function runMartin(input: RunMartinInput): Promise<RunMartinResult>
   let currentAdapterIndex = 0;
   let currentAdapter = adapterChain[currentAdapterIndex] ?? input.adapter;
   let useCompressedContext = false;
-  const isVerifyOnly = input.task.mutationMode === "verify_only";
   const executionProfile = resolveExecutionProfile({
     executionProfile: input.task.executionProfile,
     allowedNetworkDomains: input.task.allowedNetworkDomains
@@ -1205,109 +1204,7 @@ export async function runMartin(input: RunMartinInput): Promise<RunMartinResult>
     const changedFileEvidenceAvailable =
       result.execution?.changedFiles !== undefined || changedFiles.length > 0;
     const isVerifierOnlyAdapter = executingAdapter.adapterId === "direct:verifier:verify-only";
-    const patchTruthCountsEdits =
-      !isVerifyOnly && !isVerifierOnlyAdapter && changedFileEvidenceAvailable;
-
-    if (isVerifyOnly && changedFiles.length > 0) {
-      const patchDecision = evaluatePatchDecision({
-        verificationPassed: verification.passed,
-        previousVerifierScore,
-        verifierScore: verification.passed ? 1 : 0,
-        scopeViolationCount: changedFiles.length,
-        changedFileCount: changedFiles.length,
-        diffNovelty: 1,
-        diffStats: result.execution?.diffStats,
-        costUsd: getUsageUsd(result.usage),
-        summary: result.summary
-      });
-      const verifyOnlyExitDecision: ExitDecision = {
-        shouldExit: true,
-        lifecycleState: "human_escalation",
-        status: "exited",
-        reason: "Verify-only mode forbids file changes.",
-        failureClass: "safety_leash_blocked",
-        safetySurface: "filesystem",
-        reasonCode: "verify_only_write_attempt"
-      };
-      const rollbackOutcome = await restoreRollbackBoundary({
-        repoRoot: request.context.repoRoot,
-        boundary: rollbackBoundary,
-        restoredAt: attemptCompletedAt,
-        decision: patchDecision.decision
-      });
-
-      if (input.store) {
-        const verifyOnlyViolation: SafetyViolation = {
-          kind: "path_not_allowed",
-          message: `Verify-only mode forbids changed files: ${changedFiles.join(", ")}`,
-          file: changedFiles[0]
-        };
-        await input.store.writeAttemptArtifacts(loop.loopId, currentAttemptIndex, {
-          compiledContext,
-          leash: createLeashArtifact(
-            {
-              surface: "filesystem",
-              reason: verifyOnlyExitDecision.reason,
-              violations: [verifyOnlyViolation]
-            },
-            currentAttemptIndex
-          ),
-          patchScore: patchDecision.score,
-          patchDecision: toPatchDecisionArtifact(patchDecision),
-          ...(rollbackBoundary ? { rollbackBoundary } : {}),
-          ...(rollbackOutcome ? { rollbackOutcome } : {})
-        });
-        await input.store.appendLedger(
-          loop.loopId,
-          makeLedgerEvent({
-            kind: "safety.violations_found",
-            runId: loop.loopId,
-            attemptIndex: currentAttemptIndex,
-            payload: {
-              surface: "filesystem",
-              blocked: true,
-              attemptIndex: currentAttemptIndex,
-              violations: [
-                {
-                  kind: "path_not_allowed",
-                  message: verifyOnlyExitDecision.reason,
-                  files: changedFiles
-                }
-              ]
-            }
-          })
-        );
-        await input.store.appendLedger(
-          loop.loopId,
-          makeLedgerEvent({
-            kind: "attempt.discarded",
-            runId: loop.loopId,
-            attemptIndex: currentAttemptIndex,
-            payload: {
-              decision: patchDecision.decision,
-              reason: patchDecision.summary,
-              reasonCodes: patchDecision.reasonCodes,
-              score: patchDecision.score.score
-            }
-          })
-        );
-        await input.store.appendLedger(
-          loop.loopId,
-          makeLedgerEvent({
-            kind: "run.exited",
-            runId: loop.loopId,
-            payload: createRunExitPayload(verifyOnlyExitDecision)
-          })
-        );
-      }
-
-      const finalizedLoop = finalizeLoop(loop, verifyOnlyExitDecision, now(), idFactory);
-      await persistLoopRecordIfSupported(input.store, finalizedLoop);
-      return {
-        loop: finalizedLoop,
-        decision: verifyOnlyExitDecision
-      };
-    }
+    const patchTruthCountsEdits = !isVerifierOnlyAdapter && changedFileEvidenceAvailable;
 
     const filesystemDecision = evaluateFilesystemLeash({
       repoRoot: request.context.repoRoot,

--- a/packages/core/tests/policy-compiler.test.ts
+++ b/packages/core/tests/policy-compiler.test.ts
@@ -48,7 +48,7 @@ describe("compileExecutionPolicy", () => {
         policyProfile: "balanced",
         telemetryDestination: "control-plane",
         repoRoot: "C:/repo",
-        mutationMode: "verify_only",
+        mutationMode: "edit",
         allowedPaths: ["src/**"],
         deniedPaths: ["docs/**"],
         acceptanceCriteria: ["Verifier stays green."],
@@ -70,7 +70,7 @@ describe("compileExecutionPolicy", () => {
     });
     expect(policy.task).toEqual({
       verificationPlan: ["pnpm test", "pnpm lint"],
-      mutationMode: "verify_only",
+      mutationMode: "edit",
       repoRoot: "C:/repo",
       allowedPaths: ["src/**"],
       deniedPaths: ["docs/**"],

--- a/packages/core/tests/runtime.test.ts
+++ b/packages/core/tests/runtime.test.ts
@@ -712,68 +712,6 @@ describe("runMartin", () => {
     expect(artifact.verdict).toBe("clean");
   });
 
-  it("allows verifier-only runs to complete without code changes when verification passes", async () => {
-    const adapter: MartinAdapter = {
-      adapterId: "direct:verify-only",
-      kind: "direct-provider",
-      label: "Verify only adapter",
-      metadata: {
-        providerId: "openai",
-        model: "gpt-5-mini"
-      },
-      async execute() {
-        return {
-          status: "completed",
-          summary: "Ran the verifier without making edits.",
-          usage: {
-            actualUsd: 0,
-            tokensIn: 0,
-            tokensOut: 0
-          },
-          verification: {
-            passed: true,
-            summary: "Verification passed without changes."
-          },
-          execution: {
-            changedFiles: []
-          }
-        };
-      }
-    };
-
-    const result = await runMartin({
-      workspaceId: "ws_ops",
-      projectId: "proj_runtime",
-      task: {
-        title: "Verify the contracts package",
-        objective: "Run the verifier only and do not edit files.",
-        verificationPlan: ["pnpm --filter @martin/contracts test"],
-        mutationMode: "verify_only",
-        allowedPaths: ["packages/contracts/**"]
-      },
-      budget: {
-        maxUsd: 10,
-        softLimitUsd: 6,
-        maxIterations: 1,
-        maxTokens: 2_000
-      },
-      adapter,
-      now: createTimestampSource([
-        "2026-05-11T12:00:00.000Z",
-        "2026-05-11T12:00:01.000Z",
-        "2026-05-11T12:00:02.000Z",
-        "2026-05-11T12:00:03.000Z",
-        "2026-05-11T12:00:04.000Z"
-      ]),
-      idFactory: createIdFactory()
-    });
-
-    expect(result.decision.lifecycleState).toBe("completed");
-    expect(result.loop.lifecycleState).toBe("completed");
-    expect(result.loop.attempts).toHaveLength(1);
-    expect(result.loop.attempts[0]?.failureClass).toBeUndefined();
-  });
-
   it("allows proof adapters to complete without edits when verification passes", async () => {
     const adapter: MartinAdapter = {
       adapterId: "direct:verifier:verify-only",


### PR DESCRIPTION
## Summary

- Removes the \`--verify-only\` CLI flag — no bypass path to skip the coding adapter
- Removes \`verify_only\` from the \`MutationMode\` contracts type
- Removes verifier-only adapter dispatch from CLI arg parser and adapter selection
- Removes 2 test cases that exercised the removed flag
- Removes dead \`verify_only\` branches in core, adapters, and cli caught by TypeScript

The \`createVerifierOnlyAdapter\` implementation is retained in \`@martin/adapters\` because the MCP server uses it internally for proof mode. The public CLI has no path to reach it.

## Test plan

- [ ] CI passes on all 3 platforms
- [ ] \`martin-loop run --verify-only\` produces an unknown flag error
- [ ] \`--proof\` mode still works (separate code path, unaffected)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * None
* **Bug Fixes**
  * Removed the special “verify-only” execution lane so runs, preflights, and gating follow one consistent workflow.
  * Made prompt guidance and file-path constraints always apply, improving edit-scope correctness.
* **Refactor**
  * Simplified CLI and runtime mode handling around verification flows.
  * Restricted supported `mutationMode` values to `edit`.
* **Tests**
  * Updated and narrowed test coverage to align with the new run and proof behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->