### PR TITLE
fix(adapters,mcp): detect Claude CLI at native installer path, drop deprecated npm suggestion

### DIFF
--- a/packages/adapters/src/codex-launcher.ts
+++ b/packages/adapters/src/codex-launcher.ts
@@ -560,6 +560,9 @@ function discoverCommandOffPath(
     if (appData) dirs.push(join(appData, "npm"));
     const localAppData = env.LOCALAPPDATA;
     if (localAppData) dirs.push(join(localAppData, "OpenAI", "Codex", "bin"));
+    // Claude Code native installer places binary at %USERPROFILE%\.local\bin
+    const userProfile = env.USERPROFILE ?? env.HOMEPATH;
+    if (userProfile) dirs.push(join(userProfile, ".local", "bin"));
     if (home) dirs.push(join(home, "scoop", "shims"));
   } else {
     dirs.push("/usr/local/bin", "/opt/homebrew/bin");
@@ -592,8 +595,13 @@ function discoverCommandOffPath(
 }
 
 function suggestInstall(command: string): string {
+  if (command === "claude") {
+    const installCmd = process.platform === "win32"
+      ? "irm https://claude.ai/install.ps1 | iex"
+      : "curl -fsSL https://claude.ai/install.sh | sh";
+    return `Install with: ${installCmd}  — or: npm install -g @anthropic-ai/claude-code`;
+  }
   const installs: Record<string, string> = {
-    claude: "Install with: npm install -g @anthropic-ai/claude-code",
     codex: "Install with: npm install -g @openai/codex",
     gemini: "Install with: npm install -g @google/gemini-cli"
   };

--- a/packages/adapters/src/codex-launcher.ts
+++ b/packages/adapters/src/codex-launcher.ts
@@ -598,7 +598,7 @@ function suggestInstall(command: string): string {
   if (command === "claude") {
     const installCmd = process.platform === "win32"
       ? "irm https://claude.ai/install.ps1 | iex"
-      : "curl -fsSL https://claude.ai/install.sh | sh";
+      : "curl -fsSL https://claude.ai/install.sh | bash";
     return `Install with: ${installCmd}  — or: npm install -g @anthropic-ai/claude-code`;
   }
   const installs: Record<string, string> = {

--- a/packages/adapters/src/codex-launcher.ts
+++ b/packages/adapters/src/codex-launcher.ts
@@ -599,7 +599,7 @@ function suggestInstall(command: string): string {
     const installCmd = process.platform === "win32"
       ? "irm https://claude.ai/install.ps1 | iex"
       : "curl -fsSL https://claude.ai/install.sh | bash";
-    return `Install with: ${installCmd}  — or: npm install -g @anthropic-ai/claude-code`;
+    return `Install with: ${installCmd}`;
   }
   const installs: Record<string, string> = {
     codex: "Install with: npm install -g @openai/codex",

--- a/packages/mcp/src/tools/tool-support.ts
+++ b/packages/mcp/src/tools/tool-support.ts
@@ -354,7 +354,7 @@ function suggestInstallCommand(command: string): string {
     const installCmd = process.platform === "win32"
       ? "irm https://claude.ai/install.ps1 | iex"
       : "curl -fsSL https://claude.ai/install.sh | bash";
-    return `Install with: ${installCmd}  (or: npm install -g @anthropic-ai/claude-code)`;
+    return `Install with: ${installCmd}`;
   }
 
   const npmInstalls: Record<string, string> = {

--- a/packages/mcp/src/tools/tool-support.ts
+++ b/packages/mcp/src/tools/tool-support.ts
@@ -279,6 +279,11 @@ function discoverCommonInstallDirectories(command: string): string[] {
     if (localAppData) {
       dirs.push(join(localAppData, "OpenAI", "Codex", "bin"));
     }
+    // Claude Code native installer places binary at %USERPROFILE%\.local\bin
+    const userProfile = process.env.USERPROFILE ?? process.env.HOMEPATH;
+    if (userProfile) {
+      dirs.push(join(userProfile, ".local", "bin"));
+    }
     // Scoop
     if (home) {
       dirs.push(join(home, "scoop", "shims"));
@@ -345,8 +350,14 @@ function isOnPathDirectly(command: string, resolvedPath: string): boolean {
  * Returns a platform-specific one-liner install command for a known CLI.
  */
 function suggestInstallCommand(command: string): string {
+  if (command === "claude") {
+    const installCmd = process.platform === "win32"
+      ? "irm https://claude.ai/install.ps1 | iex"
+      : "curl -fsSL https://claude.ai/install.sh | sh";
+    return `Install with: ${installCmd}  (or: npm install -g @anthropic-ai/claude-code)`;
+  }
+
   const npmInstalls: Record<string, string> = {
-    claude: "npm install -g @anthropic-ai/claude-code",
     codex: "npm install -g @openai/codex",
     gemini: "npm install -g @google/gemini-cli"
   };

--- a/packages/mcp/src/tools/tool-support.ts
+++ b/packages/mcp/src/tools/tool-support.ts
@@ -353,7 +353,7 @@ function suggestInstallCommand(command: string): string {
   if (command === "claude") {
     const installCmd = process.platform === "win32"
       ? "irm https://claude.ai/install.ps1 | iex"
-      : "curl -fsSL https://claude.ai/install.sh | sh";
+      : "curl -fsSL https://claude.ai/install.sh | bash";
     return `Install with: ${installCmd}  (or: npm install -g @anthropic-ai/claude-code)`;
   }
 


### PR DESCRIPTION
## Summary

- Adds `%USERPROFILE%\.local\bin` to Windows off-PATH discovery in both the codex adapter and MCP tool-support fallback. This is where the Claude Code native installer places the binary — separate from npm's global bin directory.
- Updates install suggestion strings to use the native installer commands (`irm https://claude.ai/install.ps1 | iex` on Windows, `curl -fsSL https://claude.ai/install.sh | bash` on macOS/Linux).
- Suggestion strings are now platform-aware via `process.platform` branching, consistent with how the existing discovery logic already works.
- Removes the deprecated `npm install -g @anthropic-ai/claude-code` suggestion. The npm package is deprecated per Anthropic's official documentation in favor of the native installer.

## Why

Claude Code moved to a native installer as the primary distribution path. Users installing via the native installer on Windows would hit "claude not found" even with a working install if the binary wasn't explicitly on PATH, because the off-PATH discovery fallback only checked npm's global bin directory. This brings detection in line with where the installer actually places the binary.

## Test plan

- [x] TypeScript: `tsc --noEmit` exits 0 on both changed packages
- [x] Unit tests: adapters 87/87 passed, mcp 93/93 passed (1 pre-existing skip)
- [ ] Manual: on Windows with native Claude install not on PATH, `martin doctor` should find claude via `%USERPROFILE%\.local\bin` fallback

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of locally installed command-line tools on Windows, including common user-level install locations.
  * Updated install guidance for `claude` to show the official platform-specific installer command instead of a generic package install command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->