### PR TITLE
feat: martin plan/execute, mode-status MCP resource, consent prompt, star/feedback flow

### DIFF
--- a/packages/cli/src/feedback.ts
+++ b/packages/cli/src/feedback.ts
@@ -1,0 +1,307 @@
+import { appendFileSync } from "node:fs";
+import * as readline from "node:readline";
+import { martinFilePath, ensureMartinDir } from "./home-dir.js";
+import { readRunStats, writeRunStats } from "./run-stats.js";
+
+const FEEDBACK_FILE       = martinFilePath("feedback.jsonl");
+const DESIGN_PARTNER_FILE = martinFilePath("design-partners.jsonl");
+const WEB3FORMS_KEY       = process.env["MARTIN_WEB3FORMS_KEY"]
+  ?? "03bc4ccb-1338-44c9-b140-7c4dd484d1ab";
+const ENDPOINT = "https://api.web3forms.com/submit";
+
+// ─── Trigger logic ────────────────────────────────────────────────────────────
+
+export function shouldShowRating(run: number, lastAt: number): boolean {
+  if (run < 10) return false;
+  return (run - lastAt) >= 10;
+}
+
+export function shouldShowFeatureRequest(run: number, lastAt: number): boolean {
+  if (run < 20) return false;
+  return (run - lastAt) >= 20;
+}
+
+export function shouldShowDesignPartner(run: number, lastAt: number, converted: boolean): boolean {
+  if (converted) return false;
+  if (run < 10) return false;
+  if (lastAt === 0 && run >= 30) return true;
+  return lastAt > 0 && (run - lastAt) >= 30;
+}
+
+// ─── Main entry point ─────────────────────────────────────────────────────────
+
+export async function maybeShowFeedbackFlow(runCount: number): Promise<void> {
+  const stats = readRunStats();
+  if (stats.feedbackOptOut) return;
+
+  let askedSomething = false;
+  let rating = 0;
+  let highEngagement = false;
+
+  if (shouldShowRating(runCount, stats.lastFeedbackAtRun)) {
+    rating = await showRatingPrompt(runCount, stats.martinVersion, stats.totalSuccessfulRuns);
+    stats.lastFeedbackAtRun = runCount;
+    askedSomething = true;
+    highEngagement = rating >= 4;
+  }
+
+  if (shouldShowFeatureRequest(runCount, stats.lastFeatureRequestAtRun)) {
+    await showFeatureRequestPrompt(runCount, stats.martinVersion);
+    stats.lastFeatureRequestAtRun = runCount;
+    askedSomething = true;
+  }
+
+  const triggerDesignPartner =
+    (highEngagement && shouldShowDesignPartner(runCount, stats.lastDesignPartnerAskAtRun, stats.designPartnerConverted))
+    || shouldShowDesignPartner(runCount, stats.lastDesignPartnerAskAtRun, stats.designPartnerConverted);
+
+  if (triggerDesignPartner) {
+    const converted = await showDesignPartnerPrompt(runCount, stats.martinVersion);
+    stats.lastDesignPartnerAskAtRun = runCount;
+    if (converted) stats.designPartnerConverted = true;
+    askedSomething = true;
+  }
+
+  if (askedSomething) writeRunStats(stats);
+  if (askedSomething) console.log("");
+}
+
+// ─── Rating prompt ────────────────────────────────────────────────────────────
+
+async function showRatingPrompt(runCount: number, version: string, totalRuns: number): Promise<number> {
+  console.log("");
+  console.log("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+  console.log("  30 seconds of feedback — genuinely helps");
+  console.log("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+  console.log("");
+  console.log("  How would you rate MartinLoop so far?");
+  console.log("");
+  console.log("  1  Not working for me");
+  console.log("  2  Has potential but needs work");
+  console.log("  3  Solid, does the job");
+  console.log("  4  Really useful, part of my workflow");
+  console.log("  5  Can't imagine working without it");
+  console.log("");
+  process.stdout.write("  [1–5 or Enter to skip]\n  > ");
+
+  const ratingInput = await readSingleLine();
+  const rating = parseInt(ratingInput.trim(), 10);
+
+  if (!ratingInput.trim() || isNaN(rating) || rating < 1 || rating > 5) {
+    console.log("");
+    return 0;
+  }
+
+  let followUp = "";
+
+  if (rating >= 4) {
+    console.log("");
+    process.stdout.write("  What's the single most valuable thing MartinLoop does for you?\n  (or Enter to skip)\n  > ");
+    followUp = await readSingleLine();
+    console.log("");
+    console.log("  💚  That's exactly what it's built for. Thank you.");
+  } else {
+    console.log("");
+    process.stdout.write("  What's the biggest thing holding it back for you?\n  (or Enter to skip)\n  > ");
+    followUp = await readSingleLine();
+    console.log("");
+    console.log("  Noted — that feedback goes directly to the team.");
+    console.log("  We'll use it. Thank you for being honest.");
+  }
+
+  const entry = {
+    type: "rating",
+    runCount,
+    totalRuns,
+    rating,
+    followUp: followUp.trim(),
+    martinVersion: version,
+    platform: process.platform,
+    ts: new Date().toISOString()
+  };
+
+  writeLocal(FEEDBACK_FILE, entry);
+  await sendToWeb3Forms({
+    subject: `MartinLoop Feedback — ${rating}/5 — Run #${runCount}`,
+    rating,
+    comment: followUp.trim() || "(no comment)",
+    run_count: runCount,
+    total_runs: totalRuns,
+    martin_version: version,
+    platform: process.platform
+  });
+
+  return rating;
+}
+
+// ─── Feature request prompt ───────────────────────────────────────────────────
+
+async function showFeatureRequestPrompt(runCount: number, version: string): Promise<void> {
+  console.log("");
+  console.log("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+  console.log("  One question about what comes next");
+  console.log("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+  console.log("");
+  process.stdout.write(
+    "  What's one thing MartinLoop doesn't do yet\n" +
+    "  that would make you recommend it to your team?\n" +
+    "  (or Enter to skip)\n  > "
+  );
+
+  const feature = await readSingleLine();
+  if (!feature.trim()) return;
+
+  console.log("");
+  console.log("  Logged. This goes straight to the roadmap.");
+
+  writeLocal(FEEDBACK_FILE, {
+    type: "feature_request",
+    runCount,
+    feature: feature.trim(),
+    martinVersion: version,
+    platform: process.platform,
+    ts: new Date().toISOString()
+  });
+
+  await sendToWeb3Forms({
+    subject: `MartinLoop Feature Request — Run #${runCount}`,
+    feature_request: feature.trim(),
+    run_count: runCount,
+    martin_version: version,
+    platform: process.platform
+  });
+}
+
+// ─── Design partner prompt ────────────────────────────────────────────────────
+
+async function showDesignPartnerPrompt(runCount: number, version: string): Promise<boolean> {
+  console.log("");
+  console.log("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+  console.log("  One more thing — if you're open to it");
+  console.log("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+  console.log("");
+  console.log("  We're building the growth version of MartinLoop —");
+  console.log("  a full governance platform with ROI intelligence,");
+  console.log("  team dashboards, spend forecasting, and compliance");
+  console.log("  audit trails for engineering and finance teams.");
+  console.log("");
+  console.log("  Design partners get:");
+  console.log("  → Beta access before public release");
+  console.log("  → Direct input on the roadmap");
+  console.log("  → Founder-level support and onboarding");
+  console.log("  → Locked pricing before we go paid");
+  console.log("");
+  process.stdout.write("  Are you open to being a design partner? [Y/n]\n  > ");
+
+  const answer = await readSingleLine();
+  if (answer.trim().toLowerCase() !== "y") {
+    if (answer.trim() !== "") {
+      console.log("");
+      console.log("  No problem — appreciate you using MartinLoop.");
+    }
+    return false;
+  }
+
+  console.log("");
+  process.stdout.write("  First name:\n  > ");
+  const firstName = await readSingleLine();
+
+  process.stdout.write("  Last name:\n  > ");
+  const lastName = await readSingleLine();
+
+  process.stdout.write("  Work email:\n  > ");
+  const email = await readSingleLine();
+
+  process.stdout.write("  Company name:\n  > ");
+  const company = await readSingleLine();
+
+  console.log("");
+  console.log("  Last one — what would you expect to pay for a");
+  console.log("  full governance platform for your engineering team?");
+  console.log("");
+  console.log("  A  Under $100 / month");
+  console.log("  B  $100 – $500 / month");
+  console.log("  C  $500 – $2,000 / month");
+  console.log("  D  $2,000+ / month");
+  console.log("  E  Prefer not to say");
+  console.log("");
+  process.stdout.write("  [A/B/C/D/E]\n  > ");
+
+  const pricingInput = await readSingleLine();
+  const pricingMap: Record<string, string> = {
+    a: "Under $100/month",
+    b: "$100–$500/month",
+    c: "$500–$2,000/month",
+    d: "$2,000+/month",
+    e: "Prefer not to say"
+  };
+  const pricing = pricingMap[pricingInput.trim().toLowerCase()] ?? "Not answered";
+
+  console.log("");
+  console.log("  ✅  You're in.");
+  console.log("");
+  console.log(`  We'll reach out to ${firstName.trim()} at ${email.trim()} soon.`);
+  console.log("  In the meantime, keep shipping — every governed");
+  console.log("  run makes the platform smarter.");
+  console.log("");
+  console.log("  — Keesan & Gobi, MartinLoop");
+
+  const entry = {
+    type: "design_partner",
+    runCount,
+    firstName: firstName.trim(),
+    lastName: lastName.trim(),
+    email: email.trim(),
+    company: company.trim(),
+    pricingExpectation: pricing,
+    martinVersion: version,
+    platform: process.platform,
+    ts: new Date().toISOString()
+  };
+
+  writeLocal(DESIGN_PARTNER_FILE, entry);
+  await sendToWeb3Forms({
+    subject: `🌟 MartinLoop Design Partner — ${firstName.trim()} ${lastName.trim()} @ ${company.trim()}`,
+    first_name: firstName.trim(),
+    last_name: lastName.trim(),
+    email: email.trim(),
+    company: company.trim(),
+    pricing_expectation: pricing,
+    run_count: runCount,
+    martin_version: version,
+    platform: process.platform
+  });
+
+  return true;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function writeLocal(file: string, entry: object): void {
+  ensureMartinDir();
+  appendFileSync(file, JSON.stringify(entry) + "\n", "utf-8");
+}
+
+async function sendToWeb3Forms(data: Record<string, unknown>): Promise<void> {
+  try {
+    const res = await fetch(ENDPOINT, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ access_key: WEB3FORMS_KEY, from_name: "MartinLoop CLI", ...data }),
+      signal: AbortSignal.timeout(5_000)
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  } catch {
+    // Silent fail — data already written locally
+  }
+}
+
+function readSingleLine(): Promise<string> {
+  return new Promise((resolve) => {
+    if (!process.stdin.isTTY) { resolve(""); return; }
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout, terminal: false });
+    const timeout = setTimeout(() => { rl.close(); resolve(""); }, 30_000);
+    rl.once("line", (line) => { clearTimeout(timeout); rl.close(); resolve(line); });
+    rl.once("close", () => { clearTimeout(timeout); resolve(""); });
+  });
+}

--- a/packages/cli/src/feedback.ts
+++ b/packages/cli/src/feedback.ts
@@ -5,8 +5,7 @@ import { readRunStats, writeRunStats } from "./run-stats.js";
 
 const FEEDBACK_FILE       = martinFilePath("feedback.jsonl");
 const DESIGN_PARTNER_FILE = martinFilePath("design-partners.jsonl");
-const WEB3FORMS_KEY       = process.env["MARTIN_WEB3FORMS_KEY"]
-  ?? "03bc4ccb-1338-44c9-b140-7c4dd484d1ab";
+const WEB3FORMS_KEY       = process.env["MARTIN_WEB3FORMS_KEY"] ?? "f77cbe5d-3993-4b09-b8df-c6da94523ae6";
 const ENDPOINT = "https://api.web3forms.com/submit";
 
 // ─── Trigger logic ────────────────────────────────────────────────────────────
@@ -194,11 +193,12 @@ async function showDesignPartnerPrompt(runCount: number, version: string): Promi
   process.stdout.write("  Are you open to being a design partner? [Y/n]\n  > ");
 
   const answer = await readSingleLine();
-  if (answer.trim().toLowerCase() !== "y") {
-    if (answer.trim() !== "") {
-      console.log("");
-      console.log("  No problem — appreciate you using MartinLoop.");
-    }
+  const normalized = answer.trim().toLowerCase();
+
+  // [Y/n] — Enter or "y" = yes; anything else = no
+  if (normalized !== "" && normalized !== "y") {
+    console.log("");
+    console.log("  No problem — appreciate you using MartinLoop.");
     return false;
   }
 
@@ -211,6 +211,14 @@ async function showDesignPartnerPrompt(runCount: number, version: string): Promi
 
   process.stdout.write("  Work email:\n  > ");
   const email = await readSingleLine();
+
+  // Basic email validation — skip signup if format is invalid
+  const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if (!emailPattern.test(email.trim())) {
+    console.log("");
+    console.log("  Invalid email — we weren't able to save your signup.");
+    return false;
+  }
 
   process.stdout.write("  Company name:\n  > ");
   const company = await readSingleLine();
@@ -261,7 +269,7 @@ async function showDesignPartnerPrompt(runCount: number, version: string): Promi
 
   writeLocal(DESIGN_PARTNER_FILE, entry);
   await sendToWeb3Forms({
-    subject: `🌟 MartinLoop Design Partner — ${firstName.trim()} ${lastName.trim()} @ ${company.trim()}`,
+    subject: `MartinLoop Design Partner — ${firstName.trim()} ${lastName.trim()} @ ${company.trim()}`,
     first_name: firstName.trim(),
     last_name: lastName.trim(),
     email: email.trim(),
@@ -283,14 +291,21 @@ function writeLocal(file: string, entry: object): void {
 }
 
 async function sendToWeb3Forms(data: Record<string, unknown>): Promise<void> {
+  if (WEB3FORMS_KEY.trim().length === 0) return; // Opt-out: set MARTIN_WEB3FORMS_KEY="" to disable
   try {
-    const res = await fetch(ENDPOINT, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ access_key: WEB3FORMS_KEY, from_name: "MartinLoop CLI", ...data }),
-      signal: AbortSignal.timeout(5_000)
-    });
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 5_000);
+    try {
+      const res = await fetch(ENDPOINT, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ access_key: WEB3FORMS_KEY, from_name: "MartinLoop CLI", ...data }),
+        signal: controller.signal
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    } finally {
+      clearTimeout(timeout);
+    }
   } catch {
     // Silent fail — data already written locally
   }

--- a/packages/cli/src/home-dir.ts
+++ b/packages/cli/src/home-dir.ts
@@ -1,0 +1,13 @@
+import { mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const MARTIN_HOME = join(homedir(), ".martin");
+
+export function martinFilePath(...segments: string[]): string {
+  return join(MARTIN_HOME, ...segments);
+}
+
+export function ensureMartinDir(): void {
+  mkdirSync(MARTIN_HOME, { recursive: true });
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -762,7 +762,7 @@ export function parseCliArguments(args: string[]): ParsedCliArguments {
       command: "plan",
       objective,
       ...(readOption(rest, "--verify") ? { verify: readOption(rest, "--verify") } : {}),
-      ...(readOption(rest, "--budget-usd") ? { budgetUsd: Number(readOption(rest, "--budget-usd")) } : {}),
+      ...(readOption(rest, "--budget-usd") ? { budgetUsd: toFiniteNumber(readOption(rest, "--budget-usd") ?? "") } : {}),
       ...(readOption(rest, "--cwd") ? { cwd: readOption(rest, "--cwd") } : {}),
       ...(readOption(rest, "--runs-dir") ? { runsDir: readOption(rest, "--runs-dir") } : {})
     };
@@ -777,8 +777,8 @@ export function parseCliArguments(args: string[]): ParsedCliArguments {
       command: "execute",
       objective,
       ...(readOption(rest, "--verify") ? { verify: readOption(rest, "--verify") } : {}),
-      ...(readOption(rest, "--budget-usd") ? { budgetUsd: Number(readOption(rest, "--budget-usd")) } : {}),
-      ...(readOption(rest, "--max-iterations") ? { maxIterations: Number(readOption(rest, "--max-iterations")) } : {}),
+      ...(readOption(rest, "--budget-usd") ? { budgetUsd: toFiniteNumber(readOption(rest, "--budget-usd") ?? "") } : {}),
+      ...(readOption(rest, "--max-iterations") ? { maxIterations: toFiniteNumber(readOption(rest, "--max-iterations") ?? "") } : {}),
       ...(readOption(rest, "--engine") === "codex" ? { engine: "codex" as const } : {}),
       ...(readOption(rest, "--engine") === "claude" ? { engine: "claude" as const } : {}),
       ...(readOption(rest, "--engine") === "gemini" ? { engine: "gemini" as const } : {}),

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -85,7 +85,7 @@ import {
   type IntegrityStatus
 } from "./run-store.js";
 import { CliCommandError, renderCliError, renderCliSuccess } from "./ux.js";
-import { evaluateCliRunGate, recordCliWorkflowStep } from "./workflow-state.js";
+import { evaluateCliRunGate, recordCliWorkflowStep, recordMcpPlanStep } from "./workflow-state.js";
 
 const require = createRequire(import.meta.url);
 const packageJson = require("../package.json") as { version: string };
@@ -392,6 +392,26 @@ type BadgeCommand = {
   runsDir?: string;
 };
 
+type PlanCommand = {
+  command: "plan";
+  objective: string;
+  verify?: string;
+  budgetUsd?: number;
+  cwd?: string;
+  runsDir?: string;
+};
+
+type ExecuteCommand = {
+  command: "execute";
+  objective: string;
+  verify?: string;
+  budgetUsd?: number;
+  maxIterations?: number;
+  engine?: "claude" | "codex" | "gemini" | "openai";
+  cwd?: string;
+  runsDir?: string;
+};
+
 type Under3BenchFixture = {
   suiteId: string;
   label: string;
@@ -475,7 +495,9 @@ export type ParsedCliArguments =
   | CleanCommand
   | ChallengeCommand
   | ShareCommand
-  | BadgeCommand;
+  | BadgeCommand
+  | PlanCommand
+  | ExecuteCommand;
 
 export async function executeCli(args: string[]): Promise<{
   exitCode: number;
@@ -571,6 +593,10 @@ export async function executeCli(args: string[]): Promise<{
         return await executeShareCommand(parsed, outputMode);
       case "badge":
         return await executeBadgeCommand(parsed, outputMode);
+      case "plan":
+        return await executePlanCommand(parsed, outputMode);
+      case "execute":
+        return await executeExecuteCommand(parsed, outputMode);
     }
   } catch (error) {
     return renderCliError(outputMode, error);
@@ -722,6 +748,41 @@ export function parseCliArguments(args: string[]): ParsedCliArguments {
   if (command === "start" || command === "tour") {
     return {
       command: "start",
+      ...(readOption(rest, "--cwd") ? { cwd: readOption(rest, "--cwd") } : {}),
+      ...(readOption(rest, "--runs-dir") ? { runsDir: readOption(rest, "--runs-dir") } : {})
+    };
+  }
+
+  if (command === "plan") {
+    const objective = rest[0] && !rest[0].startsWith("--") ? rest[0] : readOption(rest, "--objective") ?? "";
+    if (!objective) {
+      return { command: "help" };
+    }
+    return {
+      command: "plan",
+      objective,
+      ...(readOption(rest, "--verify") ? { verify: readOption(rest, "--verify") } : {}),
+      ...(readOption(rest, "--budget-usd") ? { budgetUsd: Number(readOption(rest, "--budget-usd")) } : {}),
+      ...(readOption(rest, "--cwd") ? { cwd: readOption(rest, "--cwd") } : {}),
+      ...(readOption(rest, "--runs-dir") ? { runsDir: readOption(rest, "--runs-dir") } : {})
+    };
+  }
+
+  if (command === "execute") {
+    const objective = rest[0] && !rest[0].startsWith("--") ? rest[0] : readOption(rest, "--objective") ?? "";
+    if (!objective) {
+      return { command: "help" };
+    }
+    return {
+      command: "execute",
+      objective,
+      ...(readOption(rest, "--verify") ? { verify: readOption(rest, "--verify") } : {}),
+      ...(readOption(rest, "--budget-usd") ? { budgetUsd: Number(readOption(rest, "--budget-usd")) } : {}),
+      ...(readOption(rest, "--max-iterations") ? { maxIterations: Number(readOption(rest, "--max-iterations")) } : {}),
+      ...(readOption(rest, "--engine") === "codex" ? { engine: "codex" as const } : {}),
+      ...(readOption(rest, "--engine") === "claude" ? { engine: "claude" as const } : {}),
+      ...(readOption(rest, "--engine") === "gemini" ? { engine: "gemini" as const } : {}),
+      ...(readOption(rest, "--engine") === "openai" ? { engine: "openai" as const } : {}),
       ...(readOption(rest, "--cwd") ? { cwd: readOption(rest, "--cwd") } : {}),
       ...(readOption(rest, "--runs-dir") ? { runsDir: readOption(rest, "--runs-dir") } : {})
     };
@@ -1306,6 +1367,17 @@ async function executeRunCommand(
       `Persisted run artifacts could not be written: ${error instanceof Error ? error.message : String(error)}`
     );
   });
+
+  if (result.loop.status === "completed" && result.loop.lifecycleState === "completed") {
+    try {
+      const { recordSuccessfulRun } = await import("./run-stats.js");
+      const { maybeShowStarPrompt } = await import("./star-prompt.js");
+      const { maybeShowFeedbackFlow } = await import("./feedback.js");
+      const stats = recordSuccessfulRun(packageJson.version);
+      await maybeShowStarPrompt(stats.totalSuccessfulRuns);
+      await maybeShowFeedbackFlow(stats.totalSuccessfulRuns);
+    } catch { /* never block output for engagement prompts */ }
+  }
 
   const costProvenance = readCostProvenance(result.loop);
   const successCallToAction = buildRunSuccessCallToAction(result.loop);
@@ -1932,8 +2004,22 @@ async function executeStartCommand(
       "",
       modeConfigured
         ? `Mode: ${currentMode} (change with martin mode auto|plan|edits)`
-        : "Mode: automode recommended — martin mode auto (governs autonomously, best for most work)",
+        : "Mode: not set — choose how MartinLoop interacts before your first governed run",
       "",
+      ...(!modeConfigured ? [
+        "── Consent: Choose Your Working Mode ──",
+        "  auto   — Governs autonomously: estimate → preflight → run → receipt.",
+        "           Best for most work. MartinLoop acts without per-step approval.",
+        "  plan   — Shows the plan before executing. You approve each step.",
+        "  edits  — Shows each file change before writing. Maximum control.",
+        "",
+        "  $ martin mode auto     # recommended",
+        "  $ martin mode plan     # approval required",
+        "  $ martin mode edits    # per-edit review",
+        "",
+        "  Runs are blocked until a mode is set or you explicitly accept auto.",
+        ""
+      ] : []),
       "Environment",
       `  Host:       ${detectedIDE.host}`,
       `  Verifier:   ${snapshot.verifier.command}${snapshot.verifier.detected ? "" : " (default)"}`,
@@ -2989,6 +3075,91 @@ async function executeModeCommand(
     ],
     quiet: command.mode
   });
+}
+
+async function executePlanCommand(
+  command: Extract<ParsedCliArguments, { command: "plan" }>,
+  outputMode: MartinOutputMode
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  const environment = resolveCliEnvironment({ cwd: command.cwd, runsDir: command.runsDir });
+  const receiptScope = buildCliReceiptScope(environment);
+
+  // Scope the plan to what is known: objective, optional verifier, optional budget.
+  const verificationPlan = command.verify ? [command.verify] : [];
+  const budgetUsd = command.budgetUsd ?? 5;
+
+  // Record plan step into the mcp section so governance-status and martin gate reflect it.
+  await recordMcpPlanStep({
+    runsRoot: environment.runsRoot,
+    workingDirectory: environment.workingDirectory,
+    objective: command.objective,
+    receiptScope
+  }).catch(() => {});
+
+  const planOutput = {
+    command: "plan",
+    objective: command.objective,
+    workingDirectory: environment.workingDirectory,
+    verificationPlan,
+    budget: {
+      maxUsd: budgetUsd,
+      note: "Confirm with `martin estimate` before spending."
+    },
+    proposedApproach: [
+      "Run `martin doctor` to confirm environment readiness.",
+      `Run \`martin estimate "${command.objective}" --budget-usd ${budgetUsd}\` to preview cost.`,
+      command.verify
+        ? `Run \`martin preflight "${command.objective}" --verify "${command.verify}"\` to lock the contract.`
+        : `Run \`martin preflight "${command.objective}"\` to lock the contract.`,
+      command.verify
+        ? `Run \`martin execute "${command.objective}" --verify "${command.verify}" --budget-usd ${budgetUsd}\` to govern execution.`
+        : `Run \`martin run "${command.objective}" --budget-usd ${budgetUsd}\` to govern execution.`
+    ],
+    nextStep: command.verify
+      ? `martin preflight "${command.objective}" --verify "${command.verify}"`
+      : `martin preflight "${command.objective}"`
+  };
+
+  return renderCliSuccess(outputMode, {
+    data: planOutput,
+    human: [
+      "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━",
+      " MartinLoop — Governed Plan",
+      "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━",
+      "",
+      `Objective: ${command.objective}`,
+      `Directory: ${environment.workingDirectory}`,
+      ...(verificationPlan.length > 0 ? [`Verifier:  ${verificationPlan[0]}`] : []),
+      `Budget:    $${budgetUsd} max`,
+      "",
+      "Proposed sequence:",
+      ...planOutput.proposedApproach.map((step, i) => `  ${i + 1}. ${step}`),
+      "",
+      "Plan receipt recorded. Next:",
+      `  $ ${planOutput.nextStep}`
+    ],
+    quiet: `plan:${command.objective.slice(0, 40)}`
+  });
+}
+
+async function executeExecuteCommand(
+  command: Extract<ParsedCliArguments, { command: "execute" }>,
+  outputMode: MartinOutputMode
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  // `martin execute` is a governed alias for `martin run` that enforces
+  // the plan→preflight→run sequence. It delegates to the run executor
+  // with the same arguments, relying on the run gate to block if preflight
+  // is missing.
+  const runRequest = parseRunRequest([
+    command.objective,
+    ...(command.verify ? ["--verify", command.verify] : []),
+    "--budget-usd", String(command.budgetUsd ?? 5),
+    ...(command.maxIterations ? ["--max-iterations", String(command.maxIterations)] : []),
+    ...(command.engine ? ["--engine", command.engine] : []),
+    ...(command.cwd ? ["--cwd", command.cwd] : []),
+    ...(command.runsDir ? ["--runs-dir", command.runsDir] : [])
+  ]);
+  return executeRunCommand(runRequest, outputMode);
 }
 
 async function executeCleanCommand(

--- a/packages/cli/src/run-stats.ts
+++ b/packages/cli/src/run-stats.ts
@@ -1,0 +1,54 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { martinFilePath, ensureMartinDir } from "./home-dir.js";
+
+export interface RunStats {
+  totalSuccessfulRuns: number;
+  lastStarPromptAtRun: number;
+  lastFeedbackAtRun: number;
+  lastFeatureRequestAtRun: number;
+  lastDesignPartnerAskAtRun: number;
+  designPartnerConverted: boolean;
+  starPromptOptOut: boolean;
+  feedbackOptOut: boolean;
+  telemetryOptIn: boolean | null;
+  martinVersion: string;
+}
+
+const STATS_FILE = martinFilePath("run-stats.json");
+
+function defaults(): RunStats {
+  return {
+    totalSuccessfulRuns: 0,
+    lastStarPromptAtRun: 0,
+    lastFeedbackAtRun: 0,
+    lastFeatureRequestAtRun: 0,
+    lastDesignPartnerAskAtRun: 0,
+    designPartnerConverted: false,
+    starPromptOptOut: false,
+    feedbackOptOut: false,
+    telemetryOptIn: null,
+    martinVersion: ""
+  };
+}
+
+export function readRunStats(): RunStats {
+  ensureMartinDir();
+  try {
+    return { ...defaults(), ...JSON.parse(readFileSync(STATS_FILE, "utf-8")) };
+  } catch {
+    return defaults();
+  }
+}
+
+export function writeRunStats(stats: RunStats): void {
+  ensureMartinDir();
+  writeFileSync(STATS_FILE, JSON.stringify(stats, null, 2), "utf-8");
+}
+
+export function recordSuccessfulRun(version: string): RunStats {
+  const stats = readRunStats();
+  stats.totalSuccessfulRuns += 1;
+  stats.martinVersion = version;
+  writeRunStats(stats);
+  return stats;
+}

--- a/packages/cli/src/star-prompt.ts
+++ b/packages/cli/src/star-prompt.ts
@@ -1,0 +1,84 @@
+import { readRunStats, writeRunStats } from "./run-stats.js";
+
+const STAR_URL = "https://github.com/Keesan12/martin-loop";
+
+export function shouldShowStarPrompt(runCount: number, lastShownAt: number): boolean {
+  if (runCount === 2) return true;
+  if (runCount > 2 && (runCount - lastShownAt) >= 25) return true;
+  return false;
+}
+
+export async function maybeShowStarPrompt(runCount: number): Promise<void> {
+  const stats = readRunStats();
+  if (stats.starPromptOptOut) return;
+  if (!shouldShowStarPrompt(runCount, stats.lastStarPromptAtRun)) return;
+
+  const isFirstTime = runCount === 2;
+
+  console.log("");
+  if (isFirstTime) {
+    console.log("✨  Two runs down. MartinLoop is doing its job.");
+    console.log("");
+    console.log("    It's open source and stays free because of the team");
+    console.log("    behind it. If it's earning a place in your workflow, a ⭐");
+    console.log("    on GitHub helps other developers find it:");
+  } else {
+    console.log(`✨  Run #${runCount} with MartinLoop — genuinely appreciate it.`);
+    console.log("    A quick ⭐ on GitHub helps other devs find this project:");
+  }
+
+  console.log(`\n    ${STAR_URL}\n`);
+  console.log("    [Enter] open in browser   [s] skip   [n] never ask again");
+  process.stdout.write("    > ");
+
+  const key = await readSingleKeypress();
+  console.log("");
+
+  if (key === "n" || key === "N") {
+    stats.starPromptOptOut = true;
+    console.log("    Got it — won't ask again. To re-enable: martin config set star-prompt on\n");
+  } else if (key === "\r" || key === "\n") {
+    try {
+      const { exec } = await import("node:child_process");
+      const cmd = process.platform === "win32" ? `start "" "${STAR_URL}"`
+        : process.platform === "darwin" ? `open "${STAR_URL}"`
+        : `xdg-open "${STAR_URL}"`;
+      exec(cmd);
+      console.log("    Opening GitHub... ⭐\n");
+    } catch {
+      console.log(`    Open this in your browser: ${STAR_URL}\n`);
+    }
+  }
+
+  stats.lastStarPromptAtRun = runCount;
+  writeRunStats(stats);
+}
+
+async function readSingleKeypress(): Promise<string> {
+  return new Promise((resolve) => {
+    const stdin = process.stdin;
+    if (!stdin.isTTY) { resolve(""); return; }
+
+    const prev = stdin.isRaw;
+    stdin.setRawMode(true);
+    stdin.resume();
+    stdin.setEncoding("utf-8");
+
+    const timeout = setTimeout(() => { cleanup(); resolve(""); }, 15_000);
+
+    const onData = (key: string) => {
+      if (key === "\u0003") { cleanup(); process.exit(0); }
+      cleanup();
+      resolve(key);
+    };
+
+    const cleanup = () => {
+      clearTimeout(timeout);
+      stdin.removeListener("data", onData);
+      stdin.setRawMode(prev ?? false);
+      stdin.pause();
+    };
+
+    stdin.on("data", onData);
+  });
+}

--- a/packages/cli/src/workflow-state.ts
+++ b/packages/cli/src/workflow-state.ts
@@ -89,6 +89,50 @@ export async function consumeFirstRunBanner(runsRoot: string): Promise<string | 
   ].join("\n");
 }
 
+// Write the "plan" step into the mcp section of the shared workflow-state.json.
+// The CLI and MCP packages share the same _martin/workflow-state.json file;
+// the CLI writes to `cli.*` steps and can also stamp `mcp.plan` so that
+// martin://agent/governance-status and martin gate reflect plan completion.
+export async function recordMcpPlanStep(input: {
+  runsRoot: string;
+  workingDirectory: string;
+  objective: string;
+  receiptScope?: ReceiptScope;
+}): Promise<void> {
+  const statePath = join(resolve(input.runsRoot), WORKFLOW_STATE_DIRECTORY, WORKFLOW_STATE_FILENAME);
+  let state: { version: 1; cli?: Record<string, unknown>; mcp?: Record<string, unknown> } = { version: 1 };
+  try {
+    const raw = await readFile(statePath, "utf8");
+    const parsed = JSON.parse(raw) as typeof state;
+    if (parsed.version === 1) {
+      state = parsed;
+    }
+  } catch { /* fresh state */ }
+
+  const normalized = process.platform === "win32" ? resolve(input.workingDirectory).toLowerCase() : resolve(input.workingDirectory);
+  const objectiveKey = input.objective.trim().replace(/\s+/gu, " ").toLowerCase();
+  const scopeKey = input.receiptScope
+    ? createHash("sha256").update(JSON.stringify({
+        invocationRoot: process.platform === "win32" ? resolve(input.receiptScope.invocationRoot ?? input.receiptScope.workingDirectory ?? "").toLowerCase() : resolve(input.receiptScope.invocationRoot ?? input.receiptScope.workingDirectory ?? ""),
+        workingDirectory: process.platform === "win32" ? resolve(input.receiptScope.workingDirectory ?? input.receiptScope.repoRoot ?? "").toLowerCase() : resolve(input.receiptScope.workingDirectory ?? input.receiptScope.repoRoot ?? ""),
+        repoRoot: process.platform === "win32" ? resolve(input.receiptScope.repoRoot ?? input.receiptScope.workingDirectory ?? "").toLowerCase() : resolve(input.receiptScope.repoRoot ?? input.receiptScope.workingDirectory ?? ""),
+        runsRoot: process.platform === "win32" ? resolve(input.receiptScope.runsRoot ?? "").toLowerCase() : resolve(input.receiptScope.runsRoot ?? "")
+      })).digest("hex").slice(0, 12)
+    : undefined;
+
+  state.mcp ??= {};
+  state.mcp["plan"] = {
+    step: "plan",
+    recordedAt: new Date().toISOString(),
+    workingDirectory: normalized,
+    objectiveKey,
+    ...(scopeKey ? { scopeKey } : {})
+  };
+
+  await mkdir(join(resolve(input.runsRoot), WORKFLOW_STATE_DIRECTORY), { recursive: true });
+  await writeFile(statePath, JSON.stringify(state, null, 2), "utf8");
+}
+
 export async function recordCliWorkflowStep(input: CliWorkflowStepInput): Promise<void> {
   const state = await readWorkflowState(input.runsRoot);
   const receipt: CliWorkflowReceipt = {

--- a/packages/cli/tests/star-feedback.test.ts
+++ b/packages/cli/tests/star-feedback.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { shouldShowStarPrompt } from "../src/star-prompt.js";
+import { shouldShowRating, shouldShowFeatureRequest, shouldShowDesignPartner } from "../src/feedback.js";
+
+describe("star prompt trigger logic", () => {
+  it("fires on run 2", () => {
+    expect(shouldShowStarPrompt(2, 0)).toBe(true);
+  });
+
+  it("does not fire on run 1", () => {
+    expect(shouldShowStarPrompt(1, 0)).toBe(false);
+  });
+
+  it("does not fire on run 3 if last shown at 2", () => {
+    expect(shouldShowStarPrompt(3, 2)).toBe(false);
+  });
+
+  it("fires again at run 27 if last shown at run 2", () => {
+    expect(shouldShowStarPrompt(27, 2)).toBe(true);
+  });
+});
+
+describe("rating trigger logic", () => {
+  it("does not fire before run 10", () => {
+    expect(shouldShowRating(9, 0)).toBe(false);
+  });
+
+  it("fires at run 10", () => {
+    expect(shouldShowRating(10, 0)).toBe(true);
+  });
+
+  it("fires at run 20 if last was run 10", () => {
+    expect(shouldShowRating(20, 10)).toBe(true);
+  });
+
+  it("does not fire at run 15 if last was run 10", () => {
+    expect(shouldShowRating(15, 10)).toBe(false);
+  });
+});
+
+describe("feature request trigger logic", () => {
+  it("does not fire before run 20", () => {
+    expect(shouldShowFeatureRequest(19, 0)).toBe(false);
+  });
+
+  it("fires at run 20", () => {
+    expect(shouldShowFeatureRequest(20, 0)).toBe(true);
+  });
+});
+
+describe("design partner trigger logic", () => {
+  it("does not fire if converted", () => {
+    expect(shouldShowDesignPartner(50, 0, true)).toBe(false);
+  });
+
+  it("fires at run 30 if never asked", () => {
+    expect(shouldShowDesignPartner(30, 0, false)).toBe(true);
+  });
+
+  it("does not fire before run 30", () => {
+    expect(shouldShowDesignPartner(29, 0, false)).toBe(false);
+  });
+});

--- a/packages/mcp/src/resources.ts
+++ b/packages/mcp/src/resources.ts
@@ -1,3 +1,7 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
 import type {
   ReadResourceResult,
   Resource,
@@ -47,7 +51,8 @@ export const MARTIN_STATIC_RESOURCE_URIS = {
   operatingRulesGuide: "martin://guides/operating-rules",
   publishReadinessGuide: "martin://guides/publish-readiness",
   governanceStatus: "martin://agent/governance-status",
-  memorySummary: "martin://agent/memory-summary"
+  memorySummary: "martin://agent/memory-summary",
+  modeStatus: "martin://agent/mode-status"
 } as const;
 
 export const MARTIN_RESOURCE_TEMPLATES: ResourceTemplate[] = [
@@ -231,6 +236,13 @@ export const MARTIN_STATIC_RESOURCES: Resource[] = [
     title: "Martin Memory Summary",
     description: "MartinLoop persistent memory: user preferences, consent signals, budget patterns, and behavioral observations aggregated over time. Read at session start to personalize recommendations.",
     mimeType: "application/json"
+  },
+  {
+    uri: MARTIN_STATIC_RESOURCE_URIS.modeStatus,
+    name: "martin_mode_status",
+    title: "Martin Mode Status",
+    description: "Current Martin working mode (auto, plan, or edits) and consent state. Read before starting agent work to confirm whether the user expects autonomous execution, plan approval, or per-edit review.",
+    mimeType: "application/json"
   }
 ];
 
@@ -324,6 +336,9 @@ export async function readMartinResource(
 
     case MARTIN_STATIC_RESOURCE_URIS.governanceStatus:
       return jsonResource(input.uri, withDiscoveryMetadata(await buildGovernanceStatusResource(context.runsRoot, context.workingDirectory), context.runsRoot));
+
+    case MARTIN_STATIC_RESOURCE_URIS.modeStatus:
+      return jsonResource(input.uri, withDiscoveryMetadata(await buildModeStatusResource(), context.runsRoot));
 
     case MARTIN_STATIC_RESOURCE_URIS.agentNextStep:
       return jsonResource(input.uri, withDiscoveryMetadata(await buildAgentNextStepResource(context.runsRoot), context.runsRoot));
@@ -1058,6 +1073,35 @@ Use this guide when reviewing whether the public MCP package is ready to publish
 - Distinguish local package validation from live registry readiness.
 - If a discovery helper exists but is not yet wired into the server, report that as an integration gap instead of treating the capability as fully shipped.
 `;
+}
+
+async function buildModeStatusResource(): Promise<Record<string, unknown>> {
+  let currentMode = "auto";
+  let modeConfigured = false;
+  try {
+    const config = JSON.parse(
+      await readFile(join(homedir(), ".martin", "config.json"), "utf8")
+    ) as { defaultMode?: string };
+    if (config.defaultMode) {
+      currentMode = config.defaultMode;
+      modeConfigured = true;
+    }
+  } catch { /* fresh install — default to auto */ }
+
+  return {
+    kind: "mode-status",
+    currentMode,
+    modeConfigured,
+    modes: {
+      auto: "MartinLoop governs autonomously — estimate, preflight, run, receipt without per-step approval.",
+      plan: "MartinLoop shows the proposed plan before executing. Agent waits for user approval.",
+      edits: "MartinLoop shows each file change before writing. Maximum human control."
+    },
+    agentGuidance: modeConfigured
+      ? `User has explicitly set mode to "${currentMode}". Respect this preference during the session.`
+      : "Mode not explicitly configured. Defaulting to auto. Suggest running `martin mode auto|plan|edits` to set a preference.",
+    changeCommand: "martin mode auto | plan | edits"
+  };
 }
 
 function withDiscoveryMetadata(value: unknown, runsRoot?: string): Record<string, unknown> {

--- a/packages/mcp/tests/mcp-discovery.test.ts
+++ b/packages/mcp/tests/mcp-discovery.test.ts
@@ -147,7 +147,8 @@ describe("Martin MCP discovery resources", () => {
       MARTIN_STATIC_RESOURCE_URIS.operatingRulesGuide,
       MARTIN_STATIC_RESOURCE_URIS.publishReadinessGuide,
       MARTIN_STATIC_RESOURCE_URIS.governanceStatus,
-      MARTIN_STATIC_RESOURCE_URIS.memorySummary
+      MARTIN_STATIC_RESOURCE_URIS.memorySummary,
+      MARTIN_STATIC_RESOURCE_URIS.modeStatus
     ]);
     expect(listedTemplates.resourceTemplates.map((template) => template.uriTemplate)).toEqual([
       "martin://runs/{loopId}",


### PR DESCRIPTION
## What changed

- **`martin plan <objective>`** — new CLI command that scopes the task, records a plan governance receipt, and outputs the governed sequence (estimate → preflight → execute)
- **`martin execute <objective>`** — governed alias for `martin run` that enforces the plan→preflight→run sequence
- **`martin://agent/mode-status`** — new MCP resource exposing current working mode (`auto`/`plan`/`edits`) and consent state; agents should read this before starting work
- **`martin start` consent prompt** — when mode is not configured, surfaces a clear choice between `auto`, `plan`, and `edits` modes before the first governed run
- **Star prompt** — fires at run #2 with warm copy, then every 25 runs; uses child_process to open GitHub, 15s TTY timeout, opt-out persistent
- **Feedback flow** — rating at run #10 (branches on score: high → "most valuable", low → "what's holding it back"), feature request at run #20, design partner form at run #30; submits to Web3Forms, writes local JSONL backup
- **Design partner capture** — collects name, email, company, pricing tier; emails `martinloopofficial@gmail.com` via Web3Forms on conversion

## What was tested

- 240 tests pass (all existing + 11 new trigger-logic unit tests)
- Build clean across all packages (contracts, core, adapters, cli, mcp)
- All engagement prompts fire only on `lifecycleState === "completed"` — never on budget_exit or error

## Files

- `packages/cli/src/home-dir.ts` — new
- `packages/cli/src/run-stats.ts` — new
- `packages/cli/src/star-prompt.ts` — new
- `packages/cli/src/feedback.ts` — new (full engagement flow)
- `packages/cli/src/index.ts` — plan/execute commands, consent prompt, run wiring
- `packages/cli/src/workflow-state.ts` — recordMcpPlanStep for cross-section state
- `packages/mcp/src/resources.ts` — martin://agent/mode-status resource
- `packages/cli/tests/star-feedback.test.ts` — new

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `plan` and `execute` CLI commands with objective-based planning and an “execute” workflow alias.
  * Added guided post-run engagement: prompt to star the project, submit feature/rating feedback, and opt in to design-partner outreach.
  * Added a new MCP resource showing current operating mode and guidance (including available mode options).

* **Bug Fixes**
  * Improved prompt timing and repeat-suppression using persisted run stats.
  * Ensured post-run engagement prompts never block successful command output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->