### PR TITLE
fix(release): publish immutable 0.5.3 tags via explicit dispatch

### DIFF
--- a/.github/workflows/cut-release-tags.yml
+++ b/.github/workflows/cut-release-tags.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   cut-release-tags:
@@ -79,3 +80,65 @@ jobs:
           MCP_TAG="mcp-v${{ steps.versions.outputs.mcp_version }}"
           test "$(git rev-parse "${ROOT_TAG}^{commit}")" = "$GITHUB_SHA"
           test "$(git rev-parse "${MCP_TAG}^{commit}")" = "$GITHUB_SHA"
+
+      - name: Dispatch trusted publishers
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run release.yml --ref main -f tag="v${{ steps.versions.outputs.root_version }}"
+          gh workflow run publish-mcp.yml --ref main -f tag="mcp-v${{ steps.versions.outputs.mcp_version }}"
+
+  publish-existing-release-tags:
+    name: Publish existing immutable release tags
+    if: contains(github.event.head_commit.message, '[publish-existing-release]')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Resolve and verify existing release tags
+        id: existing
+        shell: bash
+        run: |
+          ROOT_VERSION="$(node -p "require('./package.json').version")"
+          MCP_VERSION="$(node -p "require('./packages/mcp/package.json').version")"
+          ROOT_TAG="v${ROOT_VERSION}"
+          MCP_TAG="mcp-v${MCP_VERSION}"
+
+          git fetch --tags --force
+          git rev-parse -q --verify "refs/tags/${ROOT_TAG}" >/dev/null
+          git rev-parse -q --verify "refs/tags/${MCP_TAG}" >/dev/null
+
+          ROOT_SHA="$(git rev-parse "${ROOT_TAG}^{commit}")"
+          MCP_SHA="$(git rev-parse "${MCP_TAG}^{commit}")"
+          if [ "$ROOT_SHA" != "$MCP_SHA" ]; then
+            echo "Root and MCP release tags do not resolve to the same commit: ${ROOT_SHA} != ${MCP_SHA}"
+            exit 1
+          fi
+
+          TAG_ROOT_VERSION="$(git show "${ROOT_TAG}:package.json" | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>process.stdout.write(JSON.parse(s).version))")"
+          TAG_MCP_VERSION="$(git show "${MCP_TAG}:packages/mcp/package.json" | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>process.stdout.write(JSON.parse(s).version))")"
+          TAG_MCP_SERVER_VERSION="$(git show "${MCP_TAG}:packages/mcp/server.json" | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>process.stdout.write(JSON.parse(s).version))")"
+          TAG_MCPB_VERSION="$(git show "${MCP_TAG}:packages/mcp/mcpb/manifest.json" | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>process.stdout.write(JSON.parse(s).version))")"
+
+          test "$TAG_ROOT_VERSION" = "$ROOT_VERSION"
+          test "$TAG_MCP_VERSION" = "$MCP_VERSION"
+          test "$TAG_MCP_SERVER_VERSION" = "$MCP_VERSION"
+          test "$TAG_MCPB_VERSION" = "$MCP_VERSION"
+          git cat-file -e "${ROOT_TAG}:docs/release/OSS-${ROOT_VERSION}-RELEASE-NOTES.md"
+          git cat-file -e "${MCP_TAG}:docs/release/MCP-${MCP_VERSION}-RELEASE-NOTES.md"
+
+          echo "root_tag=${ROOT_TAG}" >> "$GITHUB_OUTPUT"
+          echo "mcp_tag=${MCP_TAG}" >> "$GITHUB_OUTPUT"
+          echo "release_sha=${ROOT_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Dispatch trusted publishers for existing tags
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "Publishing immutable release commit ${{ steps.existing.outputs.release_sha }}"
+          gh workflow run release.yml --ref main -f tag="${{ steps.existing.outputs.root_tag }}"
+          gh workflow run publish-mcp.yml --ref main -f tag="${{ steps.existing.outputs.mcp_tag }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,12 @@
 name: Release
 
 on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing vX.Y.Z tag to publish
+        required: true
+        type: string
   push:
     tags:
       - "v*.*.*"
