### PR TITLE
docs: update martin-loop 0.4.3 package line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [0.4.3]
+
+### Fixed
+- **Start budget preference consistency** — `martin start` now uses the stored default budget consistently across recommended estimate, run, proof-run, and enable commands.
+- **Generated workflow commands preserve context** — start output now carries explicit `--cwd` and `--runs-dir` through the generated doctor, estimate, preflight, run, enable, dossier, and share commands.
+- **Preflight reuse is bound to execution bounds** — governed runs now require a fresh preflight when engine, verifier, path scope, or budget bounds change, while unchanged bounds continue through the receipt chain normally.
+
 ## [0.4.2]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ npx -y martin-loop@latest preflight "Summarize the demo workspace and prove test
 
 `share --latest` writes `run-receipt.json` and `run-receipt.md` into the selected run directory under `share/`. Proof-card images are opt-in with `--with-proof-card` or `--proof-card-format`.
 
-Release notes for the current root package: [MartinLoop 0.4.2](./docs/release/OSS-0.4.2-RELEASE-NOTES.md).
+Release notes for the current root package: [MartinLoop 0.4.3](./docs/release/OSS-0.4.3-RELEASE-NOTES.md).
 
 ## Visual Proof
 
@@ -127,17 +127,17 @@ Example receipt files: [Markdown](./docs/examples/proof-receipts/live-governed-r
 Use this lane from a clean temp directory to verify the public CLI flow exactly as shipped:
 
 ```sh
-npx -y martin-loop@0.4.2 --version
-npx -y martin-loop@0.4.2 start
-npx -y martin-loop@0.4.2 demo
+npx -y martin-loop@0.4.3 --version
+npx -y martin-loop@0.4.3 start
+npx -y martin-loop@0.4.3 demo
 cd martin-loop-demo
 npm install
-npx -y martin-loop@0.4.2 run "Summarize the demo workspace and prove tests still pass" --verify "npm test" --budget-usd 2 --max-iterations 1 --json
-npx -y martin-loop@0.4.2 dossier --latest --json
-npx -y martin-loop@0.4.2 share --latest --json
+npx -y martin-loop@0.4.3 run "Summarize the demo workspace and prove tests still pass" --verify "npm test" --budget-usd 2 --max-iterations 1 --json
+npx -y martin-loop@0.4.3 dossier --latest --json
+npx -y martin-loop@0.4.3 share --latest --json
 ```
 
-For deterministic installs, pin the package line (`martin-loop@0.4.2`) or use `martin-loop@latest`. Plain `npx martin-loop` can resolve a stale local cache on some machines.
+For deterministic installs, pin the package line (`martin-loop@0.4.3`) or use `martin-loop@latest`. Plain `npx martin-loop` can resolve a stale local cache on some machines.
 
 Default share bundle outputs:
 
@@ -305,7 +305,7 @@ npx martin-loop mcp print-config --host gemini --transport stdio --profile full-
 npx martin-loop mcp print-config --host generic --transport stdio --profile github-review
 ```
 
-The root `martin-loop` package and the standalone `@martinloop/mcp` package move on separate version lines. The current root package line here is `0.4.2`; the current standalone MCP source line is `0.3.7`, and the live npm baseline is `0.3.7`.
+The root `martin-loop` package and the standalone `@martinloop/mcp` package move on separate version lines. The current root package line here is `0.4.3`; the current standalone MCP source line is `0.3.7`, and the live npm baseline is `0.3.7`.
 
 The public MCP release train labels are:
 

--- a/dist/vendor/cli/package.json
+++ b/dist/vendor/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@martin/cli",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "description": "Martin Loop CLI — budget-aware coding loops with failure classification and verified exits.",
   "main": "./index.js",

--- a/docs/release/OSS-0.4.3-RELEASE-NOTES.md
+++ b/docs/release/OSS-0.4.3-RELEASE-NOTES.md
@@ -1,0 +1,33 @@
+# MartinLoop 0.4.3 — Loop workflow consistency fixes
+
+`0.4.3` is a focused patch on top of `0.4.2` that tightens the local loop workflow around budget preferences, command context, and preflight approval boundaries.
+
+## What changed
+
+- `martin start` now uses the stored default budget consistently across recommended estimate, run, proof-run, and enable commands
+- generated next-step commands now preserve explicit `--cwd` and `--runs-dir` values so users can keep governing the intended workspace and run store
+- preflight receipts are now tied to execution bounds: changing engine, verifier, path scope, or budget requires a fresh preflight, while unchanged bounds continue normally
+
+## Why it matters
+
+The first-run workflow is where users learn whether MartinLoop is a real governance layer or just another wrapper. This patch keeps the generated command path faithful to the user's selected workspace, run directory, budget, verifier, engine, and file scope.
+
+## Upgrade / audit lane
+
+```sh
+npx -y martin-loop@0.4.3 --version
+npx -y martin-loop@0.4.3 start
+npx -y martin-loop@0.4.3 demo
+cd martin-loop-demo
+npm install
+npx -y martin-loop@0.4.3 run "Summarize the demo workspace and prove tests still pass" --verify "npm test" --budget-usd 2 --max-iterations 1 --json
+npx -y martin-loop@0.4.3 dossier --latest --json
+npx -y martin-loop@0.4.3 share --latest --json
+```
+
+## Package lines in this release
+
+- root package advances to `0.4.3`
+- standalone `@martinloop/mcp` remains on `0.3.7`
+
+See [VERSION-LEDGER.md](./VERSION-LEDGER.md) for the canonical version map.

--- a/docs/release/VERSION-LEDGER.md
+++ b/docs/release/VERSION-LEDGER.md
@@ -4,10 +4,10 @@ This file is the release source of truth for package/version mapping in this rep
 
 ## Root package: `martin-loop`
 
-- live npm dist-tag `latest`: `0.4.2`
-- live public GitHub release: `v0.4.2`
-- live public baseline in this train: `0.4.2`
-- root public baseline: `0.4.2`
+- live npm dist-tag `latest`: `0.4.3`
+- live public GitHub release: `v0.4.3`
+- live public baseline in this train: `0.4.3`
+- root public baseline: `0.4.3`
 - releases consumed since the original `0.2.8` launch:
   - `0.2.9` fixed proof-run classification, Windows `.cmd` resolution, and public provider defaults
   - `0.2.10` tightened verifier evidence, `--runs-dir` consistency, and public help output
@@ -30,8 +30,9 @@ This file is the release source of truth for package/version mapping in this rep
   - `0.4.0` receipt-first share ledgers, receipts as default share artifact, MCP discovery updated, --verify-only removed, CI action SHA pinning
   - `0.4.1` preflight receipt written on all CI platforms (codex availability override fix), receipt-first trust surface defaults
   - `0.4.2` error normalization restored, Codex launch failure diagnostics improved, token flag regression guard added
-- current in-repo root release line: `0.4.2`
-- next planned root follow-on after `0.4.2`: `0.4.3`
+  - `0.4.3` start budget consistency, generated command context preservation, preflight execution-bound reuse checks
+- current in-repo root release line: `0.4.3`
+- next planned root follow-on after `0.4.3`: `0.4.4`
 
 ## Standalone package: `@martinloop/mcp`
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "martin-loop",
   "private": false,
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "description": "Open-source command center for governed AI coding agents with built-in onboarding, hard gates, MCP, and shareable run receipts.",
   "packageManager": "pnpm@10.33.0",


### PR DESCRIPTION
## Summary
- advance the root package line to `0.4.3`
- add public 0.4.3 release notes for the merged R2 loop workflow fixes
- update README, changelog, version ledger, and packaged CLI facade metadata

## Scope
- release bookkeeping only
- no hosted sync changes
- no product code changes beyond the already-merged R2 PR

## Verification
- `pnpm public:copy-scan`
- `pnpm public:portability-guard`
- `pnpm public:git-surface`
- `node --test scripts/tests/readme-public-surface.test.mjs scripts/tests/mcp-release-docs.test.mjs scripts/tests/root-release-workflow.test.mjs scripts/tests/root-release-guard.test.mjs`
- `pnpm pack --pack-destination $env:TEMP\martin-043-release-pack`
- clean install from `martin-loop-0.4.3.tgz` with budget/context/bounds proof