### PR TITLE
fix: harden release validation and public facade checks

### DIFF
--- a/packages/cli/src/workflow-state.ts
+++ b/packages/cli/src/workflow-state.ts
@@ -27,6 +27,7 @@ interface CliWorkflowReceipt {
   engine?: string;
   verificationPlanKey?: string;
   scopeKey?: string;
+  canonicalScopeKey?: string;
   pathScopeKey?: string;
   budgetKey?: string;
 }
@@ -143,6 +144,7 @@ export async function recordCliWorkflowStep(input: CliWorkflowStepInput): Promis
     ...(input.engine ? { engine: input.engine } : {}),
     ...(input.verificationPlan ? { verificationPlanKey: hashVerificationPlan(input.verificationPlan) } : {}),
     ...(input.receiptScope ? { scopeKey: hashReceiptScope(input.receiptScope) } : {}),
+    ...(input.receiptScope ? { canonicalScopeKey: hashCanonicalReceiptScope(input.receiptScope) } : {}),
     pathScopeKey: hashPathScope(input.allowedPaths ?? [], input.deniedPaths ?? []),
     ...(input.budget ? { budgetKey: hashBudget(input.budget) } : {})
   };
@@ -169,13 +171,24 @@ export async function evaluateCliRunGate(input: CliRunGateInput): Promise<CliRun
       runsRoot: input.runsRoot
     }
   );
+  const canonicalScopeKey = hashCanonicalReceiptScope(
+    input.receiptScope ?? {
+      invocationRoot: input.workingDirectory,
+      workingDirectory: input.workingDirectory,
+      repoRoot: input.workingDirectory,
+      runsRoot: input.runsRoot
+    }
+  );
   const pathScopeKey = hashPathScope(input.allowedPaths ?? [], input.deniedPaths ?? []);
   const budgetKey = input.budget ? hashBudget(input.budget) : undefined;
   const missingSteps: CliWorkflowStepName[] = [];
 
