### PR TITLE
Fix root release artifact inspection

### DIFF
--- a/scripts/root-release-guard.mjs
+++ b/scripts/root-release-guard.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 
 import { spawn } from "node:child_process";
-import { access, readFile } from "node:fs/promises";
+import { access, mkdtemp, readFile, readdir, rm } from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -104,22 +105,39 @@ export function assertPackedSurface(packedFiles) {
 export async function inspectPackedFiles(options = {}) {
   const rootDir = options.rootDir ?? process.cwd();
   const ignoreScripts = options.ignoreScripts ?? true;
-  const command = ["npm", "pack", "--dry-run", "--json"];
-  if (ignoreScripts) {
-    command.push("--ignore-scripts");
-  }
-  const packRun = await runCommand(
-    command,
-    { cwd: rootDir },
-  );
-  const packArtifacts = extractPackJsonPayload(packRun.stdout);
-  const files = extractPackFilePaths(packArtifacts);
+  const packDestination = await mkdtemp(path.join(os.tmpdir(), "martin-root-pack-"));
 
-  if (files.length === 0) {
-    throw new Error("npm pack --dry-run did not report any packaged files.");
-  }
+  try {
+    const command = ["npm", "pack", "--pack-destination", packDestination];
+    if (ignoreScripts) {
+      command.push("--ignore-scripts");
+    }
+    await runCommand(command, { cwd: rootDir });
 
-  return files;
+    const tarballs = (await readdir(packDestination)).filter((entry) => entry.endsWith(".tgz"));
+    if (tarballs.length !== 1) {
+      throw new Error(`npm pack produced ${tarballs.length} tarballs; expected exactly one.`);
+    }
+
+    const tarRun = await runCommand(
+      ["tar", "-tf", path.join(packDestination, tarballs[0])],
+      { cwd: rootDir },
+    );
+    const files = normalizePackedTarEntries(tarRun.stdout.split(/\r?\n/u));
+    if (files.length === 0) {
+      throw new Error("Packed tarball did not contain any files.");
+    }
+
+    return files;
+  } finally {
+    await rm(packDestination, { force: true, recursive: true });
+  }
+}
+
+export function normalizePackedTarEntries(entries) {
+  return entries
+    .map((entry) => entry.trim().replace(/^package\//u, ""))
+    .filter((entry) => entry.length > 0 && !entry.endsWith("/"));
 }
 
 export function extractPackJsonPayload(stdout) {

--- a/scripts/tests/root-release-guard.test.mjs
+++ b/scripts/tests/root-release-guard.test.mjs
@@ -10,6 +10,7 @@ import {
   assertRootVersionPolicy,
   assertVendoredCliManifest,
   extractPackFilePaths,
+  normalizePackedTarEntries,
   runRootReleaseGuard,
 } from "../root-release-guard.mjs";
 
@@ -94,6 +95,19 @@ test("extractPackFilePaths accepts npm pack object and array envelopes", () => {
 
   assert.deepEqual(extractPackFilePaths([artifact]), ["package.json", "dist/index.js"]);
   assert.deepEqual(extractPackFilePaths(artifact), ["package.json", "dist/index.js"]);
+});
+
+test("normalizePackedTarEntries reads the real npm tarball surface", () => {
+  assert.deepEqual(
+    normalizePackedTarEntries([
+      "package/",
+      "package/package.json",
+      "package/dist/index.js",
+      "package/dist/vendor/adapters/codex.js",
+      "",
+    ]),
+    ["package.json", "dist/index.js", "dist/vendor/adapters/codex.js"],
+  );
 });
 
 test("assertVendoredCliManifest accepts the sanitized vendored CLI package manifest", async () => {


### PR DESCRIPTION
## Summary
- inspect the actual temporary root package tarball in the release guard
- preserve the existing packed-surface allowlist and forbidden retired-artifact checks
- stop relying on optional `npm pack --dry-run` file metadata

## Verification
- focused release-guard tests: 8/8 passed
- root release guard: exit 0
- public facade smoke: exit 0
- OSS validation: exit 0
- git diff --check: exit 0

## Release blocker
Two trusted Linux release runs stopped before pack/publish because npm returned no dry-run file metadata. This change validates the real artifact instead and always removes the temporary pack directory.