### PR TITLE
release(mcp): publish 0.3.9 with MCPB assets

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -43,6 +43,7 @@ jobs:
         with:
           ref: ${{ steps.release-vars.outputs.tag }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up pnpm
         uses: pnpm/action-setup@b0f76dfb45f55f8421693e4803ac7bb65143bd34
@@ -78,6 +79,24 @@ jobs:
         shell: bash
         run: |
           node ../../scripts/read-mcp-package-metadata.mjs >> "$GITHUB_OUTPUT"
+
+      - name: Build and validate MCPB
+        run: |
+          pnpm --filter @martinloop/mcp mcpb:build
+          pnpm --filter @martinloop/mcp mcpb:validate
+
+      - name: Verify MCPB release assets
+        shell: bash
+        env:
+          MCPB_PATH: packages/mcp/dist-mcpb/martinloop-${{ steps.mcp-metadata.outputs.package_version }}.mcpb
+          CHECKSUM_PATH: packages/mcp/dist-mcpb/martinloop-${{ steps.mcp-metadata.outputs.package_version }}.mcpb.sha256
+        run: |
+          test -f "${MCPB_PATH}"
+          test -f "${CHECKSUM_PATH}"
+          (
+            cd "$(dirname "${MCPB_PATH}")"
+            sha256sum --check "$(basename "${CHECKSUM_PATH}")"
+          )
 
       - name: Verify MCP tag/version parity
         shell: bash
@@ -213,3 +232,7 @@ jobs:
           tag_name: ${{ steps.release-vars.outputs.tag }}
           name: "@martinloop/mcp ${{ steps.mcp-metadata.outputs.package_version }}"
           body_path: "docs/release/MCP-${{ steps.mcp-metadata.outputs.package_version }}-RELEASE-NOTES.md"
+          files: |
+            packages/mcp/dist-mcpb/martinloop-${{ steps.mcp-metadata.outputs.package_version }}.mcpb
+            packages/mcp/dist-mcpb/martinloop-${{ steps.mcp-metadata.outputs.package_version }}.mcpb.sha256
+          fail_on_unmatched_files: true

--- a/docs/oss/MCP-FOR-AI-AGENTS.md
+++ b/docs/oss/MCP-FOR-AI-AGENTS.md
@@ -1,6 +1,6 @@
 # MCP For AI Agents
 
-`@martinloop/mcp@0.3.8` is the current standalone MCP source line for MartinLoop. The live npm baseline remains `0.3.6` until the `0.3.8` release is published, and follow-on standalone releases should still be cut only when the MCP surface itself changes.
+`@martinloop/mcp@0.3.9` is the current standalone MCP source line for MartinLoop. The live npm baseline is `0.3.9`, and follow-on standalone releases should still be cut only when the MCP surface itself changes.
 
 It is built for hosts that need a governed local-first workflow, not a vague bag of tools.
 
@@ -62,8 +62,7 @@ claude mcp add --transport stdio --scope user martin-loop -- cmd /c npx -y @mart
 
 ## What comes next in the train
 
-- `0.3.8` is the current standalone MCP source line.
-- `0.3.6` remains the live npm baseline until `0.3.8` ships.
+- `0.3.9` is the current standalone MCP source line and live npm baseline.
 - follow-on MCP versions should ship only when the standalone server surface changes.
 - future `0.3.x` follow-ons stay local-first and stdio-first.
 

--- a/docs/release/MCP-0.3.9-RELEASE-NOTES.md
+++ b/docs/release/MCP-0.3.9-RELEASE-NOTES.md
@@ -1,0 +1,28 @@
+# @martinloop/mcp 0.3.9 Release Notes
+
+## Release Summary
+
+`0.3.9` adds an audited, cross-platform MCPB distribution for installing MartinLoop in MCPB-compatible desktop clients. The npm package and MCP Registry entry remain available for standard stdio integrations.
+
+## What this release adds
+
+- a self-contained `martinloop-0.3.9.mcpb` bundle built from the reviewed pnpm lockfile
+- a SHA-256 checksum published beside the bundle on the GitHub Release
+- validation on Ubuntu, macOS, and Windows with Node.js 20 and 24
+- explicit client configuration for the workspace root, run storage, and live execution
+- safer defaults: `MARTIN_LIVE` remains disabled unless the user enables it
+
+## Installing the MCPB bundle
+
+Download `martinloop-0.3.9.mcpb` and `martinloop-0.3.9.mcpb.sha256` from this GitHub Release. Verify the checksum, import the bundle into an MCPB-compatible client, select the allowed workspace and run-storage directories, and launch the server.
+
+## Verification
+
+- `pnpm --filter @martinloop/mcp lint`
+- `pnpm --filter @martinloop/mcp test`
+- `pnpm --filter @martinloop/mcp build`
+- `pnpm --filter @martinloop/mcp smoke:pack`
+- `pnpm --filter @martinloop/mcp smoke:published:pack`
+- `pnpm --filter @martinloop/mcp verify:release`
+- `pnpm --filter @martinloop/mcp mcpb:build`
+- `pnpm --filter @martinloop/mcp mcpb:validate`

--- a/docs/release/VERSION-LEDGER.md
+++ b/docs/release/VERSION-LEDGER.md
@@ -38,12 +38,12 @@ This file is the release source of truth for package/version mapping in this rep
 
 ## Standalone package: `@martinloop/mcp`
 
-- live npm dist-tag `latest`: `0.3.6`
-- live public GitHub release: `mcp-v0.3.6`
-- live public baseline in this train: `0.3.6`
-- standalone MCP public baseline: `0.3.6`
-- current in-repo standalone release line: `0.3.8`
-- next planned standalone release: `0.3.9`
+- live npm dist-tag `latest`: `0.3.9`
+- live public GitHub release: `mcp-v0.3.9`
+- live public baseline in this train: `0.3.9`
+- standalone MCP public baseline: `0.3.9`
+- current in-repo standalone release line: `0.3.9`
+- next planned standalone release: not scheduled in this patch train
 - next planned follow-ons:
   - reserved for additional host-coverage follow-ups when the MCP line changes again
 

--- a/packages/mcp/mcpb/manifest.json
+++ b/packages/mcp/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.3",
   "name": "martinloop",
   "display_name": "MartinLoop",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "Independent governance and authorization layer for autonomous AI coding-agent execution.",
   "long_description": "MartinLoop governs autonomous software work with budgets, verification gates, controlled execution, recovery, rollback evidence, and auditable run receipts. It runs locally so it can inspect and govern work inside user-approved repositories without uploading source code to a hosted MartinLoop service.",
   "author": {"name":"MartinLoop","email":"keesan@martinloop.com","url":"https://martinloop.com"},

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@martinloop/mcp",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "mcpName": "io.github.Keesan12/martin-loop",
   "private": false,
   "type": "module",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/Keesan12/martin-loop",
     "source": "github"
   },