@@ -14,8 +20,27 @@ jobs:
     name: Publish to npm
     runs-on: ubuntu-latest
     steps:
+      - name: Resolve release coordinates
+        id: release-vars
+        shell: bash
+        env:
+          INPUT_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || '' }}
+        run: |
+          RELEASE_TAG="${INPUT_TAG:-$GITHUB_REF_NAME}"
+          if [[ -z "$RELEASE_TAG" ]]; then
+            echo "Missing release tag."
+            exit 1
+          fi
+          if [[ "$RELEASE_TAG" != v* ]]; then
+            echo "Expected a vX.Y.Z tag"
+            exit 1
+          fi
+          echo "tag=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
+          echo "version=${RELEASE_TAG#v}" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@v6
         with:
+          ref: ${{ steps.release-vars.outputs.tag }}
           fetch-depth: 0
 
       - uses: pnpm/action-setup@b0f76dfb45f55f8421693e4803ac7bb65143bd34
@@ -49,7 +74,7 @@ jobs:
           pnpm --filter @martinloop/mcp smoke:pack
           pnpm --filter @martinloop/mcp smoke:published:pack
           pnpm --filter @martinloop/mcp verify:release
-          node ./scripts/root-release-guard.mjs --tag "${GITHUB_REF_NAME}" --pack
+          node ./scripts/root-release-guard.mjs --tag "${{ steps.release-vars.outputs.tag }}" --pack
 
       - name: Build, validate, and smoke-test MCPB
         run: |
@@ -69,6 +94,10 @@ jobs:
         id: package-version
         run: |
           VERSION="$(node -p "require('./package.json').version")"
+          if [ "$VERSION" != "${{ steps.release-vars.outputs.version }}" ]; then
+            echo "Tag ${{ steps.release-vars.outputs.tag }} does not match package.json version ${VERSION}."
+            exit 1
+          fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Extract changelog entry
@@ -112,6 +141,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b
         with:
+          tag_name: ${{ steps.release-vars.outputs.tag }}
           files: |
             ${{ steps.root-pack.outputs.tarball }}
             packages/mcp/dist-mcpb/martinloop-*.mcpb

--- a/docs/release/0.5.3-PUBLICATION-RECOVERY.md
+++ b/docs/release/0.5.3-PUBLICATION-RECOVERY.md
@@ -1,0 +1,15 @@
+# MartinLoop 0.5.3 Publication Recovery
+
+The immutable `v0.5.3` and `mcp-v0.5.3` tags were cut from the same validated release commit.
+
+GitHub Actions does not recursively trigger tag-push publisher workflows when a tag is created by the repository `GITHUB_TOKEN`. The release orchestration therefore uses explicit `workflow_dispatch` after tag parity is verified.
+
+Recovery rules:
+
+- Never move or recreate the existing 0.5.3 tags.
+- Root and MCP tags must resolve to the same release commit.
+- Versions inside the tagged root package, MCP package, MCP server metadata, and MCPB manifest must match the release tags.
+- Publication must run from the immutable tags, not from the later orchestration-fix commit.
+- Root and MCP trusted-publishing workflows retain duplicate-publish protection and live-artifact verification.
+
+Future `[cut-release]` merges cut immutable tags and explicitly dispatch both trusted publishers after tag parity passes.

--- a/scripts/tests/cut-release-tags-workflow.test.mjs
+++ b/scripts/tests/cut-release-tags-workflow.test.mjs
@@ -6,14 +6,16 @@ import { fileURLToPath } from "node:url";
 
 const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 
-test("release tag cutter is explicit, immutable, and aligns root/MCP coordinates", async () => {
+test("release tag cutter is explicit, immutable, and dispatches trusted publishers", async () => {
   const workflow = await readFile(
     path.join(ROOT_DIR, ".github", "workflows", "cut-release-tags.yml"),
     "utf8"
   );
 
   assert.match(workflow, /branches:\s*[\s\S]*- main/);
+  assert.match(workflow, /permissions:\s*[\s\S]*contents:\s*write[\s\S]*actions:\s*write/);
   assert.match(workflow, /contains\(github\.event\.head_commit\.message, '\[cut-release\]'\)/);
+  assert.match(workflow, /contains\(github\.event\.head_commit\.message, '\[publish-existing-release\]'\)/);
   assert.match(workflow, /require\('\.\/package\.json'\)\.version/);
   assert.match(workflow, /require\('\.\/packages\/mcp\/package\.json'\)\.version/);
   assert.match(workflow, /require\('\.\/packages\/mcp\/server\.json'\)\.version/);
@@ -26,6 +28,12 @@ test("release tag cutter is explicit, immutable, and aligns root/MCP coordinates
   assert.match(workflow, /git tag -a "\$MCP_TAG" "\$GITHUB_SHA"/);
   assert.match(workflow, /git push origin "\$ROOT_TAG" "\$MCP_TAG"/);
   assert.match(workflow, /\^\{commit\}/);
+  assert.match(workflow, /Root and MCP release tags do not resolve to the same commit/);
+  assert.match(workflow, /git show "\$\{ROOT_TAG\}:package\.json"/);
+  assert.match(workflow, /git show "\$\{MCP_TAG\}:packages\/mcp\/package\.json"/);
+  assert.match(workflow, /gh workflow run release\.yml --ref main -f tag=/);
+  assert.match(workflow, /gh workflow run publish-mcp\.yml --ref main -f tag=/);
+  assert.match(workflow, /GH_TOKEN: \$\{\{ github\.token \}\}/);
 
   assert.doesNotMatch(workflow, /git tag -f/);
   assert.doesNotMatch(workflow, /git push[^\n]*--force/);

--- a/scripts/tests/root-release-workflow.test.mjs
+++ b/scripts/tests/root-release-workflow.test.mjs
@@ -6,11 +6,18 @@ import { fileURLToPath } from "node:url";
 
 const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 
-test("root release workflow uses GitHub Actions trusted publishing without npm tokens", async () => {
+test("root release workflow uses exact-tag trusted publishing without npm tokens", async () => {
   const workflowPath = path.join(ROOT_DIR, ".github", "workflows", "release.yml");
   const workflow = await readFile(workflowPath, "utf8");
 
+  assert.match(workflow, /workflow_dispatch:\s*[\s\S]*tag:\s*[\s\S]*Existing vX\.Y\.Z tag to publish/);
   assert.match(workflow, /push:\s*[\s\S]*tags:\s*[\s\S]*"v\*\.\*\.\*"/);
+  assert.match(workflow, /INPUT_TAG: \$\{\{ github\.event_name == 'workflow_dispatch' && inputs\.tag \|\| '' \}\}/);
+  assert.match(workflow, /RELEASE_TAG="\$\{INPUT_TAG:-\$GITHUB_REF_NAME\}"/);
+  assert.match(workflow, /ref: \$\{\{ steps\.release-vars\.outputs\.tag \}\}/);
+  assert.match(workflow, /root-release-guard\.mjs --tag "\$\{\{ steps\.release-vars\.outputs\.tag \}\}" --pack/);
+  assert.match(workflow, /tag_name: \$\{\{ steps\.release-vars\.outputs\.tag \}\}/);
+  assert.match(workflow, /Tag \$\{\{ steps\.release-vars\.outputs\.tag \}\} does not match package\.json version/);
   assert.match(workflow, /permissions:\s*[\s\S]*contents:\s*write/);
   assert.match(workflow, /permissions:\s*[\s\S]*id-token:\s*write/);
   assert.match(workflow, /node-version:\s*24/);


### PR DESCRIPTION
## Summary
- add exact-tag workflow_dispatch support to the root trusted publisher
- preserve the existing standalone MCP dispatch contract
- keep immutable release tags unchanged
- dispatch both trusted publishers after future tag cuts
- add a guarded recovery path for already-cut matching root/MCP tags
- add regression tests and a durable 0.5.3 publication-recovery note

## Recovery invariant
The existing `v0.5.3` and `mcp-v0.5.3` tags are never moved. Recovery verifies they resolve to the same release commit and that tagged root/MCP/MCPB versions match before dispatching publication.

## Merge condition
Merge only after hosted Windows, macOS, and Linux validation is green. Merge commit title must contain `[publish-existing-release]` so the already-cut immutable 0.5.3 tags are published from their original release SHA.