### PR TITLE
fix(release): parse npm pack json robustly

### DIFF
--- a/scripts/root-release-guard.mjs
+++ b/scripts/root-release-guard.mjs
@@ -112,12 +112,17 @@ export async function inspectPackedFiles(options = {}) {
     { cwd: rootDir },
   );
   const packArtifacts = extractPackJsonPayload(packRun.stdout);
-  const files = Array.isArray(packArtifacts)
-    ? packArtifacts[0]?.files?.map((entry) => entry.path).filter((entry) => typeof entry === "string")
-    : [];
+  return extractPackedFilePaths(packArtifacts);
+}
+
+export function extractPackedFilePaths(packArtifacts) {
+  const artifact = Array.isArray(packArtifacts) ? packArtifacts[0] : null;
+  const artifactFiles = Array.isArray(artifact?.files) ? artifact.files : [];
+  const files = artifactFiles.map((entry) => entry.path).filter((entry) => typeof entry === "string");
 
   if (files.length === 0) {
-    throw new Error("npm pack --dry-run did not report any packaged files.");
+    const artifactKeys = artifact === null ? "none" : Object.keys(artifact).sort().join(", ");
+    throw new Error(`npm pack --dry-run did not report any packaged files. Artifact keys: ${artifactKeys}.`);
   }
 
   return files;
@@ -125,9 +130,83 @@ export async function inspectPackedFiles(options = {}) {
 
 export function extractPackJsonPayload(stdout) {
   const trimmed = stdout.trim();
-  const trailingJsonMatch = trimmed.match(/(\[\s*\{[\s\S]*\}\s*\])$/);
-  const jsonPayload = trailingJsonMatch?.[1] ?? trimmed;
-  return JSON.parse(jsonPayload);
+  if (trimmed.length === 0) {
+    throw new Error("npm pack --json produced no stdout.");
+  }
+
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    // npm versions may print notices around --json output. Extract the first
+    // balanced JSON value so release validation stays tied to npm's payload.
+  }
+
+  for (let index = 0; index < trimmed.length; index += 1) {
+    if (trimmed[index] !== "[" && trimmed[index] !== "{") {
+      continue;
+    }
+
+    const candidate = extractBalancedJsonValue(trimmed, index);
+    if (candidate === null) {
+      continue;
+    }
+
+    try {
+      return JSON.parse(candidate);
+    } catch {
+      continue;
+    }
+  }
+
+  throw new Error("Unable to parse npm pack --json output.");
+}
+
+function extractBalancedJsonValue(text, startIndex) {
+  const stack = [];
+  let inString = false;
+  let escaped = false;
+
+  for (let index = startIndex; index < text.length; index += 1) {
+    const character = text[index];
+
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (character === "\\") {
+        escaped = true;
+      } else if (character === "\"") {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (character === "\"") {
+      inString = true;
+      continue;
+    }
+
+    if (character === "[") {
+      stack.push("]");
+      continue;
+    }
+
+    if (character === "{") {
+      stack.push("}");
+      continue;
+    }
+
+    if (character === "]" || character === "}") {
+      if (stack.pop() !== character) {
+        return null;
+      }
+
+      if (stack.length === 0) {
+        return text.slice(startIndex, index + 1);
+      }
+    }
+  }
+
+  return null;
 }
 
 export async function assertVendoredCliManifest(rootDir) {

--- a/scripts/tests/root-release-guard.test.mjs
+++ b/scripts/tests/root-release-guard.test.mjs
@@ -9,6 +9,8 @@ import {
   assertPackedSurface,
   assertRootVersionPolicy,
   assertVendoredCliManifest,
+  extractPackedFilePaths,
+  extractPackJsonPayload,
   runRootReleaseGuard,
 } from "../root-release-guard.mjs";
 
@@ -66,6 +68,110 @@ test("assertPackedSurface rejects forbidden vendored implementation paths", () =
         "dist/vendor/cli/bin/martin.js",
       ]),
     /forbidden vendored implementation path/i,
+  );
+});
+
+test("extractPackJsonPayload parses npm pack json output containing one package", () => {
+  const payload = extractPackJsonPayload(
+    JSON.stringify([
+      {
+        filename: "martin-loop-0.4.3.tgz",
+        files: [
+          { path: "package.json" },
+          { path: "dist/bin/martin-loop.js" },
+        ],
+      },
+    ]),
+  );
+
+  assert.equal(payload[0].filename, "martin-loop-0.4.3.tgz");
+  assert.equal(payload[0].files[1].path, "dist/bin/martin-loop.js");
+});
+
+test("extractPackJsonPayload parses npm warnings before json", () => {
+  const payload = extractPackJsonPayload(
+    [
+      "npm warn config production Use --omit=dev instead.",
+      JSON.stringify([{ files: [{ path: "package.json" }] }]),
+    ].join("\n"),
+  );
+
+  assert.equal(payload[0].files[0].path, "package.json");
+});
+
+test("extractPackJsonPayload parses Windows CRLF output and paths containing spaces", () => {
+  const payload = extractPackJsonPayload(
+    [
+      "npm notice package",
+      JSON.stringify([{ files: [{ path: "demo/seeded-workspace/file with spaces.txt" }] }]),
+      "",
+    ].join("\r\n"),
+  );
+
+  assert.equal(payload[0].files[0].path, "demo/seeded-workspace/file with spaces.txt");
+});
+
+test("extractPackJsonPayload parses multiple json package objects", () => {
+  const payload = extractPackJsonPayload(
+    JSON.stringify([
+      { filename: "first.tgz", files: [{ path: "package.json" }] },
+      { filename: "second.tgz", files: [{ path: "README.md" }] },
+    ]),
+  );
+
+  assert.equal(payload.length, 2);
+  assert.equal(payload[1].filename, "second.tgz");
+});
+
+test("extractPackJsonPayload fails closed on malformed json and empty output", () => {
+  assert.throws(() => extractPackJsonPayload(""), /no stdout/i);
+  assert.throws(() => extractPackJsonPayload("npm notice\n[{ bad json }\n"), /unable to parse/i);
+});
+
+test("extractPackedFilePaths fails closed on an empty files array", () => {
+  assert.throws(
+    () => extractPackedFilePaths([{ filename: "martin-loop-0.4.3.tgz", files: [] }]),
+    /did not report any packaged files/i,
+  );
+});
+
+test("assertPackedSurface rejects missing expected files and forbidden absolute paths", () => {
+  assert.throws(
+    () =>
+      assertPackedSurface([
+        "package.json",
+        "README.md",
+        "CODE_OF_CONDUCT.md",
+      ]),
+    /missing required file/i,
+  );
+
+  assert.throws(
+    () =>
+      assertPackedSurface([
+        "package.json",
+        "README.md",
+        "CODE_OF_CONDUCT.md",
+        "dist/index.js",
+        "dist/index.d.ts",
+        "dist/bin/martin-loop.js",
+        "C:/Users/Torram/private.txt",
+      ]),
+    /unexpected path/i,
+  );
+
+  assert.throws(
+    () =>
+      assertPackedSurface([
+        "package.json",
+        "README.md",
+        "CODE_OF_CONDUCT.md",
+        "dist/index.js",
+        "dist/index.d.ts",
+        "dist/bin/martin-loop.js",
+        "/Users/private/file.txt",
+      ]),
+    /unexpected path/i,
   );
 });
 


### PR DESCRIPTION
## Summary
- parse `npm pack --json` output robustly when npm prints notice text around the JSON payload
- keep release validation fail-closed for empty, malformed, or missing packaged-file data
- add focused parser and packed-surface regression coverage

## Validation
- `node --test scripts/tests/root-release-guard.test.mjs scripts/tests/public-facade.test.mjs`
- `pnpm public:copy-scan`
- `pnpm public:portability-guard`
- `pnpm public:git-surface`
- `git diff --check`
- `pnpm --filter @martin/cli lint`
- `pnpm build`
- `node ./scripts/root-release-guard.mjs --tag v0.4.3 --pack`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release-package validation when npm outputs warnings or formatting variations alongside JSON.
  * Added clearer error reporting for missing or invalid package file listings.
  * Strengthened detection of missing required files and prohibited paths in release packages.

* **Tests**
  * Expanded coverage for npm output parsing across platforms, malformed output, multiple packages, and empty file lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->