### PR TITLE
chore(release): prove and record live MartinLoop 0.5.3

### DIFF
--- a/.github/workflows/verify-live-release.yml
+++ b/.github/workflows/verify-live-release.yml
@@ -1,0 +1,31 @@
+name: verify-live-release
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/verify-live-release.mjs'
+      - '.github/workflows/verify-live-release.yml'
+      - 'distribution/release-truth.json'
+      - 'docs/release/VERSION-LEDGER.md'
+      - 'packages/mcp/server.json'
+      - 'packages/mcp/mcpb/manifest.json'
+      - 'packages/mcp/package.json'
+      - 'package.json'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify-live-release:
+    name: Verify live 0.5.3 publication
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - name: Verify npm, GitHub releases, MCPB, and MCP Registry
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node ./scripts/verify-live-release.mjs

--- a/distribution/release-truth.json
+++ b/distribution/release-truth.json
@@ -2,20 +2,28 @@
   "schemaVersion": 1,
   "cli": {
     "package": "martin-loop",
-    "version": "0.5.2",
-    "install": "npx -y martin-loop@latest"
+    "version": "0.5.3",
+    "install": "npx -y martin-loop@latest",
+    "releaseTag": "v0.5.3",
+    "releaseUrl": "https://github.com/Keesan12/martin-loop/releases/tag/v0.5.3"
   },
   "mcp": {
     "package": "@martinloop/mcp",
-    "version": "0.5.1",
+    "version": "0.5.3",
     "registryName": "io.github.Keesan12/martin-loop",
-    "install": "npx -y @martinloop/mcp"
+    "registryVersion": "0.5.3",
+    "install": "npx -y @martinloop/mcp",
+    "releaseTag": "mcp-v0.5.3",
+    "releaseUrl": "https://github.com/Keesan12/martin-loop/releases/tag/mcp-v0.5.3"
   },
   "mcpb": {
+    "version": "0.5.3",
+    "manifestSchema": "0.3",
     "built": true,
     "released": true,
-    "releaseUrl": "https://github.com/Keesan12/martin-loop/releases/download/v0.5.1/martinloop-0.5.1.mcpb",
-    "sha256": "987a0c72a0db8ab0c190caf61d592d4a7d126b3b3a711a937c75a4406a7c940d"
+    "releaseUrl": "https://github.com/Keesan12/martin-loop/releases/download/v0.5.3/martinloop-0.5.3.mcpb",
+    "sha256": "913e7a9707b82b66012214f2780b44d2cb6eaa6112a875a264f50bb52e9fb907",
+    "sizeBytes": 8102303
   },
   "repository": "https://github.com/Keesan12/martin-loop",
   "website": "https://martinloop.com"

--- a/docs/release/VERSION-LEDGER.md
+++ b/docs/release/VERSION-LEDGER.md
@@ -4,10 +4,10 @@ This file is the release source of truth for package/version mapping in this rep
 
 ## Root package: `martin-loop`
 
-- live npm dist-tag `latest`: `0.5.2`
-- live public GitHub release: `v0.5.2`
-- live public baseline in this train: `0.5.2`
-- root public baseline: `0.5.2`
+- live npm dist-tag `latest`: `0.5.3`
+- live public GitHub release: `v0.5.3`
+- live public baseline in this train: `0.5.3`
+- root public baseline: `0.5.3`
 - releases consumed since the original `0.2.8` launch:
   - `0.2.9` fixed proof-run classification, Windows `.cmd` resolution, and public provider defaults
   - `0.2.10` tightened verifier evidence, `--runs-dir` consistency, and public help output
@@ -36,28 +36,33 @@ This file is the release source of truth for package/version mapping in this rep
   - `0.5.0` fail-closed verification authority, workspace-bound evidence, native install, execution-surface hardening, and MCP lifecycle expansion
   - `0.5.1` Governed Run Plan, Verified Handoff, cost provenance, grounding truth, presentation hardening, and MCPB distribution
   - `0.5.2` aligned preflight readiness with the immediately following run admission gate
