### PR TITLE
Fix npm pack JSON release validation

### DIFF
--- a/scripts/root-release-guard.mjs
+++ b/scripts/root-release-guard.mjs
@@ -113,9 +113,7 @@ export async function inspectPackedFiles(options = {}) {
     { cwd: rootDir },
   );
   const packArtifacts = extractPackJsonPayload(packRun.stdout);
-  const files = Array.isArray(packArtifacts)
-    ? packArtifacts[0]?.files?.map((entry) => entry.path).filter((entry) => typeof entry === "string")
-    : [];
+  const files = extractPackFilePaths(packArtifacts);
 
   if (files.length === 0) {
     throw new Error("npm pack --dry-run did not report any packaged files.");
@@ -129,6 +127,13 @@ export function extractPackJsonPayload(stdout) {
   const trailingJsonMatch = trimmed.match(/(\[\s*\{[\s\S]*\}\s*\])$/);
   const jsonPayload = trailingJsonMatch?.[1] ?? trimmed;
   return JSON.parse(jsonPayload);
+}
+
+export function extractPackFilePaths(packArtifacts) {
+  const artifact = Array.isArray(packArtifacts) ? packArtifacts[0] : packArtifacts;
+  return Array.isArray(artifact?.files)
+    ? artifact.files.map((entry) => entry.path).filter((entry) => typeof entry === "string")
+    : [];
 }
 
 export async function assertVendoredCliManifest(rootDir) {

--- a/scripts/tests/root-release-guard.test.mjs
+++ b/scripts/tests/root-release-guard.test.mjs
@@ -9,6 +9,7 @@ import {
   assertPackedSurface,
   assertRootVersionPolicy,
   assertVendoredCliManifest,
+  extractPackFilePaths,
   runRootReleaseGuard,
 } from "../root-release-guard.mjs";
 
@@ -83,6 +84,16 @@ test("assertPackedSurface rejects forbidden vendored implementation paths", () =
       ]),
     /forbidden vendored implementation path/i,
   );
+});
+
+test("extractPackFilePaths accepts npm pack object and array envelopes", () => {
+  const artifact = {
+    filename: "martin-loop-0.5.0.tgz",
+    files: [{ path: "package.json" }, { path: "dist/index.js" }],
+  };
+
+  assert.deepEqual(extractPackFilePaths([artifact]), ["package.json", "dist/index.js"]);
+  assert.deepEqual(extractPackFilePaths(artifact), ["package.json", "dist/index.js"]);
 });
 
 test("assertVendoredCliManifest accepts the sanitized vendored CLI package manifest", async () => {


### PR DESCRIPTION
## Summary
- accept both npm pack JSON envelopes used by supported npm versions
- retain the exact packed-file allowlist and retired-artifact rejection

## Verification
- RED: focused test failed because object-envelope support was absent
- GREEN: root release guard tests 7/7
- public facade packed-artifact smoke: pass
- OSS boundary validation: GO
- git diff --check: pass

This fixes the trusted v0.5.0 release gate failure before any npm publication occurred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release package validation to correctly process package file results in multiple supported formats.
  * Ensured valid packaged file paths are consistently identified during release checks.

* **Tests**
  * Added coverage for both supported package result formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->