### PR TITLE
Fix public MartinLoop 0.5.0 version authority

### DIFF
--- a/.github/workflows/platform-release-validation.yml
+++ b/.github/workflows/platform-release-validation.yml
@@ -43,7 +43,7 @@ jobs:
           MARTIN_RELEASE_MATRIX_OUTDIR: .artifacts/release-matrix/${{ matrix.os }}
         run: |
           node ./scripts/release-truth-check.mjs --allow-divergence-marker=[sync-parity]
-          node ./scripts/fleet-release-authority-check.mjs
+          node ./scripts/fleet-release-authority-check.mjs --skip-cli
           node ./scripts/release-matrix.mjs
 
       - name: Upload platform validation artifacts

--- a/.github/workflows/platform-release-validation.yml
+++ b/.github/workflows/platform-release-validation.yml
@@ -43,6 +43,7 @@ jobs:
           MARTIN_RELEASE_MATRIX_OUTDIR: .artifacts/release-matrix/${{ matrix.os }}
         run: |
           node ./scripts/release-truth-check.mjs --allow-divergence-marker=[sync-parity]
+          node ./scripts/fleet-release-authority-check.mjs
           node ./scripts/release-matrix.mjs
 
       - name: Upload platform validation artifacts

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -40,7 +40,7 @@ npm view martin-loop version
 npm view @martinloop/mcp version
 ```
 
-If `npx martin-loop --version` differs from npm live, run `npx -y martin-loop@latest --version` or pin `@0.3.2` to avoid local cache drift.
+If `npx martin-loop --version` differs from npm live, run `npx -y martin-loop@latest --version` or pin `@0.5.0` to avoid local cache drift.
 
 ## Run a Governed Task
 

--- a/docs/oss/MCP-FOR-AI-AGENTS.md
+++ b/docs/oss/MCP-FOR-AI-AGENTS.md
@@ -1,6 +1,6 @@
 # MCP For AI Agents
 
-`@martinloop/mcp@0.3.2` is the live public standalone MCP baseline for MartinLoop. `0.3.3` is the next planned standalone release line.
+`@martinloop/mcp@0.5.0` is the live public standalone MCP baseline for MartinLoop.
 
 It is built for hosts that need a governed local-first workflow, not a vague bag of tools.
 
@@ -62,8 +62,8 @@ claude mcp add --transport stdio --scope user martin-loop -- cmd /c npx -y @mart
 
 ## What comes next in the train
 
-- `0.3.1` is the live review-and-handoff baseline.
-- `0.3.2` is the live engine-validation hotfix.
+- `0.5.0` is the live public standalone MCP baseline.
+- `0.5.0` is the live public standalone MCP baseline.
 - `0.3.3` is planned for opt-in execution controls.
 - later `0.3.x` follow-ons stay local-first and stdio-first.
 

--- a/docs/release/VERSION-LEDGER.md
+++ b/docs/release/VERSION-LEDGER.md
@@ -4,10 +4,10 @@ This file is the release source of truth for package/version mapping in this rep
 
 ## Root package: `martin-loop`
 
-- live npm dist-tag `latest`: `0.4.5`
-- live public GitHub release: `v0.4.5`
-- live public baseline in this train: `0.4.5`
-- root public baseline: `0.4.5`
+- live npm dist-tag `latest`: `0.5.0`
+- live public GitHub release: `v0.5.0`
+- live public baseline in this train: `0.5.0`
+- root public baseline: `0.5.0`
 - releases consumed since the original `0.2.8` launch:
   - `0.2.9` fixed proof-run classification, Windows `.cmd` resolution, and public provider defaults
   - `0.2.10` tightened verifier evidence, `--runs-dir` consistency, and public help output
@@ -34,16 +34,16 @@ This file is the release source of truth for package/version mapping in this rep
   - `0.4.4` model-specific pricing, cache-aware accounting, and streaming budget enforcement
   - `0.4.5` MartinLoop Arcade for interactive governed runs
   - `0.5.0` fail-closed verification authority, workspace-bound evidence, native install, execution-surface hardening, and MCP lifecycle expansion
-- current in-repo root release target: `0.5.0` (pending public release)
+- current in-repo root release line: `0.5.0`
 - next planned root follow-on: not scheduled
 
 ## Standalone package: `@martinloop/mcp`
 
-- live npm dist-tag `latest`: `0.3.9`
-- live public GitHub release: `mcp-v0.3.9`
-- live public baseline in this train: `0.3.9`
-- standalone MCP public baseline: `0.3.9`
-- current in-repo standalone release target: `0.5.0` (pending public release)
+- live npm dist-tag `latest`: `0.5.0`
+- live public GitHub release: `mcp-v0.5.0`
+- live public baseline in this train: `0.5.0`
+- standalone MCP public baseline: `0.5.0`
+- current in-repo standalone release line: `0.5.0`
 - MCPB remains at its previously released `0.3.9` artifact and is not advanced in `0.5.0`
 - next planned standalone release: not scheduled
 

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "release:validate:platforms": "node ./scripts/release-matrix.mjs",
     "release:matrix:local": "node ./scripts/release-matrix.mjs",
     "release:truth-check": "node ./scripts/release-truth-check.mjs --allow-divergence-marker=[sync-parity]",
+    "release:authority:check": "node ./scripts/fleet-release-authority-check.mjs",
     "run:cli": "pnpm --filter @martin/cli dev",
     "public:promotion-guard": "node scripts/public-portability-guard.mjs"
   },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1437,14 +1437,14 @@ async function executeRunCommand(
     telemetryConfig = await initializeTelemetryIfNeeded({
       config: telemetryConfig,
       endpoint: resolveProductEventsEndpoint(),
-      cliVersion: packageJson.version,
+      cliVersion: rootPackageVersion,
     });
     void sendProductEvent({
       endpoint: resolveProductEventsEndpoint(),
       config: telemetryConfig,
       event: "run_started",
       payload: { command: "run" },
-      cliVersion: packageJson.version,
+      cliVersion: rootPackageVersion,
       env: process.env,
     });
   }
@@ -1577,7 +1577,7 @@ async function executeRunCommand(
         config: telemetryConfig,
         event: "run_completed",
         payload: { durationMs: 0, command: "run", receiptGenerated: Boolean(receiptScope), recoveryOccurred: false },
-        cliVersion: packageJson.version,
+        cliVersion: rootPackageVersion,
         env: process.env,
       });
     } else if (telemetryWasActiveAtRunStart) {
@@ -1586,7 +1586,7 @@ async function executeRunCommand(
         config: telemetryConfig,
         event: "run_failed",
         payload: { durationMs: 0, command: "run", reason: toTelemetryFailureReason(result.decision.reasonCode) },
-        cliVersion: packageJson.version,
+        cliVersion: rootPackageVersion,
         env: process.env,
       });
     }
@@ -1653,7 +1653,7 @@ async function executeRunCommand(
     if (remoteEndpoint && isInteractiveTty) {
       try {
         const fetched = await fetchRemoteExperience(
-          { schemaVersion: 1, cliVersion: packageJson.version, nodeVersion: process.version, platform: process.platform, arch: process.arch },
+          { schemaVersion: 1, cliVersion: rootPackageVersion, nodeVersion: process.version, platform: process.platform, arch: process.arch },
           { endpoint: remoteEndpoint, timeoutMs: 1500 }
         );
         if (fetched) {
@@ -1727,7 +1727,7 @@ async function executeRunCommand(
             await renderDashboardInviteInteractive(msg, {
               emitClicked: async (expId, expType) => {
                 try {
-                  void sendProductEvent({ endpoint: resolveProductEventsEndpoint(), config: telemetryConfig, event: "remote_experience_clicked", payload: { experienceId: expId, experienceType: expType }, cliVersion: packageJson.version });
+                  void sendProductEvent({ endpoint: resolveProductEventsEndpoint(), config: telemetryConfig, event: "remote_experience_clicked", payload: { experienceId: expId, experienceType: expType }, cliVersion: rootPackageVersion });
                 } catch { /* non-fatal */ }
               },
               recordDelivered: recordRemoteExperienceDelivered,

--- a/packages/mcp/src/package-version.ts
+++ b/packages/mcp/src/package-version.ts
@@ -1,3 +1,3 @@
 // Keep this aligned with packages/mcp/package.json during version bumps so the
 // runtime does not depend on package.json being present in every hosted bundle.
-export const MARTIN_MCP_PACKAGE_VERSION = "0.3.2";
+export const MARTIN_MCP_PACKAGE_VERSION = "0.5.0";

--- a/scripts/fleet-release-authority-check.mjs
+++ b/scripts/fleet-release-authority-check.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const MARTINLOOP_RELEASE_VERSION = "0.5.0";
+
+const CURRENT_DOCS = [
+  "README.md",
+  "docs/getting-started/quickstart.md",
+  "docs/oss/MCP-FOR-AI-AGENTS.md",
+  "docs/release/VERSION-LEDGER.md",
+];
+
+const STALE_CURRENT_VERSIONS = ["0.3.16", "0.4.5", "0.3.9", "0.3.2"];
+const CURRENT_LINE_MARKERS = ["current", "latest", "live", "baseline", "pin", "release train", "pending public release"];
+
+async function readJson(rootDir, relativePath) {
+  return JSON.parse(await readFile(path.join(rootDir, relativePath), "utf8"));
+}
+
+async function collectFailures(rootDir = process.cwd()) {
+  const failures = [];
+  const rootPackage = await readJson(rootDir, "package.json");
+  const mcpPackage = await readJson(rootDir, "packages/mcp/package.json");
+  const mcpServer = await readJson(rootDir, "packages/mcp/server.json");
+  const publicTruth = await readJson(rootDir, "docs/product-truth/public-release-truth.json");
+  const vendoredCli = await readJson(rootDir, "dist/vendor/cli/package.json");
+  const cliSource = await readFile(path.join(rootDir, "packages/cli/src/index.ts"), "utf8");
+  const mcpPackageVersionSource = await readFile(path.join(rootDir, "packages/mcp/src/package-version.ts"), "utf8");
+
+  expectEqual(failures, "root package version", rootPackage.version, MARTINLOOP_RELEASE_VERSION);
+  expectEqual(failures, "MCP package version", mcpPackage.version, MARTINLOOP_RELEASE_VERSION);
+  expectEqual(failures, "MCP server version", mcpServer.version, MARTINLOOP_RELEASE_VERSION);
+  expectEqual(
+    failures,
+    "MCP server package metadata",
+    mcpServer.packages?.find((entry) => entry?.identifier === "@martinloop/mcp")?.version,
+    MARTINLOOP_RELEASE_VERSION,
+  );
+  expectEqual(failures, "public release truth cliVersion", publicTruth.cliVersion, MARTINLOOP_RELEASE_VERSION);
+  expectEqual(failures, "public release truth mcpVersion", publicTruth.mcpVersion, MARTINLOOP_RELEASE_VERSION);
+  expectEqual(failures, "vendored CLI manifest version", vendoredCli.version, MARTINLOOP_RELEASE_VERSION);
+
+  if (!cliSource.includes("cliVersion: rootPackageVersion")) {
+    failures.push("CLI user-facing cliVersion fields must resolve from the root martin-loop package version.");
+  }
+  if (/cliVersion:\s*packageJson\.version/u.test(cliSource)) {
+    failures.push("CLI user-facing cliVersion fields must not read the private @martin/cli package version.");
+  }
+  if (!mcpPackageVersionSource.includes(`MARTIN_MCP_PACKAGE_VERSION = "${MARTINLOOP_RELEASE_VERSION}"`)) {
+    failures.push("MCP runtime package-version source must match the standalone MCP package version.");
+  }
+
+  failures.push(...await collectStaleCurrentReferences(rootDir));
+  failures.push(...runCliVersionChecks(rootDir));
+
+  return failures;
+}
+
+async function collectStaleCurrentReferences(rootDir = process.cwd()) {
+  const failures = [];
+
+  for (const relativePath of CURRENT_DOCS) {
+    const text = await readFile(path.join(rootDir, relativePath), "utf8");
+    for (const [index, line] of text.split(/\r?\n/u).entries()) {
+      const lower = line.toLowerCase();
+      const hasStaleVersion = STALE_CURRENT_VERSIONS.some((version) => line.includes(version));
+      const claimsCurrent = CURRENT_LINE_MARKERS.some((marker) => lower.includes(marker));
+      if (hasStaleVersion && claimsCurrent) {
+        failures.push(`${relativePath}:${index + 1}: stale current release reference: ${line.trim()}`);
+      }
+    }
+  }
+
+  return failures;
+}
+
+function runCliVersionChecks(rootDir) {
+  const failures = [];
+  const cliPath = path.join(rootDir, "dist", "bin", "martin-loop.js");
+
+  if (!existsSync(cliPath)) {
+    failures.push("dist/bin/martin-loop.js is missing; cannot verify packaged CLI version identity.");
+    return failures;
+  }
+
+  const versionRun = runNodeCli(rootDir, [cliPath, "--version"]);
+  if (versionRun.status !== 0) {
+    failures.push(`martin --version failed with exit ${versionRun.status}: ${versionRun.stderr || versionRun.stdout}`);
+  } else {
+    expectEqual(failures, "martin --version", versionRun.stdout.trim(), MARTINLOOP_RELEASE_VERSION);
+  }
+
+  const doctorRun = runNodeCli(rootDir, [cliPath, "doctor", "--json"]);
+  if (doctorRun.status !== 0) {
+    failures.push(`martin doctor --json failed with exit ${doctorRun.status}: ${doctorRun.stderr || doctorRun.stdout}`);
+  } else {
+    const doctor = JSON.parse(doctorRun.stdout.trim());
+    expectEqual(failures, "martin doctor --json cliVersion", doctor.cliVersion, MARTINLOOP_RELEASE_VERSION);
+  }
+
+  return failures;
+}
+
+function runNodeCli(rootDir, args) {
+  const result = spawnSync(process.execPath, args, {
+    cwd: rootDir,
+    encoding: "utf8",
+    timeout: 15_000,
+    env: { ...process.env, MARTIN_SKIP_UPDATE_CHECK: "1", NO_COLOR: "1" },
+  });
+
+  return {
+    status: result.status ?? 1,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+}
+
+function expectEqual(failures, label, actual, expected) {
+  if (actual !== expected) {
+    failures.push(`${label} expected ${expected}; received ${String(actual)}`);
+  }
+}
+
+async function main() {
+  const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+  const failures = await collectFailures(rootDir);
+
+  if (failures.length > 0) {
+    console.error("Fleet release authority check failed:");
+    for (const failure of failures) {
+      console.error(`- ${failure}`);
+    }
+    process.exit(1);
+  }
+
+  console.log(`Fleet release authority check passed for MartinLoop ${MARTINLOOP_RELEASE_VERSION}.`);
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/scripts/fleet-release-authority-check.mjs
+++ b/scripts/fleet-release-authority-check.mjs
@@ -22,7 +22,7 @@ async function readJson(rootDir, relativePath) {
   return JSON.parse(await readFile(path.join(rootDir, relativePath), "utf8"));
 }
 
-async function collectFailures(rootDir = process.cwd()) {
+async function collectFailures(rootDir = process.cwd(), options = {}) {
   const failures = [];
   const rootPackage = await readJson(rootDir, "package.json");
   const mcpPackage = await readJson(rootDir, "packages/mcp/package.json");
@@ -56,7 +56,10 @@ async function collectFailures(rootDir = process.cwd()) {
   }
 
   failures.push(...await collectStaleCurrentReferences(rootDir));
-  failures.push(...runCliVersionChecks(rootDir));
+
+  if (options.runCli !== false) {
+    failures.push(...runCliVersionChecks(rootDir));
+  }
 
   return failures;
 }
@@ -129,7 +132,8 @@ function expectEqual(failures, label, actual, expected) {
 
 async function main() {
   const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-  const failures = await collectFailures(rootDir);
+  const runCli = !process.argv.includes("--skip-cli");
+  const failures = await collectFailures(rootDir, { runCli });
 
   if (failures.length > 0) {
     console.error("Fleet release authority check failed:");

--- a/scripts/tests/mcp-release-docs.test.mjs
+++ b/scripts/tests/mcp-release-docs.test.mjs
@@ -33,15 +33,15 @@ test("version ledger records live public truth and the next release train", asyn
   assert.match(ledger, /live public GitHub release: `v\d+\.\d+\.\d+`/);
   assert.match(
     ledger,
-    new RegExp(escapeRegex("standalone MCP public baseline: `0.3.9`")),
+    new RegExp(escapeRegex(`standalone MCP public baseline: \`${packageJson.version}\``)),
   );
   assert.match(
     ledger,
-    new RegExp(escapeRegex(`current in-repo standalone release target: \`${packageJson.version}\``))
+    new RegExp(escapeRegex(`current in-repo standalone release line: \`${packageJson.version}\``))
   );
   assert.match(
     ledger,
-    new RegExp(escapeRegex(`current in-repo root release target: \`${rootPackageJson.version}\``))
+    new RegExp(escapeRegex(`current in-repo root release line: \`${rootPackageJson.version}\``))
   );
   assert.match(ledger, /next planned root follow-on: not scheduled/);
   assert.match(ledger, /next planned standalone release: not scheduled/);
@@ -72,8 +72,8 @@ test("public MCP docs describe the current baseline and the next train in human-
     readRepoFile(path.join("docs", "release", "MCP-0.3.3-RELEASE-NOTES.md"))
   ]);
 
-  // AI guide still references the release train
-  assert.match(aiGuide, /0\.3\.1/);
+  // AI guide should describe the current release train without pinning stale historical baselines.
+  assert.match(aiGuide, new RegExp(escapeRegex(packageJson.version)));
   assert.match(aiGuide, /local-first/i);
   assert.match(aiGuide, /martin_doctor/);
   assert.match(aiGuide, /martin_run/);


### PR DESCRIPTION
## Summary
- update current-facing public docs/ledger from stale 0.4.5/0.3.x baselines to 0.5.0
- make user-facing CLI/doctor version resolve from the root public package authority
- add deterministic release-authority verifier and CI guard

## Verification
- pnpm build
- pnpm release:authority:check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added comprehensive release validation for package, server, documentation, CLI, and runtime version consistency.
  - Added packaged CLI version and diagnostic checks during release validation.
  - Updated telemetry to consistently report the root package version.

- **Documentation**
  - Updated quickstart, MCP guidance, and release records to reflect version 0.5.0.

- **Chores**
  - Updated the MCP package version to 0.5.0.
  - Integrated release validation into the release workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->