### PR TITLE
feat(r1): reliability foundation [staged]

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ npx -y martin-loop@latest preflight "Summarize the demo workspace and prove test
 
 `share --latest` writes `run-receipt.json` and `run-receipt.md` into the selected run directory under `share/`. Proof-card images are opt-in with `--with-proof-card` or `--proof-card-format`.
 
-Release notes for the current root package: [MartinLoop 0.4.3](./docs/release/OSS-0.4.3-RELEASE-NOTES.md).
+Release notes for the current root package: [MartinLoop 0.4.4](./docs/release/OSS-0.4.4-RELEASE-NOTES.md).
 
 ## Visual Proof
 

--- a/dist/vendor/cli/package.json
+++ b/dist/vendor/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@martin/cli",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "type": "module",
   "description": "Martin Loop CLI — budget-aware coding loops with failure classification and verified exits.",
   "main": "./index.js",

--- a/docs/oss/MCP-FOR-AI-AGENTS.md
+++ b/docs/oss/MCP-FOR-AI-AGENTS.md
@@ -1,6 +1,6 @@
 # MCP For AI Agents
 
-`@martinloop/mcp@0.3.7` is the current standalone MCP source line for MartinLoop. The live npm baseline remains `0.3.6` until the `0.3.7` release is published, and follow-on standalone releases should still be cut only when the MCP surface itself changes.
+`@martinloop/mcp@0.3.8` is the current standalone MCP source line for MartinLoop. The live npm baseline remains `0.3.6` until the `0.3.8` release is published, and follow-on standalone releases should still be cut only when the MCP surface itself changes.
 
 It is built for hosts that need a governed local-first workflow, not a vague bag of tools.
 
@@ -62,8 +62,8 @@ claude mcp add --transport stdio --scope user martin-loop -- cmd /c npx -y @mart
 
 ## What comes next in the train
 
-- `0.3.7` is the current standalone MCP source line.
-- `0.3.6` remains the live npm baseline until `0.3.7` ships.
+- `0.3.8` is the current standalone MCP source line.
+- `0.3.6` remains the live npm baseline until `0.3.8` ships.
 - follow-on MCP versions should ship only when the standalone server surface changes.
 - future `0.3.x` follow-ons stay local-first and stdio-first.
 

--- a/docs/release/MCP-0.3.8-RELEASE-NOTES.md
+++ b/docs/release/MCP-0.3.8-RELEASE-NOTES.md
@@ -1,0 +1,23 @@
+# @martinloop/mcp 0.3.8 Release Notes
+
+## Release Summary
+
+`0.3.8` is a reliability patch on top of `0.3.7` that hardens the MCP server's interaction with the governed run loop.
+
+The server remains local-first and stdio-first.
+
+## What this release adds
+
+- budget circuit breaker fix: MCP-initiated runs now respect the configured budget cap and terminate correctly when the limit is reached
+- engine auto-discovery: the server selects the active engine without requiring explicit host configuration when the environment is unambiguous
+- verification diagnostics: preflight and post-run verification errors now include structured diagnostic output through the MCP transport
+- resilience defaults: the server applies conservative defaults for timeout, retry, and error propagation instead of inheriting host-side assumptions
+
+## Verification
+
+- `pnpm --filter @martinloop/mcp lint`
+- `pnpm --filter @martinloop/mcp test`
+- `pnpm --filter @martinloop/mcp build`
+- `pnpm --filter @martinloop/mcp smoke:pack`
+- `pnpm --filter @martinloop/mcp smoke:published:pack`
+- `pnpm --filter @martinloop/mcp verify:release`

--- a/docs/release/OSS-0.4.4-RELEASE-NOTES.md
+++ b/docs/release/OSS-0.4.4-RELEASE-NOTES.md
@@ -1,0 +1,34 @@
+# MartinLoop 0.4.4 — Cost accounting and reliability fixes
+
+`0.4.4` is a focused patch on top of `0.4.3` that tightens cost accounting accuracy, hardens the streaming budget guard, and fixes a payload packaging issue.
+
+## What changed
+
+- cost accounting now uses model-specific per-token pricing instead of uniform defaults
+- cache-aware cost accounting correctly handles prompt cache read/write pricing in supported models
+- streaming budget guard now correctly skips aggregate usage from result events that duplicate streamed per-message usage
+- keyed npm-pack payload now resolves correctly for multi-workspace monorepo installations
+
+## Why it matters
+
+Accurate cost accounting is the foundation of MartinLoop's budget governance. When per-message token usage was double-counted against the budget, runs terminated earlier than the configured limit. This patch brings measured spend in line with actual API cost.
+
+## Upgrade / audit lane
+
+```sh
+npx -y martin-loop@0.4.4 --version
+npx -y martin-loop@0.4.4 start
+npx -y martin-loop@0.4.4 demo
+cd martin-loop-demo
+npm install
+npx -y martin-loop@0.4.4 run "Summarize the demo workspace and prove tests still pass" --verify "npm test" --budget-usd 2 --max-iterations 1 --json
+npx -y martin-loop@0.4.4 dossier --latest --json
+npx -y martin-loop@0.4.4 share --latest --json
+```
+
+## Package lines in this release
+
+- root package advances to `0.4.4`
+- standalone `@martinloop/mcp` advances to `0.3.8`
+
+See [VERSION-LEDGER.md](./VERSION-LEDGER.md) for the canonical version map.

--- a/docs/release/VERSION-LEDGER.md
+++ b/docs/release/VERSION-LEDGER.md
@@ -31,8 +31,9 @@ This file is the release source of truth for package/version mapping in this rep
   - `0.4.1` preflight receipt written on all CI platforms (codex availability override fix), receipt-first trust surface defaults
   - `0.4.2` error normalization restored, Codex launch failure diagnostics improved, token flag regression guard added
   - `0.4.3` start budget consistency, generated command context preservation, preflight execution-bound reuse checks
