### PR TITLE
chore(release): record live 0.5.1 artifacts

### DIFF
--- a/distribution/release-truth.json
+++ b/distribution/release-truth.json
@@ -14,8 +14,8 @@
   "mcpb": {
     "built": true,
     "released": true,
-    "releaseUrl": "https://github.com/Keesan12/martin-loop/releases/download/mcp-v0.3.9/martinloop-0.3.9.mcpb",
-    "sha256": "3b656a7d6f11f6a301b7aee291ba6f5ed29ba9e7dfc2d5ae530d57d93a13d958"
+    "releaseUrl": "https://github.com/Keesan12/martin-loop/releases/download/v0.5.1/martinloop-0.5.1.mcpb",
+    "sha256": "987a0c72a0db8ab0c190caf61d592d4a7d126b3b3a711a937c75a4406a7c940d"
   },
   "repository": "https://github.com/Keesan12/martin-loop",
   "website": "https://martinloop.com"

--- a/docs/release/VERSION-LEDGER.md
+++ b/docs/release/VERSION-LEDGER.md
@@ -4,10 +4,10 @@ This file is the release source of truth for package/version mapping in this rep
 
 ## Root package: `martin-loop`
 
-- live npm dist-tag `latest`: `0.5.0`
-- live public GitHub release: `v0.5.0`
-- live public baseline in this train: `0.5.0`
-- root public baseline: `0.5.0`
+- live npm dist-tag `latest`: `0.5.1`
+- live public GitHub release: `v0.5.1`
+- live public baseline in this train: `0.5.1`
+- root public baseline: `0.5.1`
 - releases consumed since the original `0.2.8` launch:
   - `0.2.9` fixed proof-run classification, Windows `.cmd` resolution, and public provider defaults
   - `0.2.10` tightened verifier evidence, `--runs-dir` consistency, and public help output
@@ -34,18 +34,18 @@ This file is the release source of truth for package/version mapping in this rep
   - `0.4.4` model-specific pricing, cache-aware accounting, and streaming budget enforcement
   - `0.4.5` MartinLoop Arcade for interactive governed runs
   - `0.5.0` fail-closed verification authority, workspace-bound evidence, native install, execution-surface hardening, and MCP lifecycle expansion
-- current in-repo root release target: `0.5.1` (pending public release)
+- current in-repo root release target: `0.5.1` (released publicly)
 - next planned root follow-on: not scheduled
 
 ## Standalone package: `@martinloop/mcp`
 
-- live npm dist-tag `latest`: `0.5.0`
-- live public GitHub release: `mcp-v0.5.0`
-- live public baseline in this train: `0.5.0`
-- standalone MCP public baseline: `0.5.0`
-- current in-repo standalone release target: `0.5.1` (pending public release)
-- live MCPB baseline: `0.3.9`
-- current in-repo MCPB release target: `0.5.1` with manifest schema `0.3`
+- live npm dist-tag `latest`: `0.5.1`
+- live public GitHub release: `mcp-v0.5.1`
+- live public baseline in this train: `0.5.1`
+- standalone MCP public baseline: `0.5.1`
+- current in-repo standalone release target: `0.5.1` (released publicly)
+- live MCPB baseline: `0.5.1`
+- current in-repo MCPB release target: `0.5.1` with manifest schema `0.3` (released publicly)
 - next planned standalone release: not scheduled
 
 ## Release rules

--- a/scripts/tests/mcp-release-docs.test.mjs
+++ b/scripts/tests/mcp-release-docs.test.mjs
@@ -33,7 +33,7 @@ test("version ledger records live public truth and the next release train", asyn
   assert.match(ledger, /live public GitHub release: `v\d+\.\d+\.\d+`/);
   assert.match(
     ledger,
-    new RegExp(escapeRegex("standalone MCP public baseline: `0.5.0`")),
+    new RegExp(escapeRegex(`standalone MCP public baseline: \`${packageJson.version}\``)),
   );
   assert.match(
     ledger,
@@ -45,7 +45,10 @@ test("version ledger records live public truth and the next release train", asyn
   );
   assert.match(ledger, /next planned root follow-on: not scheduled/);
   assert.match(ledger, /next planned standalone release: not scheduled/);
-  assert.match(ledger, /live MCPB baseline: `0\.3\.9`/);
+  assert.match(
+    ledger,
+    new RegExp(escapeRegex(`live MCPB baseline: \`${packageJson.version}\``))
+  );
   assert.match(
     ledger,
     new RegExp(escapeRegex(`current in-repo MCPB release target: \`${packageJson.version}\``))


### PR DESCRIPTION
Updates public release truth only after the 0.5.1 npm, GitHub, MCP Registry, and MCPB artifacts became live. Records the released MCPB URL and verified SHA-256, and advances the public version ledger. No product/runtime changes.