-  "version": "0.3.8",
+  "version": "0.3.9",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@martinloop/mcp",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "transport": {
         "type": "stdio"
       }

--- a/scripts/tests/mcp-release-docs.test.mjs
+++ b/scripts/tests/mcp-release-docs.test.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 
 import packageJson from "../../packages/mcp/package.json" with { type: "json" };
 import serverJson from "../../packages/mcp/server.json" with { type: "json" };
+import mcpbManifest from "../../packages/mcp/mcpb/manifest.json" with { type: "json" };
 import rootPackageJson from "../../package.json" with { type: "json" };
 
 const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
@@ -20,10 +21,24 @@ function escapeRegex(input) {
 
 test("current MCP metadata stays aligned for the release cut", async () => {
   assert.equal(packageJson.version, serverJson.version);
+  assert.equal(packageJson.version, mcpbManifest.version);
+  assert.equal(packageJson.version, "0.3.9");
+  assert.equal(serverJson.packages[0]?.version, "0.3.9");
+  assert.equal(rootPackageJson.version, "0.4.5");
 
   const releaseNotesPath = path.join(ROOT_DIR, "docs", "release", `MCP-${packageJson.version}-RELEASE-NOTES.md`);
 
   await access(releaseNotesPath);
+});
+
+test("0.3.9 release notes describe the audited MCPB distribution", async () => {
+  const releaseNotes = await readRepoFile(path.join("docs", "release", "MCP-0.3.9-RELEASE-NOTES.md"));
+
+  assert.match(releaseNotes, /0\.3\.9/);
+  assert.match(releaseNotes, /MCPB/);
+  assert.match(releaseNotes, /checksum/i);
+  assert.match(releaseNotes, /MARTIN_LIVE/);
+  assert.doesNotMatch(releaseNotes, /ML_Core_OSS_Internal|public-staging|C:\\Users\\/);
 });
 
 test("version ledger records live public truth and the next release train", async () => {
@@ -33,7 +48,7 @@ test("version ledger records live public truth and the next release train", asyn
   assert.match(ledger, /live public GitHub release: `v\d+\.\d+\.\d+`/);
   assert.match(
     ledger,
-    new RegExp(escapeRegex("standalone MCP public baseline: `0.3.6`")),
+    new RegExp(escapeRegex(`standalone MCP public baseline: \`${packageJson.version}\``)),
   );
   assert.match(
     ledger,
@@ -74,7 +89,7 @@ test("public MCP docs describe the current baseline and the next train in human-
 
   // AI guide should describe the live baseline and stable local-first train
   assert.match(aiGuide, new RegExp(escapeRegex(packageJson.version)));
-  assert.match(aiGuide, /live npm baseline remains `0\.3\.6` until/i);
+  assert.match(aiGuide, new RegExp(escapeRegex(`live npm baseline is \`${packageJson.version}\``), "i"));
   assert.match(aiGuide, /local-first/i);
   assert.match(aiGuide, /martin_doctor/);
   assert.match(aiGuide, /martin_run/);

--- a/scripts/tests/publish-mcp-workflow.test.mjs
+++ b/scripts/tests/publish-mcp-workflow.test.mjs
@@ -56,10 +56,31 @@ test("publish-mcp workflow covers trusted publishing, local-pack proof, and publ
   assert.match(workflow, /softprops\/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b/);
   assert.match(workflow, /name:\s*"@martinloop\/mcp/);
   assert.match(workflow, /body_path:\s*"docs\/release\/MCP-\$\{\{\s*steps\.mcp-metadata\.outputs\.package_version\s*\}\}-RELEASE-NOTES\.md"/);
+  assert.match(workflow, /pnpm --filter @martinloop\/mcp mcpb:build/);
+  assert.match(workflow, /pnpm --filter @martinloop\/mcp mcpb:validate/);
+  assert.match(
+    workflow,
+    /packages\/mcp\/dist-mcpb\/martinloop-\$\{\{\s*steps\.mcp-metadata\.outputs\.package_version\s*\}\}\.mcpb/,
+  );
+  assert.match(
+    workflow,
+    /packages\/mcp\/dist-mcpb\/martinloop-\$\{\{\s*steps\.mcp-metadata\.outputs\.package_version\s*\}\}\.mcpb\.sha256/,
+  );
+  assert.match(workflow, /fail_on_unmatched_files:\s*true/);
   assert.doesNotMatch(workflow, /registry-url/);
   assert.doesNotMatch(workflow, /NODE_AUTH_TOKEN/);
   assert.doesNotMatch(workflow, /NPM_TOKEN/);
   assert.doesNotMatch(workflow, /secrets\./);
+});
+
+test("publish-mcp workflow fails closed when MCPB release assets are missing", async () => {
+  const workflowPath = path.join(ROOT_DIR, ".github", "workflows", "publish-mcp.yml");
+  const workflow = await readFile(workflowPath, "utf8");
+
+  assert.match(workflow, /persist-credentials:\s*false/);
+  assert.match(workflow, /Verify MCPB release assets/);
+  assert.match(workflow, /test -f "\$\{MCPB_PATH\}"/);
+  assert.match(workflow, /sha256sum --check/);
 });
 
 test("metadata reader emits GitHub output keys from packages/mcp", () => {


### PR DESCRIPTION
## Summary

- release @martinloop/mcp 0.3.9 without changing the root package line
- publish the audited MCPB bundle and SHA-256 checksum with the GitHub Release
- keep npm and MCP Registry publishing in GitHub Actions via OIDC
- update public MCP release notes and version metadata

## Validation

- frozen pnpm install
- MCP lint and 91 tests
- standalone and packed-package smokes
- release-contract suite
- MCPB build, schema validation, checksum, archive scan, and staged-server E2E smoke
- public portability and git-surface guards