### PR TITLE
fix(adapters): restore error normalization + update stale test assert…

### DIFF
--- a/packages/adapters/src/claude-cli.ts
+++ b/packages/adapters/src/claude-cli.ts
@@ -840,8 +840,10 @@ export function createAgentCliAdapter(options: AgentCliAdapterOptions): MartinAd
           }),
           verification: { passed: false, summary: `Verifier not run: ${failureMessage}` },
           failure: {
-            // Full stderr preserved here — summary is capped at 2000 chars
-            message: fullStderr || failureMessage
+            // Raw stderr is preserved in diagnosticSummary above; use the
+            // normalized/classified message here so downstream consumers and
+            // tests get a consistent, parseable failure signal.
+            message: failureMessage
           }
         };
       }

--- a/packages/adapters/tests/claude-cli.test.ts
+++ b/packages/adapters/tests/claude-cli.test.ts
@@ -1072,6 +1072,22 @@ describe("createCodexCliAdapter", () => {
     expect(calls[0]?.stdin).toContain("update the target file");
   });
 
+  it("enforces token guardrails via streamingUsageCap, not --max-tokens subprocess flag", async () => {
+    const calls: SpawnCall[] = [];
+    const adapter = createClaudeCliAdapter({
+      spawnImpl: createScriptedSpawn(calls)
+    });
+
+    const result = await adapter.execute(makeRequest());
+
+    expect(result.status).toBe("completed");
+    // --max-tokens does not exist in the claude CLI; token cap is enforced by
+    // the streaming budget circuit breaker (streamingUsageCap), not a subprocess flag.
+    // Regression guard: ensure this flag is never re-introduced.
+    expect(calls[0]?.args).not.toContain("--max-tokens");
+  });
+
+
   it("preserves custom Codex model, sandbox, and extra exec flags before stdin prompt", async () => {
     const calls: SpawnCall[] = [];
     const adapter = createCodexCliAdapter({
@@ -1244,7 +1260,10 @@ describe("createCodexCliAdapter", () => {
     );
 
     expect(result.status).toBe("failed");
-    expect(result.summary).toContain("before verifier execution");
+    // Diagnostic summary surfaces exit code and stderr so failures are
+    // actionable rather than a generic "before verifier execution" message.
+    expect(result.summary).toContain("codex exited (code 2)");
+    expect(result.summary).toContain("--full-auto");
     expect(result.verification.summary).toContain("Verifier not run");
     expect(result.failure?.message).toContain("environment_mismatch");
     expect(calls).toHaveLength(1);

--- a/packages/adapters/tests/claude-cli.test.ts
+++ b/packages/adapters/tests/claude-cli.test.ts
@@ -1005,6 +1005,21 @@ describe("createClaudeCliAdapter", () => {
       expect(result.failure?.message).toContain("80% threshold");
     });
   });
+
+  it("enforces token guardrails via streamingUsageCap, not --max-tokens subprocess flag", async () => {
+    const calls: SpawnCall[] = [];
+    const adapter = createClaudeCliAdapter({
+      spawnImpl: createScriptedSpawn(calls)
+    });
+
+    const result = await adapter.execute(makeRequest());
+
+    expect(result.status).toBe("completed");
+    // --max-tokens does not exist in the claude CLI; token cap is enforced by
+    // the streaming budget circuit breaker (streamingUsageCap), not a subprocess flag.
+    // Regression guard: ensure this flag is never re-introduced.
+    expect(calls[0]?.args).not.toContain("--max-tokens");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -1086,7 +1101,6 @@ describe("createCodexCliAdapter", () => {
     // Regression guard: ensure this flag is never re-introduced.
     expect(calls[0]?.args).not.toContain("--max-tokens");
   });
-
 
   it("preserves custom Codex model, sandbox, and extra exec flags before stdin prompt", async () => {
     const calls: SpawnCall[] = [];


### PR DESCRIPTION
…ions after #168

Three regressions from #168 (bbcc34e):

1. fullStderr || failureMessage → failureMessage (claude-cli.ts) Raw stderr preserved in diagnosticSummary; failure.message carries the normalized signal downstream consumers and tests depend on.

2. Codex pre-verifier test assertion updated Test expected generic "before verifier execution" string. After the diagnostic improvement, empty-stdout path returns actual stderr content. Updated to assert "codex exited (code 2)" and "--full-auto" so the test validates diagnostic value rather than masking it.

3. Max-tokens regression guard --max-tokens removed in #168; token enforcement via streamingUsageCap. Flipped assertion: now guards that the flag is absent.

## Summary

<!-- What changed, and why? Keep it short. -->

## Related issue

<!-- Example: Closes #71 -->

## Verification

<!-- List the exact commands or manual checks you ran. If a check was not run, say why. -->

- [ ] `pnpm test`
- [ ] `pnpm lint`
- [ ] `pnpm build`
- [ ] Manual check:

## Risk and rollback

<!-- Note risky files, dependency changes, config changes, or migration concerns. Say how to back out safely. -->

## Checklist

- [ ] I kept the change focused and easy to review.
- [ ] I updated docs or examples if behavior changed.
- [ ] I did not include secrets, tokens, local paths, or non-public workspace details.
- [ ] CodeRabbit review workflow ran for this PR, or I documented the blocker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved adapter failure reporting when a pre-check subprocess exits unexpectedly, now returning a consistently classified error message while preserving diagnostic stderr details.
  * Enhanced early-exit failure summaries to include clearer subprocess exit diagnostics (including exit code) and related run flags.
* **Tests**
  * Added regression coverage to ensure token guardrails are enforced via the streaming usage circuit breaker (not a subprocess `--max-tokens` argument).
  * Updated adapter failure expectations to validate richer diagnostic summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->