### PR TITLE
fix(release): accept npm pack object payload

### DIFF
--- a/scripts/root-release-guard.mjs
+++ b/scripts/root-release-guard.mjs
@@ -116,7 +116,7 @@ export async function inspectPackedFiles(options = {}) {
 }
 
 export function extractPackedFilePaths(packArtifacts) {
-  const artifact = Array.isArray(packArtifacts) ? packArtifacts[0] : null;
+  const artifact = Array.isArray(packArtifacts) ? packArtifacts[0] : packArtifacts;
   const artifactFiles = Array.isArray(artifact?.files) ? artifact.files : [];
   const files = artifactFiles.map((entry) => entry.path).filter((entry) => typeof entry === "string");
 

--- a/scripts/tests/root-release-guard.test.mjs
+++ b/scripts/tests/root-release-guard.test.mjs
@@ -135,6 +135,18 @@ test("extractPackedFilePaths fails closed on an empty files array", () => {
   );
 });
 
+test("extractPackedFilePaths accepts a single-package object payload", () => {
+  const files = extractPackedFilePaths({
+    filename: "martin-loop-0.4.3.tgz",
+    files: [
+      { path: "package.json" },
+      { path: "dist/index.js" },
+    ],
+  });
+
+  assert.deepEqual(files, ["package.json", "dist/index.js"]);
+});
+
 test("assertPackedSurface rejects missing expected files and forbidden absolute paths", () => {
   assert.throws(
     () =>


### PR DESCRIPTION
## Summary
- accept npm pack JSON payloads that arrive as a single package object as well as an array
- keep empty `files` payloads failing closed
- add regression coverage for the object payload shape seen by release validation

## Validation
- `node --test scripts/tests/root-release-guard.test.mjs scripts/tests/public-facade.test.mjs`
- `pnpm public:copy-scan`
- `pnpm public:portability-guard`
- `git diff --check`