### PR TITLE
fix: restore public validation baseline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,19 +9,17 @@ Agents must treat this repository as a public open-source project.
 
 All MartinLoop repositories, clones, worktrees, temporary test repositories,
 runner installations, durable test evidence, and agent-created working folders
-on this machine must live under this single approved root:
+on a maintainer machine must live under the maintainer's canonical workspace
+root, as defined in the local environment.
 
-```text
-C:\Users\Torram\OneDrive\Documents\Codex Main\Setup Stuff
-```
-
+Confirm the exact approved workspace root before beginning work on a machine.
 This rule is non-negotiable.
 
 Agents must not create, clone, copy, move, or continue MartinLoop work in:
 
 - Desktop or any Desktop subfolder
-- `C:\Users\Torram` outside the approved root
-- Downloads or Documents outside the approved root
+- user-profile folders outside the approved workspace root
+- Downloads or Documents outside the approved workspace root
 - AppData
 - operating-system Temp directories
 - arbitrary `tmp-*`, scratch, cache, or one-off folders elsewhere on the machine

--- a/scripts/oss-boundary.mjs
+++ b/scripts/oss-boundary.mjs
@@ -27,6 +27,7 @@ const ALLOWED_TOP_LEVEL_ENTRIES = [
   "CHANGELOG.md",
   "CODE_OF_CONDUCT.md",
   "CONTRIBUTING.md",
+  "glama.json",
   "LICENSE",
   "martin.config.example.yaml",
   "package.json",

--- a/scripts/tests/readme-public-surface.test.mjs
+++ b/scripts/tests/readme-public-surface.test.mjs
@@ -132,7 +132,7 @@ test("root README is a public product entry point", async () => {
     previousIndex = index;
   }
 
-  assert.match(readme, /MartinLoop gives AI coding agents budgets, stop conditions, rollback rules, and receipts\./i);
+  assert.match(readme, /MartinLoop makes every agent action bounded, verified, reversible, priced, and provable\./i);
   assert.match(readme, /Built from thousands of agent runs where the problem was not intelligence -- it was uncontrolled execution\./i);
   assert.match(readme, /## Why Teams Adopt MartinLoop/);
   assert.match(readme, /## 2-Minute Install Path/);


### PR DESCRIPTION
## Summary
Restores the public repository validation baseline without changing runtime behavior.

## Changes
- recognize the intentional top-level `glama.json` metadata file in the OSS boundary
- remove private machine paths from `AGENTS.md` while preserving the canonical-workspace rule
- align the README public-surface assertion with the README's current opening copy

## Why this is separate
These failures pre-existed PR #191 and are unrelated to MCPB. Keeping them in this prep PR prevents the MCPB feature PR from absorbing unrelated repository cleanup.

## Scope
Exactly three files. No MCPB implementation, package, release, registry, or runtime changes.