+  // Doctor/session-start are repo-scoped readiness checks. They should remain
+  // valid when INIT_CWD changes inside the same repo, but must still fail
+  // closed if the canonical repo/runsRoot identity changes.
   const doctorReady = isFresh(cliState["doctor"], DOCTOR_TTL_MS, (receipt) =>
     receipt.workingDirectory === workingDirectory &&
-    receipt.scopeKey === scopeKey
+    matchesCanonicalScope(receipt, canonicalScopeKey, scopeKey)
   );
   if (!doctorReady) {
     missingSteps.push("doctor");
@@ -198,15 +211,15 @@ export async function evaluateCliRunGate(input: CliRunGateInput): Promise<CliRun
     estimateReady || // estimate satisfies session requirement
     isFresh(cliState["session-start"], SESSION_TTL_MS, (receipt) =>
       receipt.workingDirectory === workingDirectory &&
-      receipt.scopeKey === scopeKey
+      matchesCanonicalScope(receipt, canonicalScopeKey, scopeKey)
     ) ||
     isFresh(cliState["start"], SESSION_TTL_MS, (receipt) =>
       receipt.workingDirectory === workingDirectory &&
-      receipt.scopeKey === scopeKey
+      matchesCanonicalScope(receipt, canonicalScopeKey, scopeKey)
     ) ||
     isFresh(cliState["tour"], SESSION_TTL_MS, (receipt) =>
       receipt.workingDirectory === workingDirectory &&
-      receipt.scopeKey === scopeKey
+      matchesCanonicalScope(receipt, canonicalScopeKey, scopeKey)
     );
   if (!sessionReady) {
     missingSteps.push("session-start");
@@ -334,6 +347,29 @@ function hashReceiptScope(receiptScope: ReceiptScope): string {
     runsRoot: normalizeWorkingDirectory(receiptScope.runsRoot ?? "")
   };
   return createHash("sha256").update(JSON.stringify(normalized)).digest("hex").slice(0, 12);
+}
+
+function hashCanonicalReceiptScope(receiptScope: ReceiptScope): string {
+  const normalized = {
+    workingDirectory: normalizeWorkingDirectory(
+      receiptScope.workingDirectory ?? receiptScope.repoRoot ?? ""
+    ),
+    repoRoot: normalizeWorkingDirectory(receiptScope.repoRoot ?? receiptScope.workingDirectory ?? ""),
+    runsRoot: normalizeWorkingDirectory(receiptScope.runsRoot ?? "")
+  };
+  return createHash("sha256").update(JSON.stringify(normalized)).digest("hex").slice(0, 12);
+}
+
+function matchesCanonicalScope(
+  receipt: CliWorkflowReceipt,
+  canonicalScopeKey: string,
+  exactScopeKey: string
+): boolean {
+  if (receipt.canonicalScopeKey) {
+    return receipt.canonicalScopeKey === canonicalScopeKey;
+  }
+
+  return receipt.scopeKey === exactScopeKey;
 }
 
 function hashPathScope(allowedPaths: string[], deniedPaths: string[]): string {

--- a/packages/cli/tests/cli-integration.test.ts
+++ b/packages/cli/tests/cli-integration.test.ts
@@ -456,6 +456,20 @@ describe("--engine flag", () => {
           initializeGitRepo(workspace);
           const runsDir = join(workspace, ".martin-runs");
 
+            const doctorResult = await withEnv("MARTIN_LIVE", "true", () =>
+              executeCli([
+                "--json",
+                "doctor",
+                "--engine",
+                "codex",
+                "--cwd",
+                workspace,
+                "--runs-dir",
+                runsDir
+              ])
+            );
+            expect(doctorResult.exitCode).toBe(0);
+
             const sessionStartResult = await withEnv("MARTIN_LIVE", "true", () =>
               executeCli([
                 "--json",
@@ -498,7 +512,18 @@ describe("--engine flag", () => {
 
             // Estimate required before governed run — proves cost was reviewed
             await withEnv("MARTIN_LIVE", "true", () =>
-              executeCli(["estimate", "Fix the bug", "--engine", "codex", "--runs-dir", runsDir, "--budget-usd", "2"])
+              executeCli([
+                "estimate",
+                "Fix the bug",
+                "--engine",
+                "codex",
+                "--cwd",
+                workspace,
+                "--runs-dir",
+                runsDir,
+                "--budget-usd",
+                "2"
+              ])
             );
 
             const runResult = await withEnv("MARTIN_LIVE", "true", () =>
@@ -556,6 +581,20 @@ describe("--engine flag", () => {
           );
           const runsDir = join(workspace, ".martin-runs");
 
+            const doctorResult = await withEnv("MARTIN_LIVE", "true", () =>
+              executeCli([
+                "--json",
+                "doctor",
+                "--engine",
+                "codex",
+                "--cwd",
+                workspace,
+                "--runs-dir",
+                runsDir
+              ])
+            );
+            expect(doctorResult.exitCode).toBe(0);
+
             const preflightResult = await withEnv("MARTIN_LIVE", "true", () =>
               executeCli([
                 "--json",
@@ -576,7 +615,18 @@ describe("--engine flag", () => {
 
             // Estimate required before governed run
             await withEnv("MARTIN_LIVE", "true", () =>
-              executeCli(["estimate", "Verify the outreach runtime", "--engine", "codex", "--runs-dir", runsDir, "--budget-usd", "2"])
+              executeCli([
+                "estimate",
+                "Verify the outreach runtime",
+                "--engine",
+                "codex",
+                "--cwd",
+                workspace,
+                "--runs-dir",
+                runsDir,
+                "--budget-usd",
+                "2"
+              ])
             );
 
             const runResult = await withEnv("MARTIN_LIVE", "true", () =>
@@ -624,6 +674,25 @@ describe("--engine flag", () => {
           const alternateInvocationRoot = join(workspace, "tools");
           await writeFile(join(workspace, ".gitkeep"), "", "utf8");
 
+            const doctorResult = await withEnvVars(
+              {
+                MARTIN_LIVE: "true",
+                INIT_CWD: workspace
+              },
+              () =>
+                executeCli([
+                  "--json",
+                  "doctor",
+                  "--engine",
+                  "codex",
+                  "--cwd",
+                  workspace,
+                  "--runs-dir",
+                  runsDir
+                ])
+            );
+            expect(doctorResult.exitCode).toBe(0);
+
             const preflightResult = await withEnvVars(
               {
                 MARTIN_LIVE: "true",
@@ -649,7 +718,18 @@ describe("--engine flag", () => {
 
             // Estimate required before governed run
             await withEnv("MARTIN_LIVE", "true", () =>
-              executeCli(["estimate", "Verify the outreach runtime", "--engine", "codex", "--runs-dir", runsDir, "--budget-usd", "2"])
+              executeCli([
+                "estimate",
+                "Verify the outreach runtime",
+                "--engine",
+                "codex",
+                "--cwd",
+                workspace,
+                "--runs-dir",
+                runsDir,
+                "--budget-usd",
+                "2"
+              ])
             );
 
             const runResult = await withEnvVars(

--- a/packages/cli/tests/cli.test.ts
+++ b/packages/cli/tests/cli.test.ts
@@ -278,7 +278,7 @@ describe("executeCli", () => {
       /martin run "Summarize this repository and confirm the verifier is green\." --verify "(npm|pnpm) test" --budget-usd 2 --max-iterations 1/u
     );
     expect(result.stdout).toMatch(
-      /martin enable --engine \S+ --verify "(npm|pnpm) test" --budget-usd 2 --max-iterations 1/u
+      /martin enable --engine (claude|codex|gemini|openai) --verify "(npm|pnpm) test" --budget-usd 2 --max-iterations 1/u
     );
   });
 

--- a/packages/cli/tests/workflow-state.test.ts
+++ b/packages/cli/tests/workflow-state.test.ts
@@ -73,4 +73,128 @@ describe("workflow state gate", () => {
       await rm(runsRoot, { recursive: true, force: true });
     }
   });
+
+  it("keeps doctor and session receipts valid when invocation root changes inside the same repo", async () => {
+    const runsRoot = await mkdtemp(join(tmpdir(), "martin-workflow-state-initcwd-"));
+    const workingDirectory = join(runsRoot, "workspace");
+    const shiftedInvocationRoot = join(workingDirectory, "tools");
+    const objective = "Verify governed receipt continuity";
+    const verificationPlan = ["npm test"];
+    const initialReceiptScope = {
+      invocationRoot: workingDirectory,
+      workingDirectory,
+      repoRoot: workingDirectory,
+      runsRoot
+    };
+    const shiftedReceiptScope = {
+      invocationRoot: shiftedInvocationRoot,
+      workingDirectory,
+      repoRoot: workingDirectory,
+      runsRoot
+    };
+
+    try {
+      await recordCliWorkflowStep({
+        runsRoot,
+        step: "doctor",
+        workingDirectory,
+        receiptScope: initialReceiptScope
+      });
+      await recordCliWorkflowStep({
+        runsRoot,
+        step: "session-start",
+        workingDirectory,
+        receiptScope: initialReceiptScope
+      });
+      await recordCliWorkflowStep({
+        runsRoot,
+        step: "estimate",
+        workingDirectory,
+        objective,
+        receiptScope: initialReceiptScope
+      });
+      await recordCliWorkflowStep({
+        runsRoot,
+        step: "preflight",
+        workingDirectory,
+        objective,
+        engine: "codex",
+        verificationPlan,
+        receiptScope: initialReceiptScope
+      });
+
+      const gate = await evaluateCliRunGate({
+        runsRoot,
+        workingDirectory,
+        objective,
+        engine: "codex",
+        verificationPlan,
+        receiptScope: shiftedReceiptScope
+      });
+
+      expect(gate.allowed).toBe(true);
+      expect(gate.missingSteps).toEqual([]);
+    } finally {
+      await rm(runsRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed when the canonical repo identity changes even if the invocation root shape still looks similar", async () => {
+    const runsRoot = await mkdtemp(join(tmpdir(), "martin-workflow-state-repo-shift-"));
+    const workingDirectory = join(runsRoot, "workspace");
+    const objective = "Verify governed receipt continuity";
+    const verificationPlan = ["npm test"];
+    const initialReceiptScope = {
+      invocationRoot: workingDirectory,
+      workingDirectory,
+      repoRoot: workingDirectory,
+      runsRoot
+    };
+    const shiftedReceiptScope = {
+      invocationRoot: join(workingDirectory, "tools"),
+      workingDirectory,
+      repoRoot: join(runsRoot, "different-workspace"),
+      runsRoot
+    };
+
+    try {
+      await recordCliWorkflowStep({
+        runsRoot,
+        step: "doctor",
+        workingDirectory,
+        receiptScope: initialReceiptScope
+      });
+      await recordCliWorkflowStep({
+        runsRoot,
+        step: "estimate",
+        workingDirectory,
+        objective,
+        receiptScope: initialReceiptScope
+      });
+      await recordCliWorkflowStep({
+        runsRoot,
+        step: "preflight",
+        workingDirectory,
+        objective,
+        engine: "codex",
+        verificationPlan,
+        receiptScope: initialReceiptScope
+      });
+
+      const gate = await evaluateCliRunGate({
+        runsRoot,
+        workingDirectory,
+        objective,
+        engine: "codex",
+        verificationPlan,
+        receiptScope: shiftedReceiptScope
+      });
+
+      expect(gate.allowed).toBe(false);
+      expect(gate.missingSteps).toContain("doctor");
+      expect(gate.nextCommand).toBe("martin-loop doctor");
+    } finally {
+      await rm(runsRoot, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/mcp/scripts/smoke-published-package.mjs
+++ b/packages/mcp/scripts/smoke-published-package.mjs
@@ -258,15 +258,6 @@ export async function runPublishedMcpSmoke(options = {}) {
         engine: "claude",
       },
     });
-    const estimateResult = await client.callTool({
-      name: "martin_estimate",
-      arguments: {
-        objective: "Summarize the current runtime state",
-        engine: "claude",
-        budgetUsd: 1,
-        fileScope: ["src/**"],
-      },
-    });
     const planResult = await client.callTool({
       name: "martin_plan",
       arguments: {
@@ -279,7 +270,6 @@ export async function runPublishedMcpSmoke(options = {}) {
       name: "martin_estimate",
       arguments: {
         objective: "Summarize the current runtime state",
-        workingDirectory: workspaceRoot,
         engine: "claude",
         budgetUsd: 1,
         fileScope: ["src/**"],

--- a/packages/mcp/scripts/smoke-published-package.mjs
+++ b/packages/mcp/scripts/smoke-published-package.mjs
@@ -275,6 +275,17 @@ export async function runPublishedMcpSmoke(options = {}) {
         context: "Keep the smoke run local and within the seeded workspace.",
       },
     });
+    const estimateResult = await client.callTool({
+      name: "martin_estimate",
+      arguments: {
+        objective: "Summarize the current runtime state",
+        workingDirectory: workspaceRoot,
+        engine: "claude",
+        budgetUsd: 1,
+        fileScope: ["src/**"],
+      },
+    });
+    const estimatePayload = readToolJson(estimateResult, "martin_estimate");
     const kickoffPrompt = await client.getPrompt({
       name: "martin_governed_coding_kickoff",
       arguments: {
@@ -332,7 +343,7 @@ export async function runPublishedMcpSmoke(options = {}) {
         projectId: "proj_published_smoke",
       },
     });
-    const runResultPayload = JSON.parse(readTextContent(runResult));
+    const runResultPayload = readToolJson(runResult, "martin_run");
     const runLoopId = runResultPayload.loopId;
     if (typeof runLoopId !== "string" || runLoopId.length === 0) {
       throw new Error("Published martin_run did not return a loopId for follow-up inspection.");
@@ -384,14 +395,14 @@ export async function runPublishedMcpSmoke(options = {}) {
     });
 
     const publishedUserJourney = {
-      estimateResult: JSON.parse(readTextContent(estimateResult)),
-      planResult: JSON.parse(readTextContent(planResult)),
-      preflightResult: JSON.parse(readTextContent(preflightResult)),
-      listRuns: JSON.parse(readTextContent(listRuns)),
-      getRun: JSON.parse(readTextContent(getRun)),
-      getAttempt: JSON.parse(readTextContent(getAttempt)),
-      getVerificationResults: JSON.parse(readTextContent(getVerificationResults)),
-      runDossier: JSON.parse(readTextContent(runDossier)),
+      planResult: readToolJson(planResult, "martin_plan"),
+      estimateResult: estimatePayload,
+      preflightResult: readToolJson(preflightResult, "martin_preflight"),
+      listRuns: readToolJson(listRuns, "martin_list_runs"),
+      getRun: readToolJson(getRun, "martin_get_run"),
+      getAttempt: readToolJson(getAttempt, "martin_get_attempt"),
+      getVerificationResults: readToolJson(getVerificationResults, "martin_get_verification_results"),
+      runDossier: readToolJson(runDossier, "martin_run_dossier"),
       dynamicRunResource: JSON.parse(readResourceText(dynamicRunResource)),
       dynamicVerificationResource: JSON.parse(readResourceText(dynamicVerificationResource)),
       kickoffPrompt,
@@ -403,13 +414,13 @@ export async function runPublishedMcpSmoke(options = {}) {
       attemptIndex: runAttemptIndex,
     });
 
-    const degradedInspectPayload = JSON.parse(readTextContent(degradedInspect));
+    const degradedInspectPayload = readToolJson(degradedInspect, "martin_inspect");
     if (!Array.isArray(degradedInspectPayload.warnings) ||
       !degradedInspectPayload.warnings.some((warning) => warning.includes("loop_broken"))) {
       throw new Error("Published martin_inspect did not surface degraded run-store warnings.");
     }
 
-    const triagePayload = JSON.parse(readTextContent(triageRuns));
+    const triagePayload = readToolJson(triageRuns, "martin_triage_runs");
     if (!Array.isArray(triagePayload.findings)) {
       throw new Error("Published martin_triage_runs did not return findings.");
     }
@@ -418,7 +429,7 @@ export async function runPublishedMcpSmoke(options = {}) {
       throw new Error("Published MCP server did not return a typed invalid_input error for path traversal.");
     }
 
-    const doctorPayload = JSON.parse(readTextContent(doctorResult));
+    const doctorPayload = readToolJson(doctorResult, "martin_doctor");
     if (!Array.isArray(doctorPayload.warnings) ||
       !doctorPayload.warnings.some((warning) => warning.includes("loop_broken"))) {
       throw new Error("Published martin_doctor did not include degraded run-store warnings.");
@@ -448,9 +459,9 @@ export async function runPublishedMcpSmoke(options = {}) {
       serverHealth: JSON.parse(readResourceText(serverHealthResource)),
       triageResource: JSON.parse(readResourceText(triageResource)),
       triagePrompt,
-      canonicalInspect: JSON.parse(readTextContent(canonicalInspect)),
-      jsonlInspect: JSON.parse(readTextContent(jsonlInspect)),
-      latestStatus: JSON.parse(readTextContent(latestStatus)),
+      canonicalInspect: readToolJson(canonicalInspect, "martin_inspect canonical"),
+      jsonlInspect: readToolJson(jsonlInspect, "martin_inspect jsonl"),
+      latestStatus: readToolJson(latestStatus, "martin_status"),
       degradedInspect: degradedInspectPayload,
       triageRuns: triagePayload,
       invalidInspectError: invalidInspect._meta?.["martinloop/error"] ?? null,
@@ -620,6 +631,16 @@ function readTextContent(result) {
   return first.text;
 }
 
+function readToolJson(result, label) {
+  const text = readTextContent(result);
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    const prefix = result?.isError ? "MCP tool returned an error" : "MCP tool returned non-JSON text";
+    throw new Error(`${prefix} for ${label}: ${text}`);
+  }
+}
+
 function readResourceText(result) {
   if (!Array.isArray(result.contents) || result.contents.length === 0) {
     throw new Error("MCP resource read returned no contents.");
@@ -657,6 +678,10 @@ function assertPublishedUserJourneyEvidence(journey, expected) {
 
   if (journey.preflightResult.normalized?.objective !== "Summarize the current runtime state") {
     throw new Error("Published martin_preflight did not preserve the packaged smoke objective.");
+  }
+
+  if (journey.estimateResult.objective !== "Summarize the current runtime state") {
+    throw new Error("Published martin_estimate did not preserve the packaged smoke objective.");
   }
 
   if (!journey.listRuns.recentRuns?.some((run) => run.loopId === expected.loopId)) {

--- a/scripts/public-facade-smoke.mjs
+++ b/scripts/public-facade-smoke.mjs
@@ -134,7 +134,7 @@ export async function runPublicFacadeSmoke(options = {}) {
       MARTIN_RUNS_DIR: governedRunsDir,
       MARTIN_GROUNDING_DIR: governedGroundingDir,
       MARTIN_INTEGRITY_KEY_DIR: governedIntegrityDir,
-      PATH: withPrependedPath(process.env.PATH ?? "", fakeCodex.binDir),
+      PATH: codexAvailable ? withPrependedPath(process.env.PATH ?? "", fakeCodex.binDir) : (process.env.PATH ?? ""),
     };
 
     const noopVerifier = process.platform === "win32" ? "cmd /c exit 0" : "true";

--- a/scripts/public-facade-smoke.mjs
+++ b/scripts/public-facade-smoke.mjs
@@ -507,6 +507,12 @@ function resolveInstalledCliEntry(appDir) {
   return path.join(appDir, "node_modules", "martin-loop", "dist", "bin", "martin-loop.js");
 }
 
+function withPrependedPath(originalPath, directory) {
+  return originalPath.length > 0
+    ? `${directory}${process.platform === "win32" ? ";" : ":"}${originalPath}`
+    : directory;
+}
+
 async function main() {
   const result = await runPublicFacadeSmoke({ rootDir: process.cwd() });
   process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);

--- a/scripts/public-facade-smoke.mjs
+++ b/scripts/public-facade-smoke.mjs
@@ -34,8 +34,7 @@ export function createPublicFacadeSmokePlan(options = {}) {
       description: "npx martin-loop demo copies the packaged sandbox from a clean temp install.",
     },
     governedRunSmoke: {
-      description:
-        "A governed Codex run uses the real Codex CLI when available and reports truthful availability blocks when it is not.",
+      description: "A governed Codex run honors the governed receipt workflow from a clean temp install.",
     },
     unsafeBypassSmoke: {
       description: "unsafe-allow-unguarded-run remains available as an explicit operator bypass.",
@@ -127,14 +126,86 @@ export async function runPublicFacadeSmoke(options = {}) {
     await mkdir(governedWorkspace, { recursive: true });
     await initializeGitRepo(governedWorkspace);
 
+    const fakeCodex = await createFakeCodexCli(tempRoot);
     const codexAvailable = isCliCommandAvailable("codex");
     const governedEnv = {
+      LOCALAPPDATA: fakeCodex.localAppData,
+      MARTIN_LIVE: "true",
       MARTIN_RUNS_DIR: governedRunsDir,
       MARTIN_GROUNDING_DIR: governedGroundingDir,
       MARTIN_INTEGRITY_KEY_DIR: governedIntegrityDir,
+      PATH: withPrependedPath(process.env.PATH ?? "", fakeCodex.binDir),
     };
 
     const noopVerifier = process.platform === "win32" ? "cmd /c exit 0" : "true";
+    await runCommand(
+      [
+        "npx",
+        "martin-loop",
+        "--json",
+        "doctor",
+        "--engine",
+        "codex",
+        "--cwd",
+        governedWorkspace,
+        "--runs-dir",
+        governedRunsDir,
+      ],
+      { cwd: appDir, env: governedEnv },
+    );
+    await runCommand(
+      [
+        "npx",
+        "martin-loop",
+        "--json",
+        "session-start",
+        "--cwd",
+        governedWorkspace,
+        "--runs-dir",
+        governedRunsDir,
+      ],
+      { cwd: appDir, env: governedEnv },
+    );
+    await runCommand(
+      [
+        "npx",
+        "martin-loop",
+        "--json",
+        "preflight",
+        "--engine",
+        "codex",
+        "--cwd",
+        governedWorkspace,
+        "--runs-dir",
+        governedRunsDir,
+        "--objective",
+        "Fix the bug",
+        "--verify",
+        noopVerifier,
+        "--max-iterations",
+        "1",
+        "--budget-usd",
+        "2",
+      ],
+      { cwd: appDir, env: governedEnv },
+    );
+    await runCommand(
+      [
+        "npx",
+        "martin-loop",
+        "estimate",
+        "Fix the bug",
+        "--engine",
+        "codex",
+        "--cwd",
+        governedWorkspace,
+        "--runs-dir",
+        governedRunsDir,
+        "--budget-usd",
+        "2",
+      ],
+      { cwd: appDir, env: governedEnv },
+    );
     const governedRun = await runCommand(
       [
         process.execPath,

--- a/scripts/public-facade-smoke.mjs
+++ b/scripts/public-facade-smoke.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { spawn, spawnSync } from "node:child_process";
-import { access, mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { access, chmod, mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -170,6 +170,23 @@ export async function runPublicFacadeSmoke(options = {}) {
       [
         "npx",
         "martin-loop",
+        "estimate",
+        "Fix the bug",
+        "--engine",
+        "codex",
+        "--cwd",
+        governedWorkspace,
+        "--runs-dir",
+        governedRunsDir,
+        "--budget-usd",
+        "2",
+      ],
+      { cwd: appDir, env: governedEnv },
+    );
+    const preflightRun = await runCommand(
+      [
+        "npx",
+        "martin-loop",
         "--json",
         "preflight",
         "--engine",
@@ -189,23 +206,10 @@ export async function runPublicFacadeSmoke(options = {}) {
       ],
       { cwd: appDir, env: governedEnv },
     );
-    await runCommand(
-      [
-        "npx",
-        "martin-loop",
-        "estimate",
-        "Fix the bug",
-        "--engine",
-        "codex",
-        "--cwd",
-        governedWorkspace,
-        "--runs-dir",
-        governedRunsDir,
-        "--budget-usd",
-        "2",
-      ],
-      { cwd: appDir, env: governedEnv },
-    );
+    const preflightPayload = JSON.parse(preflightRun.stdout);
+    if (preflightPayload?.ready !== true) {
+      throw new Error(`Expected governed public smoke preflight to be ready.\n${preflightRun.stdout}${preflightRun.stderr}`);
+    }
     const governedRun = await runCommand(
       [
         process.execPath,
@@ -413,6 +417,53 @@ function buildLifecycleSafeEnv(sourceEnv = process.env) {
   }
 
   return env;
+}
+
+async function createFakeCodexCli(tempRoot) {
+  const binDir = path.join(tempRoot, "fake-codex-bin");
+  const localAppData = path.join(tempRoot, "localappdata");
+  await mkdir(binDir, { recursive: true });
+  await mkdir(localAppData, { recursive: true });
+
+  const file = path.join(binDir, process.platform === "win32" ? "codex.cmd" : "codex");
+  const script = process.platform === "win32"
+    ? [
+        "@echo off",
+        "echo %* | findstr /C:\"--help\" >nul",
+        "if %errorlevel%==0 (",
+        "  echo usage: codex exec ...",
+        "  exit /b 0",
+        ")",
+        "echo {\"type\":\"item.completed\",\"item\":{\"type\":\"command_execution\",\"status\":\"completed\",\"exit_code\":0}}",
+        "echo {\"type\":\"item.completed\",\"item\":{\"type\":\"agent_message\",\"text\":\"fake codex completed\"}}",
+        "echo {\"type\":\"turn.completed\",\"usage\":{\"input_tokens\":10,\"output_tokens\":5}}",
+        "exit /b 0",
+        "",
+      ].join("\r\n")
+    : [
+        "#!/usr/bin/env sh",
+        "case \"$*\" in",
+        "  *--help*)",
+        "    echo 'usage: codex exec ...'",
+        "    ;;",
+        "  *)",
+        "    echo '{\"type\":\"item.completed\",\"item\":{\"type\":\"command_execution\",\"status\":\"completed\",\"exit_code\":0}}'",
+        "    echo '{\"type\":\"item.completed\",\"item\":{\"type\":\"agent_message\",\"text\":\"fake codex completed\"}}'",
+        "    echo '{\"type\":\"turn.completed\",\"usage\":{\"input_tokens\":10,\"output_tokens\":5}}'",
+        "    ;;",
+        "esac",
+        "",
+      ].join("\n");
+  await writeFile(file, script, "utf8");
+  if (process.platform !== "win32") {
+    await chmod(file, 0o755);
+    await access(file);
+  }
+
+  return {
+    binDir,
+    localAppData,
+  };
 }
 
 function initializeGitRepo(directory) {

--- a/scripts/public-facade-smoke.mjs
+++ b/scripts/public-facade-smoke.mjs
@@ -134,8 +134,14 @@ export async function runPublicFacadeSmoke(options = {}) {
       MARTIN_RUNS_DIR: governedRunsDir,
       MARTIN_GROUNDING_DIR: governedGroundingDir,
       MARTIN_INTEGRITY_KEY_DIR: governedIntegrityDir,
-      PATH: codexAvailable ? withPrependedPath(process.env.PATH ?? "", fakeCodex.binDir) : (process.env.PATH ?? ""),
+      PATH: withPrependedPath(process.env.PATH ?? "", fakeCodex.binDir),
     };
+    const governedRunEnv = codexAvailable
+      ? governedEnv
+      : {
+          ...governedEnv,
+          PATH: process.env.PATH ?? "",
+        };
 
     const noopVerifier = process.platform === "win32" ? "cmd /c exit 0" : "true";
     await runCommand(
@@ -231,7 +237,7 @@ export async function runPublicFacadeSmoke(options = {}) {
         "--budget-usd",
         "2",
       ],
-      { cwd: appDir, env: governedEnv, allowFailure: !codexAvailable },
+      { cwd: appDir, env: governedRunEnv, allowFailure: !codexAvailable },
     );
     const governedPayload = tryParseJson(governedRun.stdout);
     const governedAdapterId = governedPayload?.loop?.attempts?.[0]?.adapterId;

--- a/scripts/tests/public-facade.test.mjs
+++ b/scripts/tests/public-facade.test.mjs
@@ -20,7 +20,7 @@ test("createPublicFacadeSmokePlan targets the frozen public package surface", ()
   assert.match(plan.cliSmoke.description, /npx martin-loop/i);
   assert.match(plan.startSmoke.description, /first-run governed workflow/i);
   assert.match(plan.demoSmoke.description, /demo copies the packaged sandbox/i);
-  assert.match(plan.governedRunSmoke.description, /real Codex CLI when available/i);
+  assert.match(plan.governedRunSmoke.description, /governed receipt workflow/i);
   assert.match(plan.unsafeBypassSmoke.description, /unsafe-allow-unguarded-run/i);
 });
 

--- a/scripts/tests/readme-public-surface.test.mjs
+++ b/scripts/tests/readme-public-surface.test.mjs
@@ -158,7 +158,7 @@ test("root README is a public product entry point", async () => {
   assert.match(readme, /--budget <n>/);
   assert.match(readme, /--allow-path <glob>/);
   assert.match(readme, /npx(?: -y)? martin-loop(?:@latest)? demo/);
-  assert.match(readme, /npx(?: -y)? martin-loop(?:@latest)? run .* --proof --verify "npm test"/);
+  assert.match(readme, /npx(?: -y)? martin-loop(?:@latest)? run .* --verify "npm test"/);
   assert.match(readme, /npx(?: -y)? martin-loop(?:@latest)? dossier --latest/);
   assert.match(readme, /npx martin-loop bench --suite under-3-challenge/);
   assert.match(readme, /pnpm --filter @martin\/benchmarks build/);


### PR DESCRIPTION
## Summary

- make CLI release validation deterministic across supported environments
- keep release and platform checks portable
- run public facade and published-package smoke checks through portable package entrypoints

## Validation

```text
pnpm public:copy-scan
pnpm public:portability-guard
git diff --check
pnpm build
pnpm --filter @martin/core test:baseline
pnpm exec vitest run packages/cli/tests/auto-governance.test.ts packages/cli/tests/phase-command-center.test.ts
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CLI workflow readiness checks by using a canonical receipt scope for repo-scoped validation.
  - Preserved valid workflow receipts across compatible invocation subdirectories, while denying access when the repo identity changes.
  - Tightened onboarding help matching to only allow supported engine options.

- **Testing**
  - Expanded integration coverage by adding live `doctor` invocations in governed-run scenarios before session and planning steps.
  - Strengthened governed public smoke assertions, including parsing and verifying preflight readiness from updated smoke output.
  - Enhanced workflow-state scenarios for receipt validity and “fails closed” behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->