### PR TITLE
fix(release): accept keyed npm pack payload

### DIFF
--- a/scripts/root-release-guard.mjs
+++ b/scripts/root-release-guard.mjs
@@ -116,7 +116,7 @@ export async function inspectPackedFiles(options = {}) {
 }
 
 export function extractPackedFilePaths(packArtifacts) {
-  const artifact = Array.isArray(packArtifacts) ? packArtifacts[0] : null;
+  const artifact = normalizePackArtifact(packArtifacts);
   const artifactFiles = Array.isArray(artifact?.files) ? artifact.files : [];
   const files = artifactFiles.map((entry) => entry.path).filter((entry) => typeof entry === "string");
 
@@ -126,6 +126,25 @@ export function extractPackedFilePaths(packArtifacts) {
   }
 
   return files;
+}
+
+function normalizePackArtifact(packArtifacts) {
+  if (Array.isArray(packArtifacts)) {
+    return packArtifacts[0] ?? null;
+  }
+
+  if (packArtifacts !== null && typeof packArtifacts === "object") {
+    if (Array.isArray(packArtifacts.files)) {
+      return packArtifacts;
+    }
+
+    const keyedArtifacts = Object.values(packArtifacts).filter(
+      (artifact) => artifact !== null && typeof artifact === "object",
+    );
+    return keyedArtifacts[0] ?? null;
+  }
+
+  return null;
 }
 
 export function extractPackJsonPayload(stdout) {

--- a/scripts/tests/root-release-guard.test.mjs
+++ b/scripts/tests/root-release-guard.test.mjs
@@ -135,6 +135,21 @@ test("extractPackedFilePaths fails closed on an empty files array", () => {
   );
 });
 
+test("extractPackedFilePaths accepts a keyed package object payload", () => {
+  assert.deepEqual(
+    extractPackedFilePaths({
+      "martin-loop": {
+        filename: "martin-loop-0.4.3.tgz",
+        files: [
+          { path: "package.json" },
+          { path: "dist/bin/martin-loop.js" },
+        ],
+      },
+    }),
+    ["package.json", "dist/bin/martin-loop.js"],
+  );
+});
+
 test("assertPackedSurface rejects missing expected files and forbidden absolute paths", () => {
   assert.throws(
     () =>


### PR DESCRIPTION
Fixes the v0.4.3 release guard failure where npm pack --dry-run --json reports a keyed package object such as martin-loop instead of an array. Adds focused regression coverage.