### PR TITLE
chore(release): automate immutable root and MCP tag cutting

### DIFF
--- a/.github/workflows/cut-release-tags.yml
+++ b/.github/workflows/cut-release-tags.yml
@@ -1,0 +1,81 @@
+name: Cut Release Tags
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  cut-release-tags:
+    name: Cut root and MCP release tags
+    if: contains(github.event.head_commit.message, '[cut-release]')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Resolve release coordinates
+        id: versions
+        shell: bash
+        run: |
+          ROOT_VERSION="$(node -p "require('./package.json').version")"
+          MCP_VERSION="$(node -p "require('./packages/mcp/package.json').version")"
+          MCP_SERVER_VERSION="$(node -p "require('./packages/mcp/server.json').version")"
+          MCPB_VERSION="$(node -p "require('./packages/mcp/mcpb/manifest.json').version")"
+
+          if [ "$MCP_VERSION" != "$MCP_SERVER_VERSION" ]; then
+            echo "MCP package/server version mismatch: ${MCP_VERSION} != ${MCP_SERVER_VERSION}"
+            exit 1
+          fi
+          if [ "$MCP_VERSION" != "$MCPB_VERSION" ]; then
+            echo "MCP package/MCPB version mismatch: ${MCP_VERSION} != ${MCPB_VERSION}"
+            exit 1
+          fi
+
+          test -f "docs/release/OSS-${ROOT_VERSION}-RELEASE-NOTES.md"
+          test -f "docs/release/MCP-${MCP_VERSION}-RELEASE-NOTES.md"
+          node ./scripts/extract-changelog-entry.mjs --version "$ROOT_VERSION" >/dev/null
+
+          echo "root_version=${ROOT_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "mcp_version=${MCP_VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Refuse to move existing release tags
+        shell: bash
+        run: |
+          git fetch --tags --force
+          ROOT_TAG="v${{ steps.versions.outputs.root_version }}"
+          MCP_TAG="mcp-v${{ steps.versions.outputs.mcp_version }}"
+
+          if git rev-parse -q --verify "refs/tags/${ROOT_TAG}" >/dev/null; then
+            echo "Release tag ${ROOT_TAG} already exists. Refusing to move it."
+            exit 1
+          fi
+          if git rev-parse -q --verify "refs/tags/${MCP_TAG}" >/dev/null; then
+            echo "Release tag ${MCP_TAG} already exists. Refusing to move it."
+            exit 1
+          fi
+
+      - name: Create immutable release tags at this commit
+        shell: bash
+        run: |
+          ROOT_TAG="v${{ steps.versions.outputs.root_version }}"
+          MCP_TAG="mcp-v${{ steps.versions.outputs.mcp_version }}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git tag -a "$ROOT_TAG" "$GITHUB_SHA" -m "MartinLoop ${{ steps.versions.outputs.root_version }}"
+          git tag -a "$MCP_TAG" "$GITHUB_SHA" -m "@martinloop/mcp ${{ steps.versions.outputs.mcp_version }}"
+          git push origin "$ROOT_TAG" "$MCP_TAG"
+
+      - name: Verify tag commit parity
+        shell: bash
+        run: |
+          ROOT_TAG="v${{ steps.versions.outputs.root_version }}"
+          MCP_TAG="mcp-v${{ steps.versions.outputs.mcp_version }}"
+          test "$(git rev-parse "${ROOT_TAG}^{commit}")" = "$GITHUB_SHA"
+          test "$(git rev-parse "${MCP_TAG}^{commit}")" = "$GITHUB_SHA"

--- a/scripts/tests/cut-release-tags-workflow.test.mjs
+++ b/scripts/tests/cut-release-tags-workflow.test.mjs
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+test("release tag cutter is explicit, immutable, and aligns root/MCP coordinates", async () => {
+  const workflow = await readFile(
+    path.join(ROOT_DIR, ".github", "workflows", "cut-release-tags.yml"),
+    "utf8"
+  );
+
+  assert.match(workflow, /branches:\s*[\s\S]*- main/);
+  assert.match(workflow, /contains\(github\.event\.head_commit\.message, '\[cut-release\]'\)/);
+  assert.match(workflow, /require\('\.\/package\.json'\)\.version/);
+  assert.match(workflow, /require\('\.\/packages\/mcp\/package\.json'\)\.version/);
+  assert.match(workflow, /require\('\.\/packages\/mcp\/server\.json'\)\.version/);
+  assert.match(workflow, /require\('\.\/packages\/mcp\/mcpb\/manifest\.json'\)\.version/);
+  assert.match(workflow, /OSS-\$\{ROOT_VERSION\}-RELEASE-NOTES\.md/);
+  assert.match(workflow, /MCP-\$\{MCP_VERSION\}-RELEASE-NOTES\.md/);
+  assert.match(workflow, /extract-changelog-entry\.mjs --version "\$ROOT_VERSION"/);
+  assert.match(workflow, /Refusing to move it/);
+  assert.match(workflow, /git tag -a "\$ROOT_TAG" "\$GITHUB_SHA"/);
+  assert.match(workflow, /git tag -a "\$MCP_TAG" "\$GITHUB_SHA"/);
+  assert.match(workflow, /git push origin "\$ROOT_TAG" "\$MCP_TAG"/);
+  assert.match(workflow, /\^\{commit\}/);
+
+  assert.doesNotMatch(workflow, /git tag -f/);
+  assert.doesNotMatch(workflow, /git push[^\n]*--force/);
+  assert.doesNotMatch(workflow, /secrets\./);
+});


### PR DESCRIPTION
## Summary
- add a guarded main-merge tag cutter behind an explicit `[cut-release]` marker
- validate root, MCP server, MCP package, MCPB and release-note coordinates before tagging
- refuse to move or overwrite existing release tags
- create both root and standalone MCP annotated tags at the exact merged commit
- leave the existing trusted-publishing workflows unchanged

## Why
This removes the manual tag step that caused release drift during 0.5.1/0.5.2 while preserving immutable release tags and existing publication guards.

## Release use
Merge only after hosted validation is green. For the 0.5.3 cut, merge with a commit title containing `[cut-release]` so both tags are created from the exact merge commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated release tagging for qualifying commits on the main branch.
  * Validates version alignment, release notes, manifest consistency, and existing tags before publishing.
  * Creates immutable annotated tags and verifies they reference the intended commit.
* **Tests**
  * Added coverage for release conditions, validation checks, commit verification, and safe non-forced tag publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->