### PR TITLE
fix(release): build workspace before clean-runner lint

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,12 +35,12 @@ jobs:
 
       - name: Validate OSS release surface
         run: |
+          pnpm build
           pnpm lint
           pnpm public:copy-scan
           pnpm public:portability-guard
           pnpm public:git-surface
           pnpm test
-          pnpm build
           pnpm oss:validate
           pnpm public:smoke
           pnpm --filter @martinloop/mcp lint

--- a/scripts/tests/root-release-workflow.test.mjs
+++ b/scripts/tests/root-release-workflow.test.mjs
@@ -26,6 +26,10 @@ test("root release workflow uses GitHub Actions trusted publishing without npm t
   assert.match(workflow, /pnpm --filter @martinloop\/mcp mcpb:smoke/);
   assert.match(workflow, /packages\/mcp\/dist-mcpb\/martinloop-\*\.mcpb/);
   assert.match(workflow, /packages\/mcp\/dist-mcpb\/martinloop-\*\.mcpb\.sha256/);
+  assert.ok(
+    workflow.indexOf("pnpm build") < workflow.indexOf("pnpm lint"),
+    "the clean release runner must build workspace type declarations before linting"
+  );
 
   assert.doesNotMatch(workflow, /NODE_AUTH_TOKEN/);
   assert.doesNotMatch(workflow, /NPM_TOKEN/);


### PR DESCRIPTION
Fixes the root v0.5.1 trusted-publishing workflow after the first tag run proved a clean checkout must build workspace type declarations before lint. Adds a regression assertion for the required order. No product/runtime changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release validation to build the project before running linting and other checks.
  * Improved workflow validation to ensure build steps run in the correct order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->