### PR TITLE
fix(cli): ship R2 loop experience workflow fixes

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1980,7 +1980,7 @@ async function executeStartCommand(
       recommended: {
         engine: snapshot.recommendedEngine,
         verifier: snapshot.verifier.command,
-        budgetUsd: 2,
+        budgetUsd: defaultBudgetUsd,
         maxIterations: 1
       },
       next: {
@@ -1991,7 +1991,7 @@ async function executeStartCommand(
         preflight: preflightCommand,
         run: governedRunCommand,
         proofRun: proofCommand,
-        enable: `martin enable --engine ${snapshot.recommendedEngine} --verify "${snapshot.verifier.command}" --budget-usd 2 --max-iterations 1`,
+        enable: `martin enable --engine ${snapshot.recommendedEngine} --verify "${snapshot.verifier.command}" --budget-usd ${defaultBudgetUsd} --max-iterations 1`,
         review: "martin review",
         dossier: "martin dossier --latest",
         share: "martin share --latest"
@@ -2048,7 +2048,7 @@ async function executeStartCommand(
       `  $ ${proofCommand}`,
       "",
       "Set repo defaults",
-      `  $ martin enable --engine ${snapshot.recommendedEngine} --verify "${snapshot.verifier.command}" --budget-usd 2 --max-iterations 1`
+      `  $ martin enable --engine ${snapshot.recommendedEngine} --verify "${snapshot.verifier.command}" --budget-usd ${defaultBudgetUsd} --max-iterations 1`
     ],
     quiet: "martin start"
   });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1952,10 +1952,17 @@ async function executeStartCommand(
   await recordPreference(environment.runsRoot, "onboarding.start.lastRun", new Date().toISOString(), "inferred").catch(() => {});
 
   const objective = "Summarize this repository and confirm the verifier is green.";
-  const preflightCommand = `martin preflight "${objective}" --verify "${snapshot.verifier.command}"`;
-  const governedRunCommand = `martin run "${objective}" --verify "${snapshot.verifier.command}" --budget-usd ${defaultBudgetUsd} --max-iterations 1`;
-  const proofCommand = `martin run "${objective}" --proof --verify "${snapshot.verifier.command}" --budget-usd ${defaultBudgetUsd} --max-iterations 1`;
-  const estimateCommand = `martin estimate "${objective}" --engine ${snapshot.recommendedEngine} --budget-usd ${defaultBudgetUsd}`;
+  const contextFlags = renderStartContextFlags(command);
+  const preflightCommand = `martin preflight "${objective}" --verify "${snapshot.verifier.command}"${contextFlags}`;
+  const governedRunCommand = `martin run "${objective}" --verify "${snapshot.verifier.command}" --budget-usd ${defaultBudgetUsd} --max-iterations 1${contextFlags}`;
+  const proofCommand = `martin run "${objective}" --proof --verify "${snapshot.verifier.command}" --budget-usd ${defaultBudgetUsd} --max-iterations 1${contextFlags}`;
+  const estimateCommand = `martin estimate "${objective}" --engine ${snapshot.recommendedEngine} --budget-usd ${defaultBudgetUsd}${contextFlags}`;
+  const doctorCommand = `martin doctor${contextFlags}`;
+  const sessionStartCommand = `martin session-start${contextFlags}`;
+  const enableCommand = `martin enable --engine ${snapshot.recommendedEngine} --verify "${snapshot.verifier.command}" --budget-usd ${defaultBudgetUsd} --max-iterations 1${contextFlags}`;
+  const reviewCommand = `martin review${renderRunsDirContextFlag(command)}`;
+  const dossierCommand = `martin dossier --latest${renderRunsDirContextFlag(command)}`;
+  const shareCommand = `martin share --latest${renderRunsDirContextFlag(command)}`;
 
   await recordCliWorkflowStep({
     runsRoot: environment.runsRoot,
@@ -1985,16 +1992,16 @@ async function executeStartCommand(
       },
       next: {
         mcpInstall: detectedIDE.mcpInstallCommand,
-        doctor: "martin doctor",
+        doctor: doctorCommand,
         estimate: estimateCommand,
-        sessionStart: "martin session-start",
+        sessionStart: sessionStartCommand,
         preflight: preflightCommand,
         run: governedRunCommand,
         proofRun: proofCommand,
-        enable: `martin enable --engine ${snapshot.recommendedEngine} --verify "${snapshot.verifier.command}" --budget-usd ${defaultBudgetUsd} --max-iterations 1`,
-        review: "martin review",
-        dossier: "martin dossier --latest",
-        share: "martin share --latest"
+        enable: enableCommand,
+        review: reviewCommand,
+        dossier: dossierCommand,
+        share: shareCommand
       }
     },
     human: [
@@ -2036,22 +2043,38 @@ async function executeStartCommand(
       `  $ ${estimateCommand}`,
       "",
       "── Step 3: Governed Run ──",
-      `  $ martin doctor`,
+      `  $ ${doctorCommand}`,
       `  $ ${preflightCommand}`,
       `  $ ${governedRunCommand}`,
       "",
       "── Step 4: Inspect Results ──",
-      `  $ martin dossier --latest`,
-      `  $ martin share --latest`,
+      `  $ ${dossierCommand}`,
+      `  $ ${shareCommand}`,
       "",
       "No-spend proof lane",
       `  $ ${proofCommand}`,
       "",
       "Set repo defaults",
-      `  $ martin enable --engine ${snapshot.recommendedEngine} --verify "${snapshot.verifier.command}" --budget-usd ${defaultBudgetUsd} --max-iterations 1`
+      `  $ ${enableCommand}`
     ],
     quiet: "martin start"
   });
+}
+
+function renderStartContextFlags(command: StartCommand): string {
+  return [renderCwdContextFlag(command), renderRunsDirContextFlag(command)].filter(Boolean).join("");
+}
+
+function renderCwdContextFlag(command: StartCommand): string {
+  return command.cwd ? ` --cwd "${escapeCliDoubleQuoted(command.cwd)}"` : "";
+}
+
+function renderRunsDirContextFlag(command: StartCommand): string {
+  return command.runsDir ? ` --runs-dir "${escapeCliDoubleQuoted(command.runsDir)}"` : "";
+}
+
+function escapeCliDoubleQuoted(value: string): string {
+  return value.replaceAll('"', '\\"');
 }
 
 async function executeEnableCommand(

--- a/packages/cli/src/workflow-state.ts
+++ b/packages/cli/src/workflow-state.ts
@@ -225,13 +225,17 @@ export async function evaluateCliRunGate(input: CliRunGateInput): Promise<CliRun
     missingSteps.push("session-start");
   }
 
-  // Preflight check: match on workingDirectory + engine only (not objective/verifier hash).
+  // Preflight check: match on workingDirectory + engine + execution bounds.
   // The full hash match was too strict — minor objective wording differences would break
   // the receipt chain. The key governance signal is that preflight ran for this directory
   // and engine recently; the exact objective text can drift between preflight and run.
+  // Path policy and budget are execution bounds, so changing them requires a fresh preflight.
   const preflightReady = isFresh(cliState["preflight"], PREFLIGHT_TTL_MS, (receipt) =>
     receipt.workingDirectory === workingDirectory &&
-    receipt.engine === engine
+    receipt.engine === engine &&
+    receipt.verificationPlanKey === verificationPlanKey &&
+    receipt.pathScopeKey === pathScopeKey &&
+    (!budgetKey || receipt.budgetKey === budgetKey)
   );
   if (!preflightReady) {
     missingSteps.push("preflight");
@@ -280,7 +284,10 @@ function buildBlockedMessage(missingSteps: CliWorkflowStepName[], nextCommand: s
   const labels = missingSteps.map((step) =>
     step === "session-start" ? "session start" : step
   );
-  return `Governed run blocked until MartinLoop receipts exist for ${labels.join(", ")}. Next command: ${nextCommand}`;
+  const preflightReason = missingSteps.includes("preflight")
+    ? " Preflight must be rerun when engine, verifier, path scope or budget changed."
+    : "";
+  return `Governed run blocked until MartinLoop receipts exist for ${labels.join(", ")}.${preflightReason} Next command: ${nextCommand}`;
 }
 
 async function readWorkflowState(runsRoot: string): Promise<WorkflowState> {

--- a/packages/cli/tests/operator-commands.test.ts
+++ b/packages/cli/tests/operator-commands.test.ts
@@ -586,7 +586,7 @@ describe("operator commands", () => {
           maxIterations: 1
         });
         expect(start.next).toHaveProperty("proofRun");
-        expect(start.next.share).toBe("martin share --latest");
+        expect(start.next.share).toContain(`--runs-dir "${runsRoot}"`);
         expect(env.command).toBe("env");
         expect(env.verifier.command).toBe("npm test");
         expect(env.receiptSigning).toHaveProperty("ready");
@@ -663,6 +663,36 @@ describe("operator commands", () => {
         expect(start.next.run).toContain("--budget-usd 7");
         expect(start.next.proofRun).toContain("--budget-usd 7");
         expect(start.next.enable).toContain("--budget-usd 7");
+      } finally {
+        await rm(workingDirectory, { force: true, recursive: true }).catch(() => {});
+      }
+    });
+  });
+
+  it("start carries explicit cwd and runs-dir into generated next-step commands", async () => {
+    await withRunsRoot(async (runsRoot) => {
+      const workingDirectory = await mkdtemp(join(tmpdir(), "martin-cli-start-context-"));
+
+      try {
+        await writeFile(
+          join(workingDirectory, "package.json"),
+          JSON.stringify({ name: "demo", version: "1.0.0", scripts: { test: "node -e \"process.exit(0)\"" } }, null, 2),
+          "utf8"
+        );
+
+        const start = JSON.parse(
+          (
+            await executeCli(["--json", "start", "--cwd", workingDirectory, "--runs-dir", runsRoot])
+          ).stdout
+        );
+
+        expect(start.next.doctor).toContain(`--cwd "${workingDirectory}"`);
+        expect(start.next.doctor).toContain(`--runs-dir "${runsRoot}"`);
+        expect(start.next.estimate).toContain(`--cwd "${workingDirectory}"`);
+        expect(start.next.estimate).toContain(`--runs-dir "${runsRoot}"`);
+        expect(start.next.preflight).toContain(`--cwd "${workingDirectory}"`);
+        expect(start.next.run).toContain(`--runs-dir "${runsRoot}"`);
+        expect(start.next.enable).toContain(`--cwd "${workingDirectory}"`);
       } finally {
         await rm(workingDirectory, { force: true, recursive: true }).catch(() => {});
       }

--- a/packages/cli/tests/operator-commands.test.ts
+++ b/packages/cli/tests/operator-commands.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { detectCodexHostPlatform } from "@martin/adapters";
-import { writeReceiptIntegrityMaterial } from "@martin/core";
+import { recordPreference, writeReceiptIntegrityMaterial } from "@martin/core";
 import { createLoopRecord, type LoopEventDraft, type LoopRecord } from "@martin/contracts";
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -634,6 +634,35 @@ describe("operator commands", () => {
         await expect(readFile(enable.configPath, "utf8")).resolves.toContain("policyProfile: strict_local");
         expect(review.command).toBe("review");
         expect(review.status).toBe("no_runs");
+      } finally {
+        await rm(workingDirectory, { force: true, recursive: true }).catch(() => {});
+      }
+    });
+  });
+
+  it("start uses stored budget preference consistently in onboarding commands", async () => {
+    await withRunsRoot(async (runsRoot) => {
+      const workingDirectory = await mkdtemp(join(tmpdir(), "martin-cli-start-budget-"));
+
+      try {
+        await writeFile(
+          join(workingDirectory, "package.json"),
+          JSON.stringify({ name: "demo", version: "1.0.0", scripts: { test: "node -e \"process.exit(0)\"" } }, null, 2),
+          "utf8"
+        );
+        await recordPreference(runsRoot, "budget.default", 7, "explicit");
+
+        const start = JSON.parse(
+          (
+            await executeCli(["--json", "start", "--cwd", workingDirectory, "--runs-dir", runsRoot])
+          ).stdout
+        );
+
+        expect(start.recommended.budgetUsd).toBe(7);
+        expect(start.next.estimate).toContain("--budget-usd 7");
+        expect(start.next.run).toContain("--budget-usd 7");
+        expect(start.next.proofRun).toContain("--budget-usd 7");
+        expect(start.next.enable).toContain("--budget-usd 7");
       } finally {
         await rm(workingDirectory, { force: true, recursive: true }).catch(() => {});
       }

--- a/packages/cli/tests/workflow-state.test.ts
+++ b/packages/cli/tests/workflow-state.test.ts
@@ -197,4 +197,131 @@ describe("workflow state gate", () => {
       await rm(runsRoot, { recursive: true, force: true });
     }
   });
+
+  it("blocks run when path scope differs from the preflight receipt", async () => {
+    const runsRoot = await mkdtemp(join(tmpdir(), "martin-workflow-state-path-scope-"));
+    const workingDirectory = join(runsRoot, "workspace");
+    const objective = "Verify scoped changes";
+    const verificationPlan = ["npm test"];
+    const receiptScope = {
+      invocationRoot: workingDirectory,
+      workingDirectory,
+      repoRoot: workingDirectory,
+      runsRoot
+    };
+    const budget = {
+      maxUsd: 1,
+      softLimitUsd: 1,
+      maxIterations: 1,
+      maxTokens: 1000
+    };
+
+    try {
+      await recordCliWorkflowStep({
+        runsRoot,
+        step: "doctor",
+        workingDirectory,
+        receiptScope
+      });
+      await recordCliWorkflowStep({
+        runsRoot,
+        step: "estimate",
+        workingDirectory,
+        objective,
+        receiptScope
+      });
+      await recordCliWorkflowStep({
+        runsRoot,
+        step: "preflight",
+        workingDirectory,
+        objective,
+        engine: "codex",
+        verificationPlan,
+        receiptScope,
+        allowedPaths: ["docs/**"],
+        budget
+      });
+
+      const gate = await evaluateCliRunGate({
+        runsRoot,
+        workingDirectory,
+        objective,
+        engine: "codex",
+        verificationPlan,
+        receiptScope,
+        allowedPaths: ["packages/**"],
+        budget
+      });
+
+      expect(gate.allowed).toBe(false);
+      expect(gate.missingSteps).toContain("preflight");
+      expect(gate.nextCommand).toContain("martin-loop preflight");
+      expect(gate.message).toContain("path scope or budget changed");
+    } finally {
+      await rm(runsRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("blocks run when verifier bounds differ from the preflight receipt", async () => {
+    const runsRoot = await mkdtemp(join(tmpdir(), "martin-workflow-state-verifier-"));
+    const workingDirectory = join(runsRoot, "workspace");
+    const objective = "Verify scoped changes";
+    const receiptScope = {
+      invocationRoot: workingDirectory,
+      workingDirectory,
+      repoRoot: workingDirectory,
+      runsRoot
+    };
+    const budget = {
+      maxUsd: 1,
+      softLimitUsd: 1,
+      maxIterations: 1,
+      maxTokens: 1000
+    };
+
+    try {
+      await recordCliWorkflowStep({
+        runsRoot,
+        step: "doctor",
+        workingDirectory,
+        receiptScope
+      });
+      await recordCliWorkflowStep({
+        runsRoot,
+        step: "estimate",
+        workingDirectory,
+        objective,
+        receiptScope
+      });
+      await recordCliWorkflowStep({
+        runsRoot,
+        step: "preflight",
+        workingDirectory,
+        objective,
+        engine: "codex",
+        verificationPlan: ["npm test"],
+        receiptScope,
+        allowedPaths: ["packages/**"],
+        budget
+      });
+
+      const gate = await evaluateCliRunGate({
+        runsRoot,
+        workingDirectory,
+        objective,
+        engine: "codex",
+        verificationPlan: ["npm run test:ci"],
+        receiptScope,
+        allowedPaths: ["packages/**"],
+        budget
+      });
+
+      expect(gate.allowed).toBe(false);
+      expect(gate.missingSteps).toContain("preflight");
+      expect(gate.nextCommand).toContain("martin-loop preflight");
+      expect(gate.message).toContain("engine, verifier, path scope or budget changed");
+    } finally {
+      await rm(runsRoot, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- honor the stored start budget preference consistently across recommended next-step commands
- preserve explicit `--cwd` and `--runs-dir` in generated loop workflow commands
- require a fresh preflight when execution bounds change: engine, verifier, path scope, or budget

## Public release boundary
- excludes hosted sync / durable hosted queue work
- includes only R2 Loop Experience CLI workflow fixes
- staged from latest public `origin/main`

## Verification
- `pnpm public:copy-scan`
- `pnpm public:portability-guard`
- `git diff --check`
- `pnpm --filter @martin/cli test -- operator-commands.test.ts`
- `pnpm --filter @martin/cli test -- workflow-state.test.ts`
- `pnpm --filter @martin/cli exec vitest run tests/cli-integration.test.ts --reporter=verbose -t "keeps governed receipts valid when guardrails normalize configured budgets"`
- `pnpm --filter @martin/cli lint`
- `pnpm --filter @martin/cli build`
- `pnpm pack --pack-destination $env:TEMP\martin-r2-public-pack`
- clean install from packed tarball with installed-package proof for budget/context/bounds behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Recommended CLI next-step commands now preserve the active working directory and runs directory.
  - Commands correctly reflect saved budget preferences and safely handle paths containing quotation marks.
  - Workflow guidance now displays context-aware commands for diagnostics, preparation, execution, proof, sharing, and enabling.

- **Bug Fixes**
  - Runs are now blocked when verifier settings, path scope, or budget changes after preflight.
  - Improved guidance explains when preflight must be rerun.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->