### PR TITLE
chore(release): cut martin-loop 0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-08-18
+
+### Fixed
+- **Preflight readiness now matches run admission** — `martin preflight` uses the same workflow admission authority as `martin run`, so it cannot report `READY` while required doctor or estimate receipts would deterministically block the identical run.
+- **Workflow prerequisites are surfaced before spend** — preflight reports the missing readiness steps and next command, while identical task, verifier, path, budget, and workspace inputs that report `READY` are immediately admissible to run.
+
 ## [0.5.1] - 2026-08-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ One system to control, verify and understand coding-agent work.
 
 ## Start Here
 
-**Install** — run `npx -y martin-loop@0.5.1 start`, or install it globally with `npm install -g martin-loop@0.5.1`.
+**Install** — run `npx -y martin-loop@0.5.2 start`, or install it globally with `npm install -g martin-loop@0.5.2`.
 
 **Governed run** — define an objective, verifier, budget, and iteration cap with `martin run`.
 
@@ -109,7 +109,7 @@ npx -y martin-loop@latest preflight "Summarize the demo workspace and prove test
 
 `share --latest` writes three files into the selected run directory under `share/`: `run-receipt.json`, `run-receipt.md`, and `proof-card.svg`.
 
-Release notes for the current root package: [MartinLoop 0.5.1](./docs/release/OSS-0.5.1-RELEASE-NOTES.md).
+Release notes for the current root package: [MartinLoop 0.5.2](./docs/release/OSS-0.5.2-RELEASE-NOTES.md).
 
 ## Visual Proof
 
@@ -150,17 +150,17 @@ Example receipt files: [Markdown](./docs/examples/proof-receipts/live-governed-r
 Use this lane from a clean temp directory to verify the public CLI flow exactly as shipped:
 
 ```sh
-npx -y martin-loop@0.5.1 --version
-npx -y martin-loop@0.5.1 start
-npx -y martin-loop@0.5.1 demo
+npx -y martin-loop@0.5.2 --version
+npx -y martin-loop@0.5.2 start
+npx -y martin-loop@0.5.2 demo
 cd martin-loop-demo
 npm install
-npx -y martin-loop@0.5.1 run "Summarize the demo workspace and prove tests still pass" --verify "npm test" --budget-usd 2 --max-iterations 1 --json
-npx -y martin-loop@0.5.1 dossier --latest --json
-npx -y martin-loop@0.5.1 share --latest --json
+npx -y martin-loop@0.5.2 run "Summarize the demo workspace and prove tests still pass" --verify "npm test" --budget-usd 2 --max-iterations 1 --json
+npx -y martin-loop@0.5.2 dossier --latest --json
+npx -y martin-loop@0.5.2 share --latest --json
 ```
 
-For deterministic installs, pin the package line (`martin-loop@0.5.1`) or use `martin-loop@latest`. Plain `npx martin-loop` can resolve a stale local cache on some machines.
+For deterministic installs, pin the package line (`martin-loop@0.5.2`) or use `martin-loop@latest`. Plain `npx martin-loop` can resolve a stale local cache on some machines.
 
 Expected share bundle outputs:
 
@@ -333,7 +333,7 @@ npx martin-loop mcp print-config --host gemini --transport stdio --profile full-
 npx martin-loop mcp print-config --host generic --transport stdio --profile github-review
 ```
 
-The root `martin-loop` package, standalone `@martinloop/mcp` package, and MCPB artifact are aligned at `0.5.1` for this release. Their version lines may move independently in future releases.
+The root `martin-loop` package is `0.5.2`; standalone `@martinloop/mcp` and MCPB remain at `0.5.1` for this root-only corrective release. Their version lines move independently.
 
 The public MCP release train labels are:
 

--- a/docs/release/OSS-0.5.2-RELEASE-NOTES.md
+++ b/docs/release/OSS-0.5.2-RELEASE-NOTES.md
@@ -1,0 +1,27 @@
+# MartinLoop 0.5.2
+
+MartinLoop 0.5.2 is a corrective CLI release that makes preflight readiness and run admission agree.
+
+## Fixed
+
+- `martin preflight` now uses the same workflow admission authority as `martin run`.
+- Preflight no longer reports `READY` when required workflow receipts such as doctor or estimate would deterministically block the identical run.
+- Missing readiness prerequisites and the next command are surfaced before agent spend begins.
+- For the same workspace, task, verifier, path scope, and budget, a `READY` preflight is immediately admissible to the run gate.
+
+## Install
+
+```sh
+npx -y martin-loop@0.5.2 --version
+npx -y martin-loop@0.5.2 start
+```
+
+The standalone MCP package and MCPB bundle remain on `0.5.1` for this root-only corrective release:
+
+```sh
+npx -y @martinloop/mcp@0.5.1
+```
+
+## Trust boundary
+
+`READY` means the workflow prerequisites and configured preflight checks required for that exact run request are satisfied at the time of evaluation. A later change to the workspace, verifier, scope, budget, policy, or environment can require preflight again.

--- a/docs/release/VERSION-LEDGER.md
+++ b/docs/release/VERSION-LEDGER.md
@@ -34,7 +34,7 @@ This file is the release source of truth for package/version mapping in this rep
   - `0.4.4` model-specific pricing, cache-aware accounting, and streaming budget enforcement
   - `0.4.5` MartinLoop Arcade for interactive governed runs
   - `0.5.0` fail-closed verification authority, workspace-bound evidence, native install, execution-surface hardening, and MCP lifecycle expansion
-- current in-repo root release target: `0.5.1` (released publicly)
+- current in-repo root release target: `0.5.2` (release candidate)
 - next planned root follow-on: not scheduled
 
 ## Standalone package: `@martinloop/mcp`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "martin-loop",
   "private": false,
-  "version": "0.5.1",
+  "version": "0.5.2",
   "type": "module",
   "description": "Open-source command center for governed AI coding agents with built-in onboarding, hard gates, MCP, and shareable run receipts.",
   "packageManager": "pnpm@10.33.0",


### PR DESCRIPTION
## Summary
- bump the root `martin-loop` package to 0.5.2
- add customer-facing release notes for the preflight/run readiness fix
- keep standalone `@martinloop/mcp` and MCPB on 0.5.1 because this corrective release is root/CLI-only

## Release note
`martin preflight` now uses the same workflow admission authority as `martin run`, so it cannot report READY when missing doctor or estimate receipts would deterministically block the identical run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for version 0.5.2.
  * Documented improved alignment between preflight checks and run admission, including clearer prerequisite steps and readiness handling.

* **Release**
  * Updated the package and release target to version 0.5.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->