-- current in-repo root release target: `0.5.3` (pending publication)
+  - `0.5.3` added capability-driven Codex execution across host variants, aligned root/MCP/MCPB public versions, refreshed agent-discovery surfaces, and made release publication/registry handoff verifiable end to end
+- current in-repo root release target: `0.5.3` (released publicly)
 - next planned root follow-on: not scheduled
 
 ## Standalone package: `@martinloop/mcp`
 
-- live npm dist-tag `latest`: `0.5.1`
-- live public GitHub release: `mcp-v0.5.1`
-- live public baseline in this train: `0.5.1`
-- standalone MCP public baseline: `0.5.1`
-- current in-repo standalone release target: `0.5.3` (pending publication)
-- live MCPB baseline: `0.5.1`
-- current in-repo MCPB release target: `0.5.3` with manifest schema `0.3` (pending publication)
+- live npm dist-tag `latest`: `0.5.3`
+- live public GitHub release: `mcp-v0.5.3`
+- live public baseline in this train: `0.5.3`
+- standalone MCP public baseline: `0.5.3`
+- current in-repo standalone release target: `0.5.3` (released publicly)
+- official MCP Registry version: `0.5.3` (verified)
+- live MCPB baseline: `0.5.3`
+- current in-repo MCPB release target: `0.5.3` with manifest schema `0.3` (released publicly)
+- MCPB SHA-256: `913e7a9707b82b66012214f2780b44d2cb6eaa6112a875a264f50bb52e9fb907`
+- MCPB size: `8,102,303` bytes
 - next planned standalone release: not scheduled
 
 ## Release rules
 
 - Live public baselines describe artifacts that actually exist. In-repo targets may advance before publication and must remain clearly marked pending until trusted publishing succeeds.
-- The `0.5.3` train intends to align the root package, standalone MCP package, plugin metadata, and MCPB product version at `0.5.3`. MCPB manifest schema remains `0.3`.
+- The `0.5.3` train aligns the root package, standalone MCP package, plugin metadata, and MCPB product version at `0.5.3`. MCPB manifest schema remains `0.3`.
 - Do not infer standalone MCP release state from the root package, or the other way around.
 - Public release notes must be written for customers and evaluators, not for internal operators.
 - Public-facing examples, screenshots, README copy, and changelog entries must stay free of internal repo names, absolute system paths, private branch names, or process noise.
 - Publish only through GitHub Actions trusted publishing / OIDC.
+- A release is not complete until npm packages, GitHub releases, release assets, checksums, and applicable registry listings have been verified live.
 
 ## Validation baseline before any public prep branch
 

--- a/scripts/tests/mcp-release-docs.test.mjs
+++ b/scripts/tests/mcp-release-docs.test.mjs
@@ -26,26 +26,43 @@ test("current MCP metadata stays aligned for the release cut", async () => {
   await access(releaseNotesPath);
 });
 
-test("version ledger separates live public truth from pending release targets", async () => {
+test("version ledger distinguishes pending targets from artifacts proven live", async () => {
   const ledger = await readRepoFile(path.join("docs", "release", "VERSION-LEDGER.md"));
+  const [rootSection, standaloneSection = ""] = ledger.split("## Standalone package: `@martinloop/mcp`");
 
-  assert.match(ledger, /root public baseline: `\d+\.\d+\.\d+`/);
-  assert.match(ledger, /live public GitHub release: `v\d+\.\d+\.\d+`/);
-  assert.match(ledger, /standalone MCP public baseline: `\d+\.\d+\.\d+`/);
-  assert.match(ledger, /live MCPB baseline: `\d+\.\d+\.\d+`/);
+  assert.match(rootSection, /root public baseline: `\d+\.\d+\.\d+`/);
+  assert.match(rootSection, /live public GitHub release: `v\d+\.\d+\.\d+`/);
+  assert.match(standaloneSection, /standalone MCP public baseline: `\d+\.\d+\.\d+`/);
+  assert.match(standaloneSection, /live MCPB baseline: `\d+\.\d+\.\d+`/);
+
+  const rootIsLive = rootSection.includes(`live npm dist-tag \`latest\`: \`${rootPackageJson.version}\``)
+    && rootSection.includes(`live public GitHub release: \`v${rootPackageJson.version}\``);
+  const mcpIsLive = standaloneSection.includes(`live npm dist-tag \`latest\`: \`${packageJson.version}\``)
+    && standaloneSection.includes(`live public GitHub release: \`mcp-v${packageJson.version}\``);
+
   assert.match(
-    ledger,
-    new RegExp(escapeRegex(`current in-repo standalone release target: \`${packageJson.version}\``))
+    rootSection,
+    new RegExp(escapeRegex(
+      `current in-repo root release target: \`${rootPackageJson.version}\` (${rootIsLive ? "released publicly" : "pending publication"})`
+    ))
   );
   assert.match(
-    ledger,
-    new RegExp(escapeRegex(`current in-repo root release target: \`${rootPackageJson.version}\``))
+    standaloneSection,
+    new RegExp(escapeRegex(
+      `current in-repo standalone release target: \`${packageJson.version}\` (${mcpIsLive ? "released publicly" : "pending publication"})`
+    ))
   );
   assert.match(
-    ledger,
-    new RegExp(escapeRegex(`current in-repo MCPB release target: \`${packageJson.version}\``))
+    standaloneSection,
+    new RegExp(escapeRegex(
+      `current in-repo MCPB release target: \`${packageJson.version}\` with manifest schema \`0.3\` (${mcpIsLive ? "released publicly" : "pending publication"})`
+    ))
   );
-  assert.match(ledger, /pending publication/i);
+
+  if (mcpIsLive) {
+    assert.match(standaloneSection, new RegExp(escapeRegex(`official MCP Registry version: \`${packageJson.version}\` (verified)`)));
+  }
+
   assert.match(ledger, /next planned root follow-on: not scheduled/);
   assert.match(ledger, /next planned standalone release: not scheduled/);
 });

--- a/scripts/verify-live-release.mjs
+++ b/scripts/verify-live-release.mjs
@@ -20,14 +20,32 @@ assert.equal(server.version, mcpVersion, "MCP server version must match package 
 assert.equal(mcpb.version, mcpVersion, "MCPB product version must match MCP package version");
 assert.equal(mcpb.manifest_version, "0.3", "MCPB manifest schema must remain 0.3");
 
-const headers = {
-  Accept: "application/vnd.github+json",
-  "User-Agent": "martinloop-live-release-verifier",
-  ...(githubToken ? { Authorization: `Bearer ${githubToken}` } : {}),
-};
+function headersFor(url) {
+  const parsed = new URL(url);
+  const base = {
+    "User-Agent": "martinloop-live-release-verifier",
+  };
 
-async function getJson(url, label, extraHeaders = {}) {
-  const response = await fetch(url, { headers: { ...headers, ...extraHeaders } });
+  if (parsed.hostname === "api.github.com") {
+    return {
+      ...base,
+      Accept: "application/vnd.github+json",
+      ...(githubToken ? { Authorization: `Bearer ${githubToken}` } : {}),
+    };
+  }
+
+  if (parsed.hostname === "registry.npmjs.org" || parsed.hostname === "registry.modelcontextprotocol.io") {
+    return {
+      ...base,
+      Accept: "application/json",
+    };
+  }
+
+  return base;
+}
+
+async function getJson(url, label) {
+  const response = await fetch(url, { headers: headersFor(url) });
   const text = await response.text();
   if (!response.ok) {
     throw new Error(`${label} failed: HTTP ${response.status}\n${text.slice(0, 1000)}`);
@@ -36,7 +54,7 @@ async function getJson(url, label, extraHeaders = {}) {
 }
 
 async function getText(url, label) {
-  const response = await fetch(url, { headers });
+  const response = await fetch(url, { headers: headersFor(url), redirect: "follow" });
   const text = await response.text();
   if (!response.ok) {
     throw new Error(`${label} failed: HTTP ${response.status}\n${text.slice(0, 1000)}`);
@@ -45,7 +63,7 @@ async function getText(url, label) {
 }
 
 async function getBytes(url, label) {
-  const response = await fetch(url, { headers });
+  const response = await fetch(url, { headers: headersFor(url), redirect: "follow" });
   const bytes = Buffer.from(await response.arrayBuffer());
   if (!response.ok) {
     throw new Error(`${label} failed: HTTP ${response.status}\n${bytes.toString("utf8", 0, Math.min(bytes.length, 1000))}`);

--- a/scripts/verify-live-release.mjs
+++ b/scripts/verify-live-release.mjs
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+
+const repo = process.env.GITHUB_REPOSITORY ?? "Keesan12/martin-loop";
+const githubToken = process.env.GITHUB_TOKEN ?? "";
+const root = JSON.parse(await readFile(new URL("../package.json", import.meta.url), "utf8"));
+const mcp = JSON.parse(await readFile(new URL("../packages/mcp/package.json", import.meta.url), "utf8"));
+const server = JSON.parse(await readFile(new URL("../packages/mcp/server.json", import.meta.url), "utf8"));
+const mcpb = JSON.parse(await readFile(new URL("../packages/mcp/mcpb/manifest.json", import.meta.url), "utf8"));
+
+const rootVersion = root.version;
+const mcpVersion = mcp.version;
+const rootTag = `v${rootVersion}`;
+const mcpTag = `mcp-v${mcpVersion}`;
+
+assert.equal(rootVersion, "0.5.3", "this release proof is pinned to MartinLoop 0.5.3");
+assert.equal(mcpVersion, "0.5.3", "this release proof is pinned to @martinloop/mcp 0.5.3");
+assert.equal(server.version, mcpVersion, "MCP server version must match package version");
+assert.equal(mcpb.version, mcpVersion, "MCPB product version must match MCP package version");
+assert.equal(mcpb.manifest_version, "0.3", "MCPB manifest schema must remain 0.3");
+
+const headers = {
+  Accept: "application/vnd.github+json",
+  "User-Agent": "martinloop-live-release-verifier",
+  ...(githubToken ? { Authorization: `Bearer ${githubToken}` } : {}),
+};
+
+async function getJson(url, label, extraHeaders = {}) {
+  const response = await fetch(url, { headers: { ...headers, ...extraHeaders } });
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(`${label} failed: HTTP ${response.status}\n${text.slice(0, 1000)}`);
+  }
+  return JSON.parse(text);
+}
+
+async function getText(url, label) {
+  const response = await fetch(url, { headers });
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(`${label} failed: HTTP ${response.status}\n${text.slice(0, 1000)}`);
+  }
+  return text;
+}
+
+async function getBytes(url, label) {
+  const response = await fetch(url, { headers });
+  const bytes = Buffer.from(await response.arrayBuffer());
+  if (!response.ok) {
+    throw new Error(`${label} failed: HTTP ${response.status}\n${bytes.toString("utf8", 0, Math.min(bytes.length, 1000))}`);
+  }
+  return bytes;
+}
+
+const rootNpm = await getJson(`https://registry.npmjs.org/martin-loop/${rootVersion}`, "root npm version");
+assert.equal(rootNpm.name, "martin-loop");
+assert.equal(rootNpm.version, rootVersion);
+
+const rootNpmIndex = await getJson("https://registry.npmjs.org/martin-loop", "root npm index");
+assert.equal(rootNpmIndex["dist-tags"]?.latest, rootVersion, "martin-loop latest must be 0.5.3");
+
+const mcpNpm = await getJson(`https://registry.npmjs.org/%40martinloop%2Fmcp/${mcpVersion}`, "MCP npm version");
+assert.equal(mcpNpm.name, "@martinloop/mcp");
+assert.equal(mcpNpm.version, mcpVersion);
+
+const mcpNpmIndex = await getJson("https://registry.npmjs.org/%40martinloop%2Fmcp", "MCP npm index");
+assert.equal(mcpNpmIndex["dist-tags"]?.latest, mcpVersion, "@martinloop/mcp latest must be 0.5.3");
+
+const [owner, repoName] = repo.split("/");
+const releaseBase = `https://api.github.com/repos/${owner}/${repoName}/releases/tags`;
+const rootRelease = await getJson(`${releaseBase}/${rootTag}`, "root GitHub release");
+assert.equal(rootRelease.tag_name, rootTag);
+assert.equal(rootRelease.draft, false);
+assert.equal(rootRelease.prerelease, false);
+
+const mcpRelease = await getJson(`${releaseBase}/${mcpTag}`, "MCP GitHub release");
+assert.equal(mcpRelease.tag_name, mcpTag);
+assert.equal(mcpRelease.draft, false);
+assert.equal(mcpRelease.prerelease, false);
+
+const expectedMcpb = `martinloop-${mcpVersion}.mcpb`;
+const expectedChecksum = `${expectedMcpb}.sha256`;
+const expectedRootTarball = `martin-loop-${rootVersion}.tgz`;
+const rootAssets = new Map(rootRelease.assets.map((asset) => [asset.name, asset]));
+
+assert.ok(rootAssets.has(expectedRootTarball), `root release must include ${expectedRootTarball}`);
+assert.ok(rootAssets.has(expectedMcpb), `root release must include ${expectedMcpb}`);
+assert.ok(rootAssets.has(expectedChecksum), `root release must include ${expectedChecksum}`);
+
+const mcpbAsset = rootAssets.get(expectedMcpb);
+const checksumAsset = rootAssets.get(expectedChecksum);
+const checksumText = await getText(checksumAsset.browser_download_url, "MCPB checksum asset");
+const expectedSha = checksumText.trim().split(/\s+/)[0]?.toLowerCase();
+assert.match(expectedSha ?? "", /^[a-f0-9]{64}$/, "MCPB checksum asset must contain a SHA-256 digest");
+
+const mcpbBytes = await getBytes(mcpbAsset.browser_download_url, "MCPB release asset");
+const actualSha = createHash("sha256").update(mcpbBytes).digest("hex");
+assert.equal(actualSha, expectedSha, "MCPB asset must match its published SHA-256 checksum");
+
+const encodedServer = encodeURIComponent(server.name);
+const registryUrl = `https://registry.modelcontextprotocol.io/v0.1/servers/${encodedServer}/versions/${mcpVersion}`;
+const registry = await getJson(registryUrl, "official MCP Registry listing");
+
+console.log(JSON.stringify({
+  verified: true,
+  root: {
+    package: root.name,
+    version: rootVersion,
+    latest: rootNpmIndex["dist-tags"].latest,
+    tag: rootTag,
+    releaseUrl: rootRelease.html_url,
+    tarball: expectedRootTarball,
+  },
+  mcp: {
+    package: mcp.name,
+    version: mcpVersion,
+    latest: mcpNpmIndex["dist-tags"].latest,
+    tag: mcpTag,
+    releaseUrl: mcpRelease.html_url,
+    registryName: server.name,
+    registryVersion: registry.version ?? mcpVersion,
+  },
+  mcpb: {
+    version: mcpVersion,
+    manifestSchema: mcpb.manifest_version,
+    asset: expectedMcpb,
+    releaseUrl: mcpbAsset.browser_download_url,
+    sha256: actualSha,
+    size: mcpbBytes.length,
+  },
+}, null, 2));

--- a/scripts/verify-live-release.mjs
+++ b/scripts/verify-live-release.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
+import { setTimeout as delay } from "node:timers/promises";
 
 const repo = process.env.GITHUB_REPOSITORY ?? "Keesan12/martin-loop";
 const githubToken = process.env.GITHUB_TOKEN ?? "";
@@ -22,9 +23,7 @@ assert.equal(mcpb.manifest_version, "0.3", "MCPB manifest schema must remain 0.3
 
 function headersFor(url) {
   const parsed = new URL(url);
-  const base = {
-    "User-Agent": "martinloop-live-release-verifier",
-  };
+  const base = { "User-Agent": "martinloop-live-release-verifier" };
 
   if (parsed.hostname === "api.github.com") {
     return {
@@ -35,27 +34,41 @@ function headersFor(url) {
   }
 
   if (parsed.hostname === "registry.npmjs.org" || parsed.hostname === "registry.modelcontextprotocol.io") {
-    return {
-      ...base,
-      Accept: "application/json",
-    };
+    return { ...base, Accept: "application/json" };
   }
 
   return base;
 }
 
+async function fetchText(url) {
+  const response = await fetch(url, { headers: headersFor(url), redirect: "follow" });
+  return { response, text: await response.text() };
+}
+
 async function getJson(url, label) {
-  const response = await fetch(url, { headers: headersFor(url) });
-  const text = await response.text();
+  const { response, text } = await fetchText(url);
   if (!response.ok) {
     throw new Error(`${label} failed: HTTP ${response.status}\n${text.slice(0, 1000)}`);
   }
   return JSON.parse(text);
 }
 
+async function getJsonWith404Retries(url, label, attempts = 8) {
+  let lastStatus = 0;
+  let lastText = "";
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const { response, text } = await fetchText(url);
+    if (response.ok) return JSON.parse(text);
+    lastStatus = response.status;
+    lastText = text;
+    if (response.status !== 404 || attempt === attempts) break;
+    await delay(attempt * 5000);
+  }
+  throw new Error(`${label} failed after bounded retries: HTTP ${lastStatus}\n${lastText.slice(0, 1000)}`);
+}
+
 async function getText(url, label) {
-  const response = await fetch(url, { headers: headersFor(url), redirect: "follow" });
-  const text = await response.text();
+  const { response, text } = await fetchText(url);
   if (!response.ok) {
     throw new Error(`${label} failed: HTTP ${response.status}\n${text.slice(0, 1000)}`);
   }
@@ -118,7 +131,7 @@ assert.equal(actualSha, expectedSha, "MCPB asset must match its published SHA-25
 
 const encodedServer = encodeURIComponent(server.name);
 const registryUrl = `https://registry.modelcontextprotocol.io/v0.1/servers/${encodedServer}/versions/${mcpVersion}`;
-const registry = await getJson(registryUrl, "official MCP Registry listing");
+const registry = await getJsonWith404Retries(registryUrl, "official MCP Registry listing");
 
 console.log(JSON.stringify({
   verified: true,
@@ -137,7 +150,7 @@ console.log(JSON.stringify({
     tag: mcpTag,
     releaseUrl: mcpRelease.html_url,
     registryName: server.name,
-    registryVersion: registry.version ?? mcpVersion,
+    registryVerified: Boolean(registry),
   },
   mcpb: {
     version: mcpVersion,


### PR DESCRIPTION
## Live 0.5.3 proof
Hosted verification is green for the full public release boundary:
- `martin-loop@0.5.3` exists and is npm `latest`
- `@martinloop/mcp@0.5.3` exists and is npm `latest`
- `v0.5.3` GitHub release exists
- `mcp-v0.5.3` GitHub release exists
- root release contains the root tarball, MCPB, and checksum
- downloaded MCPB matches its published SHA-256
- official MCP Registry lists 0.5.3

## Recorded artifact
- MCPB: `martinloop-0.5.3.mcpb`
- SHA-256: `913e7a9707b82b66012214f2780b44d2cb6eaa6112a875a264f50bb52e9fb907`
- size: `8,102,303` bytes
- manifest schema: `0.3`

## Durable closure
- add a hosted live-publication verifier
- update machine-readable release truth from stale 0.5.2/0.5.1 values to proven 0.5.3 values
- close the version ledger as released and registry-verified

No product/runtime behavior changes and no release tags are moved.