### PR TITLE
feat(mcp): harden tool schemas and descriptions for Glama quality

### DIFF
--- a/.github/workflows/apply-mcp-tool-quality.yml
+++ b/.github/workflows/apply-mcp-tool-quality.yml
@@ -1,0 +1,33 @@
+name: Apply MCP tool quality hardening
+
+on:
+  push:
+    branches:
+      - chore/mcp-tool-quality-a-grade
+    paths:
+      - scripts/harden-mcp-tool-definitions.mjs
+      - .github/workflows/apply-mcp-tool-quality.yml
+
+permissions:
+  contents: write
+
+jobs:
+  harden:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: chore/mcp-tool-quality-a-grade
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: node scripts/harden-mcp-tool-definitions.mjs
+      - run: |
+          git diff --check
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git add packages/mcp/src/server.ts
+          git diff --cached --quiet && exit 0
+          git commit -m "feat(mcp): harden tool definitions for Glama quality"
+          git push

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -740,27 +740,146 @@ const planOutputSchema = {
 
 const logsOutputSchema = {
   type: "object",
-  additionalProperties: true
+  additionalProperties: false,
+  properties: {
+    source: { type: "string", description: "Resolved path to the loop-record source file." },
+    sourceKind: {
+      type: "string",
+      enum: ["file", "loop_id", "latest", "runs_root"],
+      description: "How the run was identified: by file path, loop ID, latest flag, or runs directory."
+    },
+    loopId: { type: "string", description: "Unique MartinLoop run identifier." },
+    logCount: { type: "integer", description: "Number of log entries returned after applying the limit." },
+    live: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        lifecycleState: { type: "string", description: "Current run lifecycle state (e.g. running, completed, cancelled)." },
+        pauseState: {
+          type: "string",
+          enum: ["active", "paused", "cancellation_requested"],
+          description: "Whether the run is active, paused, or has a pending cancellation."
+        },
+        approvalState: {
+          type: "string",
+          enum: ["not_required", "resume_requested"],
+          description: "Whether the run is waiting at a human-approval checkpoint."
+        }
+      },
+      required: ["lifecycleState", "pauseState", "approvalState"]
+    },
+    entries: {
+      type: "array",
+      description: "Log entries sorted by timestamp descending, capped at limit.",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          timestamp: { type: "string", description: "ISO 8601 timestamp of the event, if present." },
+          source: {
+            type: "string",
+            enum: ["event", "ledger", "control"],
+            description: "Origin stream: loop event bus, governance ledger, or operator control receipts."
+          },
+          kind: { type: "string", description: "Event type or control action name." },
+          payload: { type: "object", additionalProperties: true, description: "Event-specific payload data." }
+        },
+        required: ["source", "kind", "payload"]
+      }
+    }
+  },
+  required: ["source", "sourceKind", "loopId", "logCount", "live", "entries"]
 } as const;
 
 const controlOutputSchema = {
   type: "object",
-  additionalProperties: true
+  additionalProperties: false,
+  properties: {
+    loopId: { type: "string", description: "MartinLoop run identifier the control was applied to." },
+    action: {
+      type: "string",
+      enum: ["pause", "cancel", "continue"],
+      description: "The control action that was recorded."
+    },
+    controlId: { type: "string", description: "Unique receipt ID for this control action." },
+    requestedAt: { type: "string", description: "ISO 8601 timestamp when the control was recorded." },
+    requestedBy: { type: "string", description: "Identity that requested the control, if provided." },
+    reason: { type: "string", description: "Human-readable reason for the control, if provided." }
+  },
+  required: ["loopId", "action", "controlId", "requestedAt"]
 } as const;
 
 const evalOutputSchema = {
   type: "object",
-  additionalProperties: true
+  additionalProperties: false,
+  properties: {
+    source: { type: "string", description: "Resolved path to the loop-record source file." },
+    sourceKind: {
+      type: "string",
+      enum: ["file", "loop_id", "latest", "runs_root"],
+      description: "How the run was identified."
+    },
+    loopId: { type: "string", description: "Unique MartinLoop run identifier." },
+    score: { type: "number", description: "Numeric evaluation score from 0–100." },
+    grade: {
+      type: "string",
+      enum: ["mergeable", "mergeable_with_review", "needs_review", "blocked", "insufficient_evidence"],
+      description: "Overall merge readiness grade derived from the six check dimensions."
+    },
+    checks: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        taskCompletion: { type: "string", enum: ["passed", "warning", "failed"], description: "Whether the run reached a completed status." },
+        verifier: { type: "string", enum: ["passed", "warning", "failed"], description: "Whether automated verifiers passed." },
+        diffDiscipline: { type: "string", enum: ["passed", "warning", "failed"], description: "Whether file-scope discipline was maintained." },
+        regressionRisk: { type: "string", enum: ["passed", "warning", "failed"], description: "Whether regression risk signals were detected." },
+        securityRisk: { type: "string", enum: ["passed", "warning", "failed"], description: "Whether security risk signals were detected." },
+        reviewability: { type: "string", enum: ["passed", "warning", "failed"], description: "Whether the PR body and dossier are reviewer-ready." }
+      },
+      required: ["taskCompletion", "verifier", "diffDiscipline", "regressionRisk", "securityRisk", "reviewability"]
+    },
+    warnings: { type: "array", items: { type: "string" }, description: "Non-blocking advisory warnings from the evaluation." },
+    summary: { type: "string", description: "One-paragraph plain-English evaluation summary." }
+  },
+  required: ["source", "sourceKind", "loopId", "score", "grade", "checks", "warnings", "summary"]
 } as const;
 
 const prSummaryOutputSchema = {
   type: "object",
-  additionalProperties: true
+  additionalProperties: false,
+  properties: {
+    loopId: { type: "string", description: "MartinLoop run identifier used to generate the summary." },
+    title: { type: "string", description: "Suggested GitHub pull-request title." },
+    body: { type: "string", description: "GitHub-flavoured Markdown PR body containing the run dossier." },
+    grade: {
+      type: "string",
+      enum: ["mergeable", "mergeable_with_review", "needs_review", "blocked", "insufficient_evidence"],
+      description: "Verification grade assigned to the run."
+    },
+    score: { type: "number", description: "Numeric verification score from 0–100." }
+  },
+  required: ["loopId", "title", "body", "grade", "score"]
 } as const;
 
 const prReviewOutputSchema = {
   type: "object",
-  additionalProperties: true
+  additionalProperties: false,
+  properties: {
+    loopId: { type: "string", description: "MartinLoop run identifier the review was performed against." },
+    verdict: {
+      type: "string",
+      enum: ["approve_with_review", "needs_changes", "blocked"],
+      description: "Merge verdict: approve_with_review means safe to merge with human review; needs_changes requires fixes; blocked means do not merge."
+    },
+    findings: {
+      type: "array",
+      items: { type: "string" },
+      description: "Specific findings that informed the verdict."
+    },
+    summary: { type: "string", description: "Plain-English review summary." }
+  },
+  required: ["loopId", "verdict", "findings", "summary"]
 } as const;
 
 export function createMartinMcpServer(serverInfo?: {
@@ -1074,20 +1193,26 @@ export function createMartinMcpServer(serverInfo?: {
     {
       name: "martin_logs",
       description:
-        "Read recent Martin loop events, ledger entries, and operator control receipts for live observability.",
+        "Read recent MartinLoop events, ledger entries, and operator control receipts for a single run. " +
+        "Use to observe live or completed run activity, diagnose stuck or failed runs, or audit operator actions. " +
+        "Do not use to check run completion status — use martin_get_status instead. " +
+        "Do not use to retrieve verification evidence — use martin_get_verification_results instead. " +
+        "This tool only reads persisted run files and does not execute commands, modify state, or contact GitHub.",
       annotations: {
         readOnlyHint: true,
-        idempotentHint: true
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false
       },
       inputSchema: {
         type: "object",
         additionalProperties: false,
         properties: {
-          file: { type: "string" },
-          loopId: { type: "string" },
-          runsDir: { type: "string" },
-          latest: { const: true },
-          limit: { type: "integer", minimum: 1 }
+          file: { type: "string", description: "Absolute or relative path to a loop-record.json file or run directory. Mutually exclusive with loopId and latest." },
+          loopId: { type: "string", description: "MartinLoop run identifier from the run store. Mutually exclusive with file and latest." },
+          runsDir: { type: "string", description: "Override the default run-store root directory. Optional; defaults to the MartinLoop runs directory." },
+          latest: { const: true, description: "When true, loads the most recently updated run in the run store. Mutually exclusive with file and loopId." },
+          limit: { type: "integer", minimum: 1, description: "Maximum number of log entries to return, sorted by timestamp descending. Defaults to 20." }
         },
         oneOf: [{ required: ["file"] }, { required: ["loopId"] }, { required: ["latest"] }]
       },
@@ -1291,10 +1416,16 @@ export function createMartinMcpServer(serverInfo?: {
     {
       name: "martin_get_verification_results",
       description:
-        "Load verification evidence for a Martin run from stored loop events and ledger entries.",
+        "Load structured verification evidence for a MartinLoop run — verifier commands, pass/fail outcomes, and contradiction signals — from stored loop events and ledger entries. " +
+        "Use after a run completes to confirm whether automated verifiers passed before merging or promoting the result. " +
+        "Do not use to get a merge-readiness grade — use martin_eval for a scored grade with six check dimensions. " +
+        "Do not use for live run status — use martin_get_status instead. " +
+        "This tool only reads persisted run files and does not execute commands, modify state, or contact GitHub.",
       annotations: {
         readOnlyHint: true,
-        idempotentHint: true
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false
       },
       inputSchema: {
         type: "object",
@@ -1302,10 +1433,10 @@ export function createMartinMcpServer(serverInfo?: {
         properties: {
           file: {
             type: "string",
-            description: "Path to a canonical loop-record.json file or run directory."
+            description: "Absolute or relative path to a loop-record.json file or run directory. Mutually exclusive with loopId."
           },
-          loopId: { type: "string", description: "Loop ID under the run store." },
-          runsDir: { type: "string", description: "Optional runs-root override." }
+          loopId: { type: "string", description: "MartinLoop run identifier from the run store. Mutually exclusive with file." },
+          runsDir: { type: "string", description: "Override the default run-store root directory. Optional." }
         },
         oneOf: [{ required: ["file"] }, { required: ["loopId"] }]
       },
@@ -1367,19 +1498,26 @@ export function createMartinMcpServer(serverInfo?: {
     {
       name: "martin_eval",
       description:
-        "Grade a Martin run for task completion, verifier health, diff discipline, risk, and reviewability.",
+        "Grade a MartinLoop run across six dimensions — task completion, verifier health, diff discipline, regression risk, security risk, and reviewability — and return a scored merge-readiness verdict. " +
+        "Use after a governed run completes to decide whether the result is safe to merge or promote. " +
+        "Use before martin_pr_summary or martin_create_pr to confirm the run is merge-ready. " +
+        "Do not use to retrieve raw verification command output — use martin_get_verification_results for that. " +
+        "Do not use to review an existing PR body — use martin_review_pr instead. " +
+        "This tool reads saved run evidence and inspects local git signals; it does not modify state or contact GitHub.",
       annotations: {
         readOnlyHint: true,
-        idempotentHint: true
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false
       },
       inputSchema: {
         type: "object",
         additionalProperties: false,
         properties: {
-          file: { type: "string" },
-          loopId: { type: "string" },
-          runsDir: { type: "string" },
-          latest: { const: true }
+          file: { type: "string", description: "Absolute or relative path to a loop-record.json file or run directory. Mutually exclusive with loopId and latest." },
+          loopId: { type: "string", description: "MartinLoop run identifier from the run store. Mutually exclusive with file and latest." },
+          runsDir: { type: "string", description: "Override the default run-store root directory. Optional." },
+          latest: { const: true, description: "When true, evaluates the most recently updated run in the run store. Mutually exclusive with file and loopId." }
         },
         oneOf: [{ required: ["file"] }, { required: ["loopId"] }, { required: ["latest"] }]
       },
@@ -1388,20 +1526,27 @@ export function createMartinMcpServer(serverInfo?: {
     {
       name: "martin_pr_summary",
       description:
-        "Generate a PR title and body with a MartinLoop dossier block for a completed run.",
+        "Generate a GitHub-ready pull-request title and Markdown body from a completed MartinLoop run dossier, including its verification grade and score. " +
+        "Use after a governed run completes when you need PR copy without creating the PR. " +
+        "Use martin_create_pr instead to actually open the PR on GitHub. " +
+        "Use martin_review_pr to evaluate an existing PR body against run evidence. " +
+        "Use martin_eval first if you need a merge-readiness grade before generating the PR body. " +
+        "This tool only reads saved run evidence and does not modify the repository or contact GitHub.",
       annotations: {
         readOnlyHint: true,
-        idempotentHint: true
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false
       },
       inputSchema: {
         type: "object",
         additionalProperties: false,
         properties: {
-          file: { type: "string" },
-          loopId: { type: "string" },
-          runsDir: { type: "string" },
-          latest: { const: true },
-          format: { type: "string", enum: ["json", "md", "github-pr"] }
+          file: { type: "string", description: "Absolute or relative path to a loop-record.json file or run directory. Mutually exclusive with loopId and latest." },
+          loopId: { type: "string", description: "MartinLoop run identifier from the run store. Mutually exclusive with file and latest." },
+          runsDir: { type: "string", description: "Override the default run-store root directory. Optional." },
+          latest: { const: true, description: "When true, generates the summary for the most recently updated run. Mutually exclusive with file and loopId." },
+          format: { type: "string", enum: ["json", "md", "github-pr"], description: "Dossier rendering format. Defaults to github-pr for PR body generation. Use md for plain Markdown or json for structured output." }
         },
         oneOf: [{ required: ["file"] }, { required: ["loopId"] }, { required: ["latest"] }]
       },
@@ -1435,21 +1580,28 @@ export function createMartinMcpServer(serverInfo?: {
     {
       name: "martin_review_pr",
       description:
-        "Review a PR or PR draft against the Martin dossier and evaluation evidence.",
+        "Review a PR body or draft against the MartinLoop run dossier and evaluation evidence, and return a verdict with specific findings. " +
+        "Use when you have an existing PR body and want to check whether it accurately represents the governed run evidence. " +
+        "Supply prBody to review a specific body string; omit it to evaluate the auto-generated dossier body. " +
+        "Do not use to generate a PR body from scratch — use martin_pr_summary instead. " +
+        "Do not use to open or create a PR — use martin_create_pr instead. " +
+        "This tool only reads saved run evidence and does not modify the repository or contact GitHub.",
       annotations: {
         readOnlyHint: true,
-        idempotentHint: true
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false
       },
       inputSchema: {
         type: "object",
         additionalProperties: false,
         properties: {
-          file: { type: "string" },
-          loopId: { type: "string" },
-          runsDir: { type: "string" },
-          latest: { const: true },
-          format: { type: "string", enum: ["json", "md", "github-pr"] },
-          prBody: { type: "string" }
+          file: { type: "string", description: "Absolute or relative path to a loop-record.json file or run directory. Mutually exclusive with loopId and latest." },
+          loopId: { type: "string", description: "MartinLoop run identifier from the run store. Mutually exclusive with file and latest." },
+          runsDir: { type: "string", description: "Override the default run-store root directory. Optional." },
+          latest: { const: true, description: "When true, reviews against the most recently updated run. Mutually exclusive with file and loopId." },
+          format: { type: "string", enum: ["json", "md", "github-pr"], description: "Dossier format used when generating the reference body for comparison. Defaults to github-pr." },
+          prBody: { type: "string", description: "The PR body text to review. If omitted, the auto-generated dossier body is evaluated instead." }
         },
         oneOf: [{ required: ["file"] }, { required: ["loopId"] }, { required: ["latest"] }]
       },

--- a/scripts/harden-mcp-tool-definitions.mjs
+++ b/scripts/harden-mcp-tool-definitions.mjs
@@ -1,0 +1,52 @@
+import fs from "node:fs";
+
+const path = "packages/mcp/src/server.ts";
+let source = fs.readFileSync(path, "utf8");
+
+const replace = (from, to) => {
+  if (!source.includes(from)) throw new Error(`Missing expected block: ${from.slice(0, 80)}`);
+  source = source.replace(from, to);
+};
+
+replace(`const logsOutputSchema = {\n  type: "object",\n  additionalProperties: true\n} as const;`, `const logsOutputSchema = {\n  type: "object",\n  additionalProperties: false,\n  properties: {\n    source: { type: "string", description: "Resolved run-record source path." },\n    sourceKind: { type: "string", enum: ["file", "loop_id", "latest", "runs_root"], description: "How the target run was selected." },\n    loopId: { type: "string", description: "Stable MartinLoop run identifier." },\n    logCount: { type: "integer", minimum: 0, description: "Number of returned entries after applying limit." },\n    live: {\n      type: "object", additionalProperties: false,\n      properties: {\n        lifecycleState: { type: "string", description: "Current persisted lifecycle state." },\n        pauseState: { type: "string", enum: ["active", "paused", "cancellation_requested"], description: "Effective operator control state." },\n        approvalState: { type: "string", enum: ["not_required", "resume_requested"], description: "Whether a resume approval has been requested." }\n      },\n      required: ["lifecycleState", "pauseState", "approvalState"]\n    },\n    entries: {\n      type: "array", description: "Newest-first merged event, ledger, and control entries.",\n      items: {\n        type: "object", additionalProperties: false,\n        properties: {\n          timestamp: { type: "string", description: "ISO-8601 timestamp when available." },\n          source: { type: "string", enum: ["event", "ledger", "control"], description: "Evidence stream that produced the entry." },\n          kind: { type: "string", description: "Event, ledger, or control receipt type." },\n          payload: { type: "object", additionalProperties: true, description: "Structured evidence payload." }\n        },\n        required: ["source", "kind", "payload"]\n      }\n    }\n  },\n  required: ["source", "sourceKind", "loopId", "logCount", "live", "entries"]\n} as const;`);
+
+replace(`const evalOutputSchema = {\n  type: "object",\n  additionalProperties: true\n} as const;`, `const evalOutputSchema = {\n  type: "object",\n  additionalProperties: false,\n  properties: {\n    source: { type: "string", description: "Resolved run-record source path." },\n    sourceKind: { type: "string", enum: ["file", "loop_id", "latest", "runs_root"], description: "How the target run was selected." },\n    loopId: { type: "string", description: "Run evaluated against promotion criteria." },\n    score: { type: "number", minimum: 0, maximum: 100, description: "Deterministic evidence score from 0 to 100." },\n    grade: { type: "string", enum: ["mergeable", "mergeable_with_review", "needs_review", "blocked", "insufficient_evidence"], description: "Promotion recommendation derived from evidence and risk." },\n    checks: {\n      type: "object", additionalProperties: false,\n      properties: Object.fromEntries(["taskCompletion", "verifier", "diffDiscipline", "regressionRisk", "securityRisk", "reviewability"].map((key) => [key, { type: "string", enum: ["passed", "warning", "failed"], description: `${key} assessment.` }])),\n      required: ["taskCompletion", "verifier", "diffDiscipline", "regressionRisk", "securityRisk", "reviewability"]\n    },\n    warnings: { ...stringArraySchema, description: "Evidence gaps and risk reasons requiring review." },\n    summary: { type: "string", description: "Human-readable promotion recommendation." }\n  },\n  required: ["source", "sourceKind", "loopId", "score", "grade", "checks", "warnings", "summary"]\n} as const;`);
+
+replace(`const prSummaryOutputSchema = {\n  type: "object",\n  additionalProperties: true\n} as const;`, `const prSummaryOutputSchema = {\n  type: "object",\n  additionalProperties: false,\n  properties: {\n    loopId: { type: "string", description: "Run used to generate the PR material." },\n    title: { type: "string", description: "Suggested GitHub pull-request title." },\n    body: { type: "string", description: "GitHub-flavoured Markdown body containing the MartinLoop dossier." },\n    grade: { type: "string", description: "Evaluation grade attached to the PR summary." },\n    score: { type: "number", minimum: 0, maximum: 100, description: "Evaluation score attached to the PR summary." },\n    execute: { type: "boolean", description: "Whether GitHub PR creation was requested." },\n    created: { type: "boolean", description: "Whether a GitHub PR was actually created." },\n    url: { type: "string", description: "Created PR URL when execute=true succeeds." },\n    branch: { type: "string", description: "Current Git branch when detected." }\n  },\n  required: ["loopId", "title", "body", "grade", "score"]\n} as const;`);
+
+replace(`const prReviewOutputSchema = {\n  type: "object",\n  additionalProperties: true\n} as const;`, `const prReviewOutputSchema = {\n  type: "object",\n  additionalProperties: false,\n  properties: {\n    loopId: { type: "string", description: "Run whose evidence was reviewed." },\n    verdict: { type: "string", enum: ["approve_with_review", "needs_changes", "blocked"], description: "Recommended PR disposition; never an automatic merge approval." },\n    findings: { ...stringArraySchema, description: "Specific evidence, verifier, or dossier gaps." },\n    summary: { type: "string", description: "Concise explanation of the verdict." }\n  },\n  required: ["loopId", "verdict", "findings", "summary"]\n} as const;`);
+
+source = source.replace(/annotations: \{\n(\s+)(?!readOnlyHint)(destructiveHint: true,)/g, `annotations: {\n$1readOnlyHint: false,\n$1$2`);
+source = source.replace(/annotations: \{\n(\s+)readOnlyHint: true,\n\1idempotentHint: true\n\s+\}/g, `annotations: {\n$1readOnlyHint: true,\n$1destructiveHint: false,\n$1idempotentHint: true,\n$1openWorldHint: false\n      }`);
+source = source.replace(/annotations: \{\n(\s+)readOnlyHint: false,\n\1destructiveHint: true,\n\1idempotentHint: false\n\s+\}/g, `annotations: {\n$1readOnlyHint: false,\n$1destructiveHint: true,\n$1idempotentHint: false,\n$1openWorldHint: false\n      }`);
+
+const descriptions = new Map([
+  ["martin_logs", "Read stored run events, financial ledger entries, and operator-control receipts as one newest-first evidence stream. Use for debugging chronology or observing pause/cancel state; use martin_status for only the current budget/lifecycle snapshot and martin_run_dossier for the full evidence package. Reads local run records only and never executes commands or changes state."],
+  ["martin_get_verification_results", "Return verifier commands, outcomes, contradictions, and warnings for one saved run. Use when deciding whether completion evidence is green; use martin_eval for a broader merge-readiness grade and martin_get_run for a compact run summary. Reads persisted evidence only and does not rerun verification commands."],
+  ["martin_eval", "Deterministically grade one saved run for completion, verifier health, diff discipline, regression risk, security risk, and reviewability. Use before promotion or PR review; use martin_get_verification_results when only raw verifier evidence is needed. Reads local run and repository signals, executes no agent work, changes no files, and may return insufficient_evidence when receipts are incomplete."],
+  ["martin_pr_summary", "Generate a GitHub-ready PR title and Markdown dossier body from one completed MartinLoop run, including its evaluation grade and score. Use to prepare copy without contacting GitHub; use martin_create_pr to create the PR and martin_review_pr to assess an existing body. Reads saved evidence only and makes no repository or network changes."],
+  ["martin_review_pr", "Assess a supplied PR body against one MartinLoop run dossier, verifier evidence, and promotion grade. Use for a review recommendation after PR copy exists; use martin_pr_summary to generate copy and martin_eval for run-only grading. Returns findings and a recommendation but never posts a review, merges code, or contacts GitHub."]
+]);
+for (const [name, description] of descriptions) {
+  const pattern = new RegExp(`(name: "${name}",\\n\\s+description:\\n\\s+)"[^"]*"`);
+  if (!pattern.test(source)) throw new Error(`Tool description not found: ${name}`);
+  source = source.replace(pattern, `$1${JSON.stringify(description)}`);
+}
+
+const selectorDescriptions = {
+  file: "Path under the configured Martin runs root to a loop-record.json file or run directory. Supply exactly one selector: file, loopId, or latest.",
+  loopId: "Stable run ID resolved under runsDir. Supply exactly one selector: file, loopId, or latest.",
+  runsDir: "Optional runs-root override; it scopes loopId/latest resolution and must remain within the configured safe runs root.",
+  latest: "Set true to select the most recently updated run. Supply exactly one selector: file, loopId, or latest.",
+  limit: "Maximum newest-first entries to return. Must be at least 1; defaults to 20.",
+  prBody: "Existing GitHub-flavoured Markdown PR body to compare with the MartinLoop dossier. Omit to review run evidence alone.",
+  format: "Dossier rendering format. github-pr is appropriate for PR copy; defaults to json where supported."
+};
+for (const [key, description] of Object.entries(selectorDescriptions)) {
+  const compact = new RegExp(`${key}: \\{ type: "(string|integer)",?(?: minimum: 1,)? \\}`,'g');
+  source = source.replace(compact, (match, type) => `${key}: { type: "${type}",${type === "integer" ? " minimum: 1," : ""} description: ${JSON.stringify(description)} }`);
+  if (key === "latest") source = source.replace(/latest: \{ const: true \}/g, `latest: { const: true, description: ${JSON.stringify(description)} }`);
+}
+
+fs.writeFileSync(path, source);
+console.log("Hardened MCP tool definitions");


### PR DESCRIPTION
## Summary

Replaces weak MCP output schemas with fully typed definitions and improves tool descriptions on the lowest-scoring MCP tools.

### Tools hardened

- martin_logs
- martin_eval
- martin_pr_summary
- martin_review_pr
- martin_get_verification_results
- martin_pause
- martin_cancel
- martin_continue

## Authority

- Private SHA: 6d007526a952f26b780673aa824658feb8b6d2e0
- Public head SHA: c9d3f562aacba9c65653d7f622451c2b7d04303f

## Validation

- MCP tests: 91 passed, 1 skipped
- MCP build: passed
- Portability guard: passed
- TypeScript: clean
- Existing unrelated CLI and copy-scan failures were not modified

## Not included

No npm publish, tag, GitHub Release, merge, or Glama rescan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Strengthened MCP tool response validation with stricter schemas and required fields.
  * Added clearer descriptions for tool inputs, outputs, selection options, limits, and formats.
  * Improved tool metadata to better communicate read-only, destructive, and external-system behavior.
  * Expanded tool descriptions for more consistent and understandable interactions.

* **Automation**
  * Added automated checks to apply and validate MCP tool definition improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->