### PR TITLE
fix(cli): align preflight readiness with run admission

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -111,7 +111,12 @@ import {
   type IntegrityStatus
 } from "./run-store.js";
 import { CliCommandError, exitCodeForGovernedOutcome, renderCliError, renderCliSuccess, renderRunHeader, renderInlineMilestone, renderMilestonePrompt, renderLoopCard, type RunOutcome } from "./ux.js";
-import { deriveWorkspaceId, evaluateCliRunGate, recordCliWorkflowStep } from "./workflow-state.js";
+import {
+  deriveWorkspaceId,
+  evaluateCliPreflightGate,
+  evaluateCliRunGate,
+  recordCliWorkflowStep
+} from "./workflow-state.js";
 import {
   recordRunAndGetPrompt,
   retryQueuedIntake,
@@ -3154,12 +3159,36 @@ async function executePreflightCommand(
     );
   }
 
+  const workflowAdmission = engineRequired
+    ? await evaluateCliPreflightGate({
+        runsRoot: environment.runsRoot,
+        workingDirectory: environment.workingDirectory,
+        objective: request.objective,
+        engine: environment.engine,
+        verificationPlan,
+        mutationMode: request.mutationMode,
+        receiptScope,
+        allowedPaths: request.allowedPaths,
+        deniedPaths: request.deniedPaths,
+        budget: resolvedGuardrails.budget
+      })
+    : {
+        allowed: true,
+        nextCommand: "martin-loop run",
+        message: "No live governed workflow admission is required for this preflight.",
+        missingSteps: []
+      };
+  if (!workflowAdmission.allowed) {
+    blockingIssues.push(workflowAdmission.message);
+  }
+
   const ready = blockingIssues.length === 0;
   const data = {
     command: "preflight",
     ready,
     blockingIssues,
     warnings,
+    workflowAdmission,
     environment,
     receiptScope,
     scope: {

--- a/packages/cli/src/workflow-state.ts
+++ b/packages/cli/src/workflow-state.ts
@@ -163,6 +163,17 @@ export async function recordCliWorkflowStep(input: CliWorkflowStepInput): Promis
 }
 
 export async function evaluateCliRunGate(input: CliRunGateInput): Promise<CliRunGateResult> {
+  return evaluateCliWorkflowGate(input, false);
+}
+
+export async function evaluateCliPreflightGate(input: CliRunGateInput): Promise<CliRunGateResult> {
+  return evaluateCliWorkflowGate(input, true);
+}
+
+async function evaluateCliWorkflowGate(
+  input: CliRunGateInput,
+  candidatePreflight: boolean
+): Promise<CliRunGateResult> {
   const state = await readWorkflowState(input.runsRoot, input.workingDirectory);
   const cliState = state.cli ?? {};
   const workingDirectory = normalizeWorkingDirectory(input.workingDirectory);
@@ -232,11 +243,12 @@ export async function evaluateCliRunGate(input: CliRunGateInput): Promise<CliRun
   // Engine, budget, max-iterations, and token limits are runtime execution controls —
   // not safety identity. Changing them does NOT require a fresh preflight.
   // Only a changed verifier command or path scope invalidates the receipt.
-  const preflightReady = isFresh(cliState["preflight"], PREFLIGHT_TTL_MS, (receipt) =>
-    receipt.workingDirectory === workingDirectory &&
-    receipt.verificationPlanKey === verificationPlanKey &&
-    receipt.pathScopeKey === pathScopeKey
-  );
+  const preflightReady = candidatePreflight ||
+    isFresh(cliState["preflight"], PREFLIGHT_TTL_MS, (receipt) =>
+      receipt.workingDirectory === workingDirectory &&
+      receipt.verificationPlanKey === verificationPlanKey &&
+      receipt.pathScopeKey === pathScopeKey
+    );
   if (!preflightReady) {
     missingSteps.push("preflight");
   }

--- a/packages/cli/tests/cli-integration.test.ts
+++ b/packages/cli/tests/cli-integration.test.ts
@@ -405,6 +405,114 @@ describe("--engine flag", () => {
     });
   });
 
+  it("makes READY preflight authority match the immediately following run gate", { timeout: 45000 }, async () => {
+    await withTempDir((workspace) =>
+      withScratchEnv(
+        {
+          MARTIN_INTEGRITY_KEY_DIR: join(workspace, ".martin-receipt-integrity"),
+          MARTIN_GROUNDING_DIR: join(workspace, ".martin-grounding")
+        },
+        async () => {
+          installDeterministicCodexHost();
+          initializeGitRepo(workspace);
+          const runsDir = join(workspace, ".martin-runs");
+          const objective = "Fix the readiness contract";
+          const requestArgs = [
+            "--engine",
+            "codex",
+            "--cwd",
+            workspace,
+            "--runs-dir",
+            runsDir,
+            "--objective",
+            objective,
+            "--verify",
+            NOOP_VERIFIER,
+            "--max-iterations",
+            "1",
+            "--budget-usd",
+            "2"
+          ];
+
+          const freshPreflight = await withEnv("MARTIN_LIVE", "true", () =>
+            executeCli(["--json", "preflight", ...requestArgs])
+          );
+          expect(freshPreflight.exitCode).toBe(0);
+          expect(JSON.parse(freshPreflight.stdout)).toMatchObject({
+            command: "preflight",
+            ready: false,
+            workflowAdmission: {
+              allowed: false,
+              missingSteps: expect.arrayContaining(["doctor", "estimate"])
+            }
+          });
+
+          const doctorResult = await withEnv("MARTIN_LIVE", "true", () =>
+            executeCli([
+              "--json",
+              "doctor",
+              "--engine",
+              "codex",
+              "--cwd",
+              workspace,
+              "--runs-dir",
+              runsDir
+            ])
+          );
+          expect(doctorResult.exitCode).toBe(0);
+
+          const doctorOnlyPreflight = await withEnv("MARTIN_LIVE", "true", () =>
+            executeCli(["--json", "preflight", ...requestArgs])
+          );
+          expect(JSON.parse(doctorOnlyPreflight.stdout)).toMatchObject({
+            ready: false,
+            workflowAdmission: {
+              allowed: false,
+              missingSteps: expect.arrayContaining(["estimate"])
+            }
+          });
+
+          const estimateResult = await withEnv("MARTIN_LIVE", "true", () =>
+            executeCli([
+              "--json",
+              "estimate",
+              objective,
+              "--engine",
+              "codex",
+              "--cwd",
+              workspace,
+              "--runs-dir",
+              runsDir,
+              "--budget-usd",
+              "2"
+            ])
+          );
+          expect(estimateResult.exitCode).toBe(0);
+
+          const readyPreflight = await withEnv("MARTIN_LIVE", "true", () =>
+            executeCli(["--json", "preflight", ...requestArgs])
+          );
+          expect(JSON.parse(readyPreflight.stdout)).toMatchObject({
+            command: "preflight",
+            ready: true,
+            workflowAdmission: {
+              allowed: true,
+              missingSteps: []
+            }
+          });
+
+          const runResult = await withEnv("MARTIN_LIVE", "true", () =>
+            executeCli(["--json", "run", ...requestArgs])
+          );
+          expect(runResult.exitCode).not.toBe(8);
+          const runPayload = JSON.parse(runResult.stdout);
+          expect(runPayload.command).toBe("run");
+          expect(runPayload.loop.attempts).toHaveLength(1);
+        }
+      )
+    );
+  });
+
   itIfCodexLiveHostOptIn("auto-bootstraps governed prerequisites and executes a live Codex run when host is ready", { timeout: 90_000 }, async () => {
     await withTempDir((workspace) =>
       withScratchEnv(
@@ -508,6 +616,22 @@ describe("--engine flag", () => {
             );
             expect(sessionStartResult.exitCode).toBe(0);
 
+            // Estimate required before a READY preflight — proves cost was reviewed.
+            await withEnv("MARTIN_LIVE", "true", () =>
+              executeCli([
+                "estimate",
+                "Fix the bug",
+                "--engine",
+                "codex",
+                "--cwd",
+                workspace,
+                "--runs-dir",
+                runsDir,
+                "--budget-usd",
+                "2"
+              ])
+            );
+
             const preflightResult = await withEnv("MARTIN_LIVE", "true", () =>
               executeCli([
                 "--json",
@@ -535,22 +659,6 @@ describe("--engine flag", () => {
             const normalizedWorkingDirectory = normalizeWorkingDirectoryForExpectation(workspace);
             expect(cliStateAfterPreflight["session-start"]?.workingDirectory).toBe(normalizedWorkingDirectory);
             expect(cliStateAfterPreflight.preflight?.workingDirectory).toBe(normalizedWorkingDirectory);
-
-            // Estimate required before governed run — proves cost was reviewed
-            await withEnv("MARTIN_LIVE", "true", () =>
-              executeCli([
-                "estimate",
-                "Fix the bug",
-                "--engine",
-                "codex",
-                "--cwd",
-                workspace,
-                "--runs-dir",
-                runsDir,
-                "--budget-usd",
-                "2"
-              ])
-            );
 
             const runResult = await withEnv("MARTIN_LIVE", "true", () =>
               executeCli([
@@ -621,6 +729,22 @@ describe("--engine flag", () => {
             );
             expect(doctorResult.exitCode).toBe(0);
 
+            // Estimate required before a READY preflight.
+            await withEnv("MARTIN_LIVE", "true", () =>
+              executeCli([
+                "estimate",
+                "Verify the outreach runtime",
+                "--engine",
+                "codex",
+                "--cwd",
+                workspace,
+                "--runs-dir",
+                runsDir,
+                "--budget-usd",
+                "2"
+              ])
+            );
+
             const preflightResult = await withEnv("MARTIN_LIVE", "true", () =>
               executeCli([
                 "--json",
@@ -638,22 +762,6 @@ describe("--engine flag", () => {
               ])
             );
             expect(preflightResult.exitCode).toBe(0);
-
-            // Estimate required before governed run
-            await withEnv("MARTIN_LIVE", "true", () =>
-              executeCli([
-                "estimate",
-                "Verify the outreach runtime",
-                "--engine",
-                "codex",
-                "--cwd",
-                workspace,
-                "--runs-dir",
-                runsDir,
-                "--budget-usd",
-                "2"
-              ])
-            );
 
             const runResult = await withEnv("MARTIN_LIVE", "true", () =>
               executeCli([
@@ -719,6 +827,22 @@ describe("--engine flag", () => {
             );
             expect(doctorResult.exitCode).toBe(0);
 
+            // Estimate required before a READY preflight.
+            await withEnv("MARTIN_LIVE", "true", () =>
+              executeCli([
+                "estimate",
+                "Verify the outreach runtime",
+                "--engine",
+                "codex",
+                "--cwd",
+                workspace,
+                "--runs-dir",
+                runsDir,
+                "--budget-usd",
+                "2"
+              ])
+            );
+
             const preflightResult = await withEnvVars(
               {
                 MARTIN_LIVE: "true",
@@ -741,22 +865,6 @@ describe("--engine flag", () => {
                 ])
             );
             expect(preflightResult.exitCode).toBe(0);
-
-            // Estimate required before governed run
-            await withEnv("MARTIN_LIVE", "true", () =>
-              executeCli([
-                "estimate",
-                "Verify the outreach runtime",
-                "--engine",
-                "codex",
-                "--cwd",
-                workspace,
-                "--runs-dir",
-                runsDir,
-                "--budget-usd",
-                "2"
-              ])
-            );
 
             const runResult = await withEnvVars(
               {


### PR DESCRIPTION
## Summary
- make preflight.ready use the same workflow-admission authority as run
- report missing doctor and estimate prerequisites before claiming READY
- preserve the invariant that an identical run can start immediately after a READY preflight
- update existing integration flows so estimation precedes READY preflight

## Verification
- focused CLI integration: 53 passed, 2 skipped
- full CLI package: 554 passed, 2 skipped
- CLI build and lint passed
- public copy, portability, OSS boundary, git-surface, and diff guards passed