### PR TITLE
Fix MCP fallback tarball discovery

### DIFF
--- a/packages/mcp/scripts/smoke-published-package.mjs
+++ b/packages/mcp/scripts/smoke-published-package.mjs
@@ -9,6 +9,7 @@ import { fileURLToPath } from "node:url";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 
+import { findSingleTarball } from "../../../scripts/root-release-guard.mjs";
 import { buildStandaloneMcpPackage, createCommandLaunch } from "./build-package-lib.mjs";
 import {
   PUBLISHED_PACKAGE_SPEC,
@@ -586,17 +587,12 @@ async function installPublishedPackage({ installRoot, npmCacheDir, packageSpec }
 
 async function buildLocalFallbackTarballSpec({ packageDir, tempPackDir }) {
   await buildStandaloneMcpPackage({ packageDir });
-  const packRun = await runCommand(
+  await runCommand(
     npmCommand(),
-    ["pack", "--ignore-scripts", "--json", "--pack-destination", tempPackDir],
+    ["pack", "--ignore-scripts", "--pack-destination", tempPackDir],
     { cwd: packageDir },
   );
-  const packEntry = JSON.parse(packRun.stdout)?.[0];
-  if (!packEntry?.filename) {
-    throw new Error("Unable to create fallback MCP tarball for smoke verification.");
-  }
-
-  return path.join(tempPackDir, packEntry.filename);
+  return path.join(tempPackDir, await findSingleTarball(tempPackDir));
 }
 
 function createInstalledPackageLaunch(installedPackageDir) {


### PR DESCRIPTION
## Summary
- discover the locally packed MCP fallback tarball from the output directory
- remove the final dependency on npm JSON filename metadata

## Verification
- exact `smoke:published:pack` gate: exit 0
- packaged MCP install/launch: passed
- tool surface: 22 tools
- git diff --check: exit 0

## Release blocker
Trusted release run 31673182115 stopped before pack/publish at this fallback smoke. No 0.5.0 package or release was published.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local package smoke testing by reliably locating the generated package archive.
  * Removed fragile manual parsing and filename validation during fallback packaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->