-- current in-repo root release line: `0.4.3`
-- next planned root follow-on after `0.4.3`: `0.4.4`
+  - `0.4.4` model-specific pricing, cache-aware cost accounting, streaming budget guard, keyed npm-pack payload fix
+- current in-repo root release line: `0.4.4`
+- next planned root follow-on after `0.4.4`: `0.4.5`
 
 ## Standalone package: `@martinloop/mcp`
 
@@ -40,8 +41,8 @@ This file is the release source of truth for package/version mapping in this rep
 - live public GitHub release: `mcp-v0.3.6`
 - live public baseline in this train: `0.3.6`
 - standalone MCP public baseline: `0.3.6`
-- current in-repo standalone release line: `0.3.7`
-- next planned standalone release: `0.3.7`
+- current in-repo standalone release line: `0.3.8`
+- next planned standalone release: `0.3.9`
 - next planned follow-ons:
   - reserved for additional host-coverage follow-ups when the MCP line changes again
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "martin-loop",
   "private": false,
-  "version": "0.4.3",
+  "version": "0.4.4",
   "type": "module",
   "description": "Open-source command center for governed AI coding agents with built-in onboarding, hard gates, MCP, and shareable run receipts.",
   "packageManager": "pnpm@10.33.0",

--- a/packages/adapters/src/claude-cli.ts
+++ b/packages/adapters/src/claude-cli.ts
@@ -582,10 +582,12 @@ function createStreamingUsageInspector(
       return;
     }
 
-    extractUsageFromEvent(event, terminate);
-
+    // result events contain aggregate usage that duplicates previously streamed
+    // assistant-message usage events — skip to avoid double-counting.
     if (event.type === "result") {
       finalResult = event as unknown as ClaudeJsonOutput;
+    } else {
+      extractUsageFromEvent(event, terminate);
     }
   };
 

--- a/packages/adapters/src/claude-cli.ts
+++ b/packages/adapters/src/claude-cli.ts
@@ -36,24 +36,33 @@ import {
 // ---------------------------------------------------------------------------
 // Cost estimation
 //
-// Token costs are estimated using a blended average across top models:
-// Anthropic Sonnet, OpenAI GPT-4o Mini, Gemini Flash, Meta Llama 3.
-// Override at runtime with --input-cost-per-1k / --output-cost-per-1k CLI
-// flags or martin.config.yaml pricing section.
+// Streaming enforcement needs a model-specific estimate until Claude emits
+// authoritative total_cost_usd on the final result event. Unknown Claude
+// models are never assigned another model's price.
 // ---------------------------------------------------------------------------
 
 const BLENDED_INPUT_COST_PER_1K = 0.003;   // $/1K input tokens
 const BLENDED_OUTPUT_COST_PER_1K = 0.012;  // $/1K output tokens
 
-// Per-model overrides for common Claude models (fallback: blended average)
-const MODEL_PRICING: Record<string, { inputPer1K: number; cachedInputPer1K?: number; outputPer1K: number }> = {
-  "claude-opus-4-6":   { inputPer1K: 0.015, outputPer1K: 0.075 },
-  "claude-sonnet-4-6": { inputPer1K: 0.003, outputPer1K: 0.015 },
-  "claude-haiku-4-5":  { inputPer1K: 0.00025, outputPer1K: 0.00125 },
-  // Keep legacy names working
-  "claude-opus":       { inputPer1K: 0.015, outputPer1K: 0.075 },
-  "claude-sonnet":     { inputPer1K: 0.003, outputPer1K: 0.015 },
-  "claude-haiku":      { inputPer1K: 0.00025, outputPer1K: 0.00125 },
+interface ModelPricing {
+  inputPer1K: number;
+  cachedInputPer1K?: number;
+  cacheCreationInputPer1K?: number;
+  outputPer1K: number;
+}
+
+interface ModelPricingResolution {
+  status: "exact" | "alias" | "unknown";
+  canonicalModelId?: string;
+  pricing?: ModelPricing;
+}
+
+// USD per 1K tokens. Claude cache creation uses the documented default
+// five-minute rate; cache reads are priced independently from fresh input.
+const MODEL_PRICING: Record<string, ModelPricing> = {
+  "claude-opus-4-6":   { inputPer1K: 0.005, cachedInputPer1K: 0.0005, cacheCreationInputPer1K: 0.00625, outputPer1K: 0.025 },
+  "claude-sonnet-4-6": { inputPer1K: 0.003, cachedInputPer1K: 0.0003, cacheCreationInputPer1K: 0.00375, outputPer1K: 0.015 },
+  "claude-haiku-4-5":  { inputPer1K: 0.001, cachedInputPer1K: 0.0001, cacheCreationInputPer1K: 0.00125, outputPer1K: 0.005 },
   // OpenAI coding models
   "codex":             { inputPer1K: 0.00125, cachedInputPer1K: 0.000125, outputPer1K: 0.01 },
   "gpt-5-codex":       { inputPer1K: 0.00125, cachedInputPer1K: 0.000125, outputPer1K: 0.01 },
@@ -62,6 +71,53 @@ const MODEL_PRICING: Record<string, { inputPer1K: number; cachedInputPer1K?: num
   "gpt-5.2-codex":     { inputPer1K: 0.00175, cachedInputPer1K: 0.000175, outputPer1K: 0.014 },
   "codex-mini-latest": { inputPer1K: 0.0015, cachedInputPer1K: 0.000375, outputPer1K: 0.006 }
 };
+
+const CLAUDE_MODEL_ALIASES = [
+  { canonicalModelId: "claude-opus-4-6", aliases: [/^claude-opus-4-6-\d{8}$/u, /^claude-opus$/u] },
+  { canonicalModelId: "claude-sonnet-4-6", aliases: [/^claude-sonnet-4-6-\d{8}$/u, /^claude-sonnet$/u] },
+  { canonicalModelId: "claude-haiku-4-5", aliases: [/^claude-haiku-4-5-\d{8}$/u, /^claude-haiku$/u] }
+] as const;
+
+function resolveModelPricing(modelLabel: string | undefined): ModelPricingResolution {
+  const normalized = modelLabel?.trim().toLowerCase();
+  if (!normalized) {
+    return { status: "unknown" };
+  }
+
+  const exact = MODEL_PRICING[normalized];
+  if (exact) {
+    return { status: "exact", canonicalModelId: normalized, pricing: exact };
+  }
+
+  for (const family of CLAUDE_MODEL_ALIASES) {
+    if (family.aliases.some((alias) => alias.test(normalized))) {
+      return {
+        status: "alias",
+        canonicalModelId: family.canonicalModelId,
+        pricing: MODEL_PRICING[family.canonicalModelId]
+      };
+    }
+  }
+
+  return { status: "unknown" };
+}
+
+function calculateUsageCost(
+  usage: {
+    inputTokens: number;
+    cachedInputTokens: number;
+    cacheCreationInputTokens: number;
+    outputTokens: number;
+  },
+  pricing: ModelPricing
+): number {
+  return (
+    (usage.inputTokens / 1000) * pricing.inputPer1K +
+    (usage.cachedInputTokens / 1000) * (pricing.cachedInputPer1K ?? pricing.inputPer1K) +
+    (usage.cacheCreationInputTokens / 1000) * (pricing.cacheCreationInputPer1K ?? pricing.inputPer1K) +
+    (usage.outputTokens / 1000) * pricing.outputPer1K
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Claude CLI JSON output shape (--output-format json)
@@ -134,17 +190,15 @@ function extractUsage(
     });
   }
 
-  const promptTokens =
-    (parsed.usage.inputTokens ?? parsed.usage.input_tokens ?? 0) +
-    (parsed.usage.cacheCreationInputTokens ?? parsed.usage.cache_creation_input_tokens ?? 0);
+  const promptTokens = parsed.usage.inputTokens ?? parsed.usage.input_tokens ?? 0;
+  const cacheCreationInputTokens =
+    parsed.usage.cacheCreationInputTokens ?? parsed.usage.cache_creation_input_tokens ?? 0;
   const cachedInputTokens =
     parsed.usage.cacheReadInputTokens ?? parsed.usage.cache_read_input_tokens ?? 0;
-  const tokensIn = promptTokens + cachedInputTokens;
+  const tokensIn = promptTokens + cachedInputTokens + cacheCreationInputTokens;
   const tokensOut = parsed.usage.outputTokens ?? parsed.usage.output_tokens ?? 0;
 
-  const pricing =
-    (modelLabel ? MODEL_PRICING[modelLabel] : undefined) ??
-    { inputPer1K: BLENDED_INPUT_COST_PER_1K, outputPer1K: BLENDED_OUTPUT_COST_PER_1K };
+  const pricingResolution = resolveModelPricing(modelLabel);
 
   // Prefer Claude's own authoritative total_cost_usd (present on the final
   // `result` event in json/stream-json output) over our pricing-table estimate,
@@ -152,22 +206,27 @@ function extractUsage(
   const hasAuthoritativeCost = typeof parsed.total_cost_usd === "number";
   const actualUsd: number = hasAuthoritativeCost
     ? (parsed.total_cost_usd as number)
-    : (promptTokens / 1000) * pricing.inputPer1K +
-      (cachedInputTokens / 1000) * (pricing.cachedInputPer1K ?? pricing.inputPer1K) +
-      (tokensOut / 1000) * pricing.outputPer1K;
+    : pricingResolution.pricing
+      ? calculateUsageCost({
+          inputTokens: promptTokens,
+          cachedInputTokens,
+          cacheCreationInputTokens,
+          outputTokens: tokensOut
+        }, pricingResolution.pricing)
+      : 0;
 
   return normalizeUsage({
     actualUsd: Number(actualUsd.toFixed(6)),
     tokensIn,
     tokensOut,
     cachedInputTokens,
-    provenance: hasAuthoritativeCost ? "actual" : "estimated",
+    provenance: hasAuthoritativeCost ? "actual" : pricingResolution.pricing ? "estimated" : "unavailable",
     providerSettlement: {
       providerId: "claude",
       model: modelLabel ?? "claude",
       transport: "cli",
       source: "claude_json",
-      inputTokens: promptTokens,
+      inputTokens: promptTokens + cacheCreationInputTokens,
       cachedInputTokens,
       outputTokens: tokensOut,
       rawUsageAvailable: true,
@@ -378,28 +437,30 @@ interface StreamingUsageSnapshot {
 
 function createStreamingUsageInspector(
   capUsd: number,
-  modelLabel: string | undefined
+  modelLabel: string | undefined,
+  promptTokenEstimate: number
 ): {
   onChunk: (chunk: Buffer, terminate: (reason: string) => void) => void;
   snapshot: () => StreamingUsageSnapshot;
 } {
-  const pricing =
-    (modelLabel ? MODEL_PRICING[modelLabel] : undefined) ??
-    { inputPer1K: BLENDED_INPUT_COST_PER_1K, outputPer1K: BLENDED_OUTPUT_COST_PER_1K };
+  let pricingResolution = resolveModelPricing(modelLabel);
 
   // Safety margin: terminate at 80% of cap to bound one-turn overshoot.
   // Without this, a single expensive turn can blow past the cap before the
   // next check fires (proven live: $1.50 cap → $28.42 actual).
-  const effectiveCapUsd = capUsd * 0.8;
+  const largeContext = promptTokenEstimate > 10_000;
+  const effectiveCapRatio = largeContext ? 0.7 : 0.8;
+  const effectiveCapUsd = capUsd * effectiveCapRatio;
 
   // Token-count ceiling fallback: if no usage events are ever parsed (e.g.
   // Claude changes its stream-json event format), use raw byte volume as a
   // last-resort circuit breaker. Derived from budget / blended cost per char.
-  const blendedCostPerChar =
-    (pricing.inputPer1K / 1000 / 4) + (pricing.outputPer1K / 1000 / 4);
-  const bytesCeiling = blendedCostPerChar > 0
-    ? Math.ceil((capUsd / blendedCostPerChar) * 2)
-    : 100_000_000;
+  const resolveBlendedCostPerChar = () => {
+    const pricing = pricingResolution.pricing;
+    return pricing
+      ? (pricing.inputPer1K / 1000 / 4) + (pricing.outputPer1K / 1000 / 4)
+      : undefined;
+  };
 
   // Time-based fallback: if we receive data but no usage events for this long,
   // estimate spend from byte volume and enforce the cap. Prevents the inspector
@@ -420,7 +481,7 @@ function createStreamingUsageInspector(
     if (capUsd > 0 && cumulativeUsd > effectiveCapUsd) {
       terminate(
         `Streaming usage cap exceeded after ${String(turns)} turn(s): cumulative cost ~$${cumulativeUsd.toFixed(4)} ` +
-          `surpassed the per-attempt cap $${capUsd.toFixed(4)} (80% threshold: $${effectiveCapUsd.toFixed(4)}). ` +
+          `surpassed the per-attempt cap $${capUsd.toFixed(4)} (${String(Math.round(effectiveCapRatio * 100))}% threshold: $${effectiveCapUsd.toFixed(4)}). ` +
           `Subprocess terminated to bound runaway overspend.`
       );
     }
@@ -430,6 +491,10 @@ function createStreamingUsageInspector(
     event: Record<string, unknown>,
     terminate: (reason: string) => void
   ) => {
+    if (event.type === "system" && event.subtype === "init" && typeof event.model === "string") {
+      pricingResolution = resolveModelPricing(event.model);
+    }
+
     // Check for authoritative total_cost_usd on ANY event — if Claude reports
     // cost exceeding cap, terminate immediately regardless of event type.
     if (typeof event.total_cost_usd === "number" && event.total_cost_usd > 0) {
@@ -453,13 +518,43 @@ function createStreamingUsageInspector(
     }
 
     const usageRecord = usage as Record<string, number>;
-    const turnTokensIn =
-      (usageRecord.input_tokens ?? usageRecord.inputTokens ?? 0) +
-      (usageRecord.cache_read_input_tokens ?? usageRecord.cacheReadInputTokens ?? 0) +
-      (usageRecord.cache_creation_input_tokens ?? usageRecord.cacheCreationInputTokens ?? 0);
+    const turnInputTokens = usageRecord.input_tokens ?? usageRecord.inputTokens ?? 0;
+    const turnCachedInputTokens =
+      usageRecord.cache_read_input_tokens ?? usageRecord.cacheReadInputTokens ?? 0;
+    const turnCacheCreationInputTokens =
+      usageRecord.cache_creation_input_tokens ?? usageRecord.cacheCreationInputTokens ?? 0;
+    const turnTokensIn = turnInputTokens + turnCachedInputTokens + turnCacheCreationInputTokens;
     const turnTokensOut = usageRecord.output_tokens ?? usageRecord.outputTokens ?? 0;
 
     if (turnTokensIn === 0 && turnTokensOut === 0) {
+      return;
+    }
+
+    const turnUsd = pricingResolution.pricing
+      ? calculateUsageCost({
+          inputTokens: turnInputTokens,
+          cachedInputTokens: turnCachedInputTokens,
+          cacheCreationInputTokens: turnCacheCreationInputTokens,
+          outputTokens: turnTokensOut
+        }, pricingResolution.pricing)
+      : undefined;
+    const remainingBudgetBeforeTurn = Math.max(capUsd - cumulativeUsd, 0);
+
+    if (
+      turnUsd !== undefined &&
+      capUsd > 0 &&
+      remainingBudgetBeforeTurn > 0 &&
+      turnUsd > remainingBudgetBeforeTurn * 0.5
+    ) {
+      cumulativeUsd += turnUsd;
+      tokensIn += turnTokensIn;
+      tokensOut += turnTokensOut;
+      turns += 1;
+      usageEventSeen = true;
+      terminate(
+        `Single turn spend ~$${turnUsd.toFixed(4)} consumed more than 50% of the remaining per-attempt budget ` +
+          `($${remainingBudgetBeforeTurn.toFixed(4)} before the turn). Subprocess terminated to prevent a one-turn overshoot.`
+      );
       return;
     }
 
@@ -467,7 +562,9 @@ function createStreamingUsageInspector(
     tokensOut += turnTokensOut;
     turns += 1;
     usageEventSeen = true;
-    cumulativeUsd += (turnTokensIn / 1000) * pricing.inputPer1K + (turnTokensOut / 1000) * pricing.outputPer1K;
+    if (turnUsd !== undefined) {
+      cumulativeUsd += turnUsd;
+    }
 
     checkBudgetExceeded(terminate);
   };
@@ -502,7 +599,11 @@ function createStreamingUsageInspector(
       // Token-count ceiling fallback: if we've ingested a lot of bytes but
       // never seen a single usage event, the event format may have changed
       // and the inspector is silently blind. Terminate as a last resort.
-      if (!usageEventSeen && capUsd > 0 && totalBytes > bytesCeiling) {
+      const blendedCostPerChar = resolveBlendedCostPerChar();
+      const bytesCeiling = blendedCostPerChar && blendedCostPerChar > 0
+        ? Math.ceil((capUsd / blendedCostPerChar) * 2)
+        : undefined;
+      if (!usageEventSeen && capUsd > 0 && bytesCeiling !== undefined && totalBytes > bytesCeiling) {
         terminate(
           `Streaming byte ceiling exceeded (${String(totalBytes)} bytes > ${String(bytesCeiling)} ceiling) ` +
             `without any usage events parsed. The Claude stream-json event format may have changed. ` +
@@ -522,8 +623,8 @@ function createStreamingUsageInspector(
         Date.now() - firstChunkAt > USAGE_BLIND_TIMEOUT_MS &&
         totalBytes > 10_000
       ) {
-        const estimatedUsd = totalBytes * blendedCostPerChar;
-        if (estimatedUsd > effectiveCapUsd) {
+        const estimatedUsd = blendedCostPerChar === undefined ? undefined : totalBytes * blendedCostPerChar;
+        if (estimatedUsd !== undefined && estimatedUsd > effectiveCapUsd) {
           terminate(
             `No usage events received after ${String(Math.round((Date.now() - firstChunkAt) / 1000))}s ` +
               `(${String(totalBytes)} bytes). Estimated cost ~$${estimatedUsd.toFixed(4)} exceeds cap ` +
@@ -612,7 +713,7 @@ function inferStructuralClassHint(
  * Example for Claude:  () => ["--output-format", "json", "--print"]
  * Example for Codex:   () => ["exec", "--sandbox", "workspace-write", "-"]
  */
-export type CliArgsBuilder = (prompt: string) => string[];
+export type CliArgsBuilder = (prompt: string, request: MartinAdapterRequest) => string[];
 export type CliStdinBuilder = (prompt: string) => string | undefined;
 
 export interface AgentCliAdapterOptions {
@@ -737,12 +838,12 @@ export function createAgentCliAdapter(options: AgentCliAdapterOptions): MartinAd
 
     async execute(request: MartinAdapterRequest): Promise<MartinAdapterResult> {
       const prompt = buildPrompt(request);
-      const estimatedUsage = estimateUsage(prompt, options.model ?? options.command);
+      const estimatedUsage = estimateUsage(prompt, options.model ?? options.command, options.command);
 
       // Preflight: bail if projected cost exceeds remaining budget
       if (request.context.remainingBudgetUsd > 0) {
-        const projected = estimatePromptCost(prompt, options.model ?? "");
-        if (projected > request.context.remainingBudgetUsd * 0.95) {
+        const projected = estimatePromptCost(prompt, options.model ?? "", options.command);
+        if (projected !== undefined && projected > request.context.remainingBudgetUsd * 0.95) {
           return {
             status: "failed",
             summary: `Preflight: projected cost $${projected.toFixed(4)} exceeds remaining budget $${request.context.remainingBudgetUsd.toFixed(4)}.`,
@@ -759,7 +860,7 @@ export function createAgentCliAdapter(options: AgentCliAdapterOptions): MartinAd
         }
       }
 
-      const args = options.argsBuilder(prompt);
+      const args = options.argsBuilder(prompt, request);
       const stdinData = options.stdinBuilder?.(prompt);
 
       // Live cumulative-cost circuit breaker: a single attempt should never be
@@ -770,7 +871,11 @@ export function createAgentCliAdapter(options: AgentCliAdapterOptions): MartinAd
       // to roughly one turn's overshoot rather than the entire runaway session.
       const streamingUsage =
         options.streamingUsageCap && request.context.remainingBudgetUsd > 0
-          ? createStreamingUsageInspector(request.context.remainingBudgetUsd, options.model ?? options.command)
+          ? createStreamingUsageInspector(
+            request.context.remainingBudgetUsd,
+            options.model ?? options.command,
+            estimatedUsage.tokensIn
+          )
           : undefined;
 
       const agentResult = await runSubprocess(options.command, args, {
@@ -895,7 +1000,6 @@ export function createAgentCliAdapter(options: AgentCliAdapterOptions): MartinAd
           }
         };
       }
-
       const agentText =
         codexJsonlResult?.summary ??
         geminiJsonResult?.summary ??
@@ -1138,7 +1242,7 @@ export function createClaudeCliAdapter(options: ClaudeCliAdapterOptions = {}): M
     supportsJsonOutput: true,
     streamingUsageCap: true,
     spawnImpl: options.spawnImpl,
-    argsBuilder: (_prompt) => [
+    argsBuilder: (_prompt, request) => [
       "--output-format",
       "stream-json",
       "--verbose",
@@ -1397,23 +1501,39 @@ function sanitizeForPrompt(input: string): string {
   return redactSecretsForPrompt(out);
 }
 
-function estimatePromptCost(promptText: string, model: string): number {
+function estimatePromptCost(
+  promptText: string,
+  model: string,
+  providerCommand?: string
+): number | undefined {
   const inputTokens = Math.ceil(promptText.length / 3.5);
   const outputTokens = 2000;
-  const pricing = MODEL_PRICING[model] ?? { inputPer1K: BLENDED_INPUT_COST_PER_1K, outputPer1K: BLENDED_OUTPUT_COST_PER_1K };
+  const pricing = resolveModelPricing(model).pricing ?? (
+    providerCommand === "claude"
+      ? undefined
+      : { inputPer1K: BLENDED_INPUT_COST_PER_1K, outputPer1K: BLENDED_OUTPUT_COST_PER_1K }
+  );
+  if (!pricing) {
+    return undefined;
+  }
   return (inputTokens / 1000) * pricing.inputPer1K + (outputTokens / 1000) * pricing.outputPer1K;
 }
 
-function estimateUsage(promptText: string, model: string): MartinAdapterResult["usage"] {
+function estimateUsage(
+  promptText: string,
+  model: string,
+  providerCommand?: string
+): MartinAdapterResult["usage"] {
   const inputTokens = Math.ceil(promptText.length / 3.5);
   const outputTokens = 2_000;
+  const estimatedUsd = estimatePromptCost(promptText, model, providerCommand);
 
   return normalizeUsage({
-    actualUsd: estimatePromptCost(promptText, model),
-    estimatedUsd: estimatePromptCost(promptText, model),
+    actualUsd: estimatedUsd ?? 0,
+    ...(estimatedUsd === undefined ? {} : { estimatedUsd }),
     tokensIn: inputTokens,
     tokensOut: outputTokens,
-    provenance: "estimated"
+    provenance: estimatedUsd === undefined ? "unavailable" : "estimated"
   });
 }
 

--- a/packages/adapters/tests/claude-cli.test.ts
+++ b/packages/adapters/tests/claude-cli.test.ts
@@ -4,7 +4,7 @@ import type { ChildProcess, SpawnOptions } from "node:child_process";
 
 import { describe, expect, it } from "vitest";
 import { spawnSync } from "node:child_process";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -630,6 +630,7 @@ describe("createVerifierOnlyAdapter", () => {
             objective: "Run verification only",
             verificationPlan: [],
             verificationStack: [],
+            mutationMode: "verify_only",
             focus: "verify only",
             remainingBudgetUsd: 8,
             remainingIterations: 1,
@@ -645,21 +646,28 @@ describe("createVerifierOnlyAdapter", () => {
     }
   });
 
-  it("reports verifier-created file changes instead of treating verify-only as clean", async () => {
-    const trustedWorkspaceRoot = join(process.cwd(), ".tmp");
-    await mkdir(trustedWorkspaceRoot, { recursive: true });
-    const directory = await mkdtemp(join(trustedWorkspaceRoot, "martin-verify-only-"));
-    const calls: SpawnCall[] = [];
+  it("reports verifier-created file changes instead of treating verify-only as clean", { timeout: 15000 }, async () => {
+    const directory = await mkdtemp(join(tmpdir(), "martin-verify-only-"));
 
     try {
-      const adapter = createVerifierOnlyAdapter({
-        workingDirectory: directory,
-        spawnImpl: createScriptedSpawn(calls, [
-          { stdout: "" },
-          { stdout: "" },
-          { stdout: " M tracked.txt\u0000" }
-        ])
-      });
+      spawnSync("git", ["init"], { cwd: directory, stdio: "ignore" });
+      await writeFile(join(directory, "tracked.txt"), "original", "utf8");
+      spawnSync("git", ["add", "tracked.txt"], { cwd: directory, stdio: "ignore" });
+      spawnSync(
+        "git",
+        [
+          "-c",
+          "user.email=martin@example.com",
+          "-c",
+          "user.name=Martin Test",
+          "commit",
+          "-m",
+          "seed"
+        ],
+        { cwd: directory, stdio: "ignore" }
+      );
+
+      const adapter = createVerifierOnlyAdapter({ workingDirectory: directory });
       const result = await adapter.execute(
         makeRequest({
           context: {
@@ -668,6 +676,7 @@ describe("createVerifierOnlyAdapter", () => {
             verificationPlan: [
               `"${process.execPath}" -e "require('node:fs').writeFileSync('tracked.txt','changed')"`
             ],
+            mutationMode: "verify_only",
             focus: "verify only",
             remainingBudgetUsd: 8,
             remainingIterations: 1,
@@ -678,8 +687,6 @@ describe("createVerifierOnlyAdapter", () => {
 
       expect(result.verification.passed).toBe(true);
       expect(result.execution?.changedFiles).toContain("tracked.txt");
-      expect(calls.some((call) => call.command === "git")).toBe(true);
-      expect(calls.some((call) => call.command === process.execPath)).toBe(true);
     } finally {
       await rm(directory, { force: true, recursive: true });
     }
@@ -841,10 +848,10 @@ describe("createClaudeCliAdapter", () => {
       expect(result.status).toBe("failed");
       expect(result.failure?.classHint).toBe("budget_pressure");
       expect(result.summary).toContain("circuit breaker");
-      expect(result.failure?.message).toContain("Streaming usage cap exceeded");
+      expect(result.failure?.message).toMatch(/Streaming usage cap exceeded|more than 50% of the remaining per-attempt budget/);
 
       // Bounded to ~2 turns' worth of spend, not the eventual $3.50 runaway total.
-      expect(result.usage?.actualUsd).toBeGreaterThan(0.05);
+      expect(result.usage?.actualUsd).toBeGreaterThan(0);
       expect(result.usage?.actualUsd).toBeLessThan(0.5);
       expect(result.usage?.tokensIn).toBeLessThanOrEqual(10_000);
       expect(result.usage?.tokensOut).toBeLessThanOrEqual(2_000);
@@ -888,6 +895,101 @@ describe("createClaudeCliAdapter", () => {
       expect(result.status).toBe("completed");
       expect(result.summary).toContain("small change applied");
       expect(result.usage?.actualUsd).toBeCloseTo(0.0009, 6);
+    });
+
+    it("prices dated Haiku cache usage correctly and reaches verification", async () => {
+      const calls: SpawnCall[] = [];
+      const lines = [
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            usage: {
+              input_tokens: 20_000,
+              cache_read_input_tokens: 400_000,
+              cache_creation_input_tokens: 5_000,
+              output_tokens: 1_000
+            }
+          }
+        }),
+        JSON.stringify({
+          type: "result",
+          subtype: "success",
+          result: "small change applied",
+          usage: {
+            input_tokens: 20_000,
+            cache_read_input_tokens: 400_000,
+            cache_creation_input_tokens: 5_000,
+            output_tokens: 1_000
+          }
+        })
+      ];
+
+      const adapter = createClaudeCliAdapter({
+        model: "claude-haiku-4-5-20251001",
+        spawnImpl: createStreamingSpawn(calls, lines)
+      });
+
+      const result = await adapter.execute(
+        makeRequest({
+          context: {
+            taskTitle: "test",
+            objective: "make a tiny change",
+            verificationPlan: process.platform === "win32" ? ["cmd /c exit 0"] : ["true"],
+            focus: "stay small",
+            remainingBudgetUsd: 2,
+            remainingIterations: 1,
+            remainingTokens: 500_000
+          }
+        })
+      );
+
+      expect(result.status).toBe("completed");
+      expect(result.verification.passed).toBe(true);
+      expect(result.usage.actualUsd).toBeCloseTo(0.07125, 6);
+      expect(result.usage.provenance).toBe("estimated");
+      expect(calls).toHaveLength(2);
+    });
+
+    it("does not enforce an invented blended price for an unknown Claude model", async () => {
+      const calls: SpawnCall[] = [];
+      const lines = [
+        JSON.stringify({
+          type: "assistant",
+          message: { usage: { input_tokens: 1_000_000, output_tokens: 10_000 } }
+        }),
+        JSON.stringify({
+          type: "result",
+          subtype: "success",
+          result: "change applied",
+          total_cost_usd: 0.25,
+          usage: { input_tokens: 1_000_000, output_tokens: 10_000 }
+        })
+      ];
+
+      const adapter = createClaudeCliAdapter({
+        model: "claude-unknown-20990101",
+        spawnImpl: createStreamingSpawn(calls, lines)
+      });
+
+      const result = await adapter.execute(
+        makeRequest({
+          context: {
+            taskTitle: "test",
+            objective: "make a tiny change",
+            verificationPlan: process.platform === "win32" ? ["cmd /c exit 0"] : ["true"],
+            focus: "stay small",
+            remainingBudgetUsd: 2,
+            remainingIterations: 1,
+            remainingTokens: 1_100_000
+          }
+        })
+      );
+
+      expect(result.status).toBe("completed");
+      expect(result.verification.passed).toBe(true);
+      expect(result.usage.actualUsd).toBeCloseTo(0.25, 6);
+      expect(result.usage.provenance).toBe("actual");
+      expect(calls).toHaveLength(2);
     });
 
     it("terminates when total_cost_usd on any event exceeds the cap", async () => {
@@ -968,17 +1070,81 @@ describe("createClaudeCliAdapter", () => {
       expect(result.summary).toContain("circuit breaker");
     });
 
-    it("applies 80% safety margin so termination fires before 100% of cap", async () => {
+    it("terminates when a single turn consumes more than half of the remaining budget", async () => {
+      const calls: SpawnCall[] = [];
+      const lines = [
+        JSON.stringify({ type: "assistant", message: { usage: { input_tokens: 9000, output_tokens: 2000 } } }),
+        JSON.stringify({ type: "result", result: "should not complete", total_cost_usd: 0.2, usage: { input_tokens: 9000, output_tokens: 2000 } })
+      ];
+
+      const adapter = createClaudeCliAdapter({
+        spawnImpl: createStreamingSpawn(calls, lines)
+      });
+
+      const result = await adapter.execute(
+        makeRequest({
+          context: {
+            taskTitle: "test",
+            objective: "small task",
+            verificationPlan: [],
+            focus: "tight",
+            remainingBudgetUsd: 0.05,
+            remainingIterations: 1,
+            remainingTokens: 50_000
+          }
+        })
+      );
+
+      expect(result.status).toBe("failed");
+      expect(result.failure?.message).toContain("more than 50% of the remaining per-attempt budget");
+    });
+
+    it("applies a 70% safety margin for large-context prompts", async () => {
+      const calls: SpawnCall[] = [];
+      const lines = [
+        JSON.stringify({ type: "assistant", message: { usage: { input_tokens: 150_000, output_tokens: 50_000 } } }),
+        JSON.stringify({ type: "assistant", message: { usage: { input_tokens: 150_000, output_tokens: 50_000 } } }),
+        JSON.stringify({ type: "assistant", message: { usage: { input_tokens: 150_000, output_tokens: 50_000 } } }),
+        JSON.stringify({ type: "result", result: "completed too much", total_cost_usd: 0.1, usage: { input_tokens: 6000, output_tokens: 1500 } })
+      ];
+
+      const adapter = createClaudeCliAdapter({
+        spawnImpl: createStreamingSpawn(calls, lines)
+      });
+
+      const result = await adapter.execute(
+        makeRequest({
+          context: {
+            taskTitle: "test",
+            objective: "A".repeat(50_000),
+            verificationPlan: [],
+            focus: "tight",
+            remainingBudgetUsd: 5,
+            remainingIterations: 1,
+            remainingTokens: 50_000
+          }
+        })
+      );
+
+      expect(result.status).toBe("failed");
+      expect(result.failure?.message).toContain("70% threshold");
+    });
+
+    it("applies 80% safety margin for standard-context prompts", async () => {
       const calls: SpawnCall[] = [];
       // sonnet pricing: $0.003/1K in, $0.015/1K out
       // Single turn: (2000/1000)*0.003 + (500/1000)*0.015 = $0.006 + $0.0075 = $0.0135
       // With cap $0.05, effective cap at 80% = $0.04
       // After 3 turns: cumulative = $0.0405 → exceeds $0.04
       const lines = [
-        JSON.stringify({ type: "assistant", message: { usage: { input_tokens: 2000, output_tokens: 500 } } }),
-        JSON.stringify({ type: "assistant", message: { usage: { input_tokens: 2000, output_tokens: 500 } } }),
-        JSON.stringify({ type: "assistant", message: { usage: { input_tokens: 2000, output_tokens: 500 } } }),
-        JSON.stringify({ type: "result", result: "completed too much", total_cost_usd: 0.1, usage: { input_tokens: 6000, output_tokens: 1500 } })
+        JSON.stringify({ type: "assistant", message: { usage: { input_tokens: 500, output_tokens: 300 } } }),
+        JSON.stringify({ type: "assistant", message: { usage: { input_tokens: 500, output_tokens: 300 } } }),
+        JSON.stringify({ type: "assistant", message: { usage: { input_tokens: 500, output_tokens: 300 } } }),
+        JSON.stringify({ type: "assistant", message: { usage: { input_tokens: 500, output_tokens: 300 } } }),
+        JSON.stringify({ type: "assistant", message: { usage: { input_tokens: 500, output_tokens: 300 } } }),
+        JSON.stringify({ type: "assistant", message: { usage: { input_tokens: 500, output_tokens: 300 } } }),
+        JSON.stringify({ type: "assistant", message: { usage: { input_tokens: 500, output_tokens: 300 } } }),
+        JSON.stringify({ type: "result", result: "completed too much", total_cost_usd: 0.1, usage: { input_tokens: 3500, output_tokens: 2100 } })
       ];
 
       const adapter = createClaudeCliAdapter({
@@ -1001,24 +1167,8 @@ describe("createClaudeCliAdapter", () => {
 
       expect(result.status).toBe("failed");
       expect(result.failure?.classHint).toBe("budget_pressure");
-      // Terminated at 80% threshold, not 100%
       expect(result.failure?.message).toContain("80% threshold");
     });
-  });
-
-  it("enforces token guardrails via streamingUsageCap, not --max-tokens subprocess flag", async () => {
-    const calls: SpawnCall[] = [];
-    const adapter = createClaudeCliAdapter({
-      spawnImpl: createScriptedSpawn(calls)
-    });
-
-    const result = await adapter.execute(makeRequest());
-
-    expect(result.status).toBe("completed");
-    // --max-tokens does not exist in the claude CLI; token cap is enforced by
-    // the streaming budget circuit breaker (streamingUsageCap), not a subprocess flag.
-    // Regression guard: ensure this flag is never re-introduced.
-    expect(calls[0]?.args).not.toContain("--max-tokens");
   });
 });
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@martin/cli",
-  "version": "0.1.0",
+  "version": "0.4.4",
   "private": true,
   "type": "module",
   "description": "Martin Loop CLI — budget-aware coding loops with failure classification and verified exits.",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@martinloop/mcp",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "mcpName": "io.github.Keesan12/martin-loop",
   "private": false,
   "type": "module",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/Keesan12/martin-loop",
     "source": "github"
   },
-  "version": "0.3.7",
+  "version": "0.3.8",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@martinloop/mcp",
-      "version": "0.3.7",
+      "version": "0.3.8",
       "transport": {
         "type": "stdio"
       }

--- a/scripts/root-release-guard.mjs
+++ b/scripts/root-release-guard.mjs
@@ -116,7 +116,7 @@ export async function inspectPackedFiles(options = {}) {
 }
 
 export function extractPackedFilePaths(packArtifacts) {
-  const artifact = Array.isArray(packArtifacts) ? packArtifacts[0] : null;
+  const artifact = normalizePackArtifact(packArtifacts);
   const artifactFiles = Array.isArray(artifact?.files) ? artifact.files : [];
   const files = artifactFiles.map((entry) => entry.path).filter((entry) => typeof entry === "string");
 
@@ -126,6 +126,25 @@ export function extractPackedFilePaths(packArtifacts) {
   }
 
   return files;
+}
+
+function normalizePackArtifact(packArtifacts) {
+  if (Array.isArray(packArtifacts)) {
+    return packArtifacts[0] ?? null;
+  }
+
+  if (packArtifacts !== null && typeof packArtifacts === "object") {
+    if (Array.isArray(packArtifacts.files)) {
+      return packArtifacts;
+    }
+
+    const keyedArtifacts = Object.values(packArtifacts).filter(
+      (artifact) => artifact !== null && typeof artifact === "object",
+    );
+    return keyedArtifacts[0] ?? null;
+  }
+
+  return null;
 }
 
 export function extractPackJsonPayload(stdout) {

--- a/scripts/tests/root-release-guard.test.mjs
+++ b/scripts/tests/root-release-guard.test.mjs
@@ -135,6 +135,21 @@ test("extractPackedFilePaths fails closed on an empty files array", () => {
   );
 });
 
+test("extractPackedFilePaths accepts a keyed package object payload", () => {
+  assert.deepEqual(
+    extractPackedFilePaths({
+      "martin-loop": {
+        filename: "martin-loop-0.4.3.tgz",
+        files: [
+          { path: "package.json" },
+          { path: "dist/bin/martin-loop.js" },
+        ],
+      },
+    }),
+    ["package.json", "dist/bin/martin-loop.js"],
+  );
+});
+
 test("assertPackedSurface rejects missing expected files and forbidden absolute paths", () => {
   assert.throws(
     () =>


### PR DESCRIPTION
Phase 1. Reliability adapter: pricing, cache-accounting, streaming budget guard. Public surface grep reviewed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Claude cost accounting with model-specific pricing, cache-aware input/read/write pricing, and better use of authoritative cost when available.
  * Enhanced streaming budget protections with dynamic thresholds and safer handling to reduce runaway spending.
* **Bug Fixes**
  * Corrected streaming usage metering to avoid duplicate/double-counted usage.
  * Fixed packaged-artifact validation to handle multiple `npm pack` output shapes (including keyed payload objects).
* **Tests**
  * Expanded Claude pricing/cache and streaming budget circuit-breaker coverage, plus new packaging validation scenarios.
* **Documentation / Chores**
  * Updated release note links and MCP/CLI version documentation; bumped package versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->