### PR TITLE
fix(release): unblock 0.5.2 copy scan

### DIFF
--- a/docs/release/VERSION-LEDGER.md
+++ b/docs/release/VERSION-LEDGER.md
@@ -34,7 +34,7 @@ This file is the release source of truth for package/version mapping in this rep
   - `0.4.4` model-specific pricing, cache-aware accounting, and streaming budget enforcement
   - `0.4.5` MartinLoop Arcade for interactive governed runs
   - `0.5.0` fail-closed verification authority, workspace-bound evidence, native install, execution-surface hardening, and MCP lifecycle expansion
-- current in-repo root release target: `0.5.2` (release candidate)
+- current in-repo root release target: `0.5.2` (pending publication)
 - next planned root follow-on: not scheduled
 
 ## Standalone package: `@martinloop/mcp`


### PR DESCRIPTION
## Summary
- remove the forbidden public-copy phrase from the version ledger
- keep 0.5.2 pending publication until the trusted release workflow succeeds

No runtime or product code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the release status for version 0.5.2 from “release candidate” to “pending publication.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->