### PR TITLE
fix(release): register published MCP releases automatically

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -14,6 +14,7 @@ on:
 permissions:
   contents: write
   id-token: write
+  actions: write
 
 jobs:
   publish-mcp:
@@ -156,3 +157,10 @@ jobs:
           tag_name: ${{ steps.release-vars.outputs.tag }}
           name: "@martinloop/mcp ${{ steps.mcp-metadata.outputs.package_version }}"
           body_path: "docs/release/MCP-${{ steps.mcp-metadata.outputs.package_version }}-RELEASE-NOTES.md"
+
+      - name: Register published MCP release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.release-vars.outputs.tag }}
+        run: gh workflow run register-current-mcp.yml --ref main -f tag="$RELEASE_TAG"

--- a/.github/workflows/register-current-mcp.yml
+++ b/.github/workflows/register-current-mcp.yml
@@ -2,6 +2,11 @@ name: register-current-mcp
 
 on:
   workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing mcp-vX.Y.Z tag to register
+        required: true
+        type: string
   push:
     branches:
       - main
@@ -17,12 +22,35 @@ jobs:
     name: Register current @martinloop/mcp release
     runs-on: ubuntu-latest
     steps:
+      - name: Resolve release ref
+        id: release-ref
+        shell: bash
+        env:
+          INPUT_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || '' }}
+        run: |
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            if [[ "$INPUT_TAG" != mcp-v* ]]; then
+              echo "Expected an mcp-vX.Y.Z tag."
+              exit 1
+            fi
+            echo "ref=${INPUT_TAG}" >> "$GITHUB_OUTPUT"
+            echo "tag=${INPUT_TAG}" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+            echo "tag=" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Check out repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.release-ref.outputs.ref }}
+          fetch-depth: 0
 
       - name: Validate MCP metadata parity
         id: mcp-metadata
         shell: bash
+        env:
+          RELEASE_TAG: ${{ steps.release-ref.outputs.tag }}
         run: |
           node <<'NODE' >> "$GITHUB_OUTPUT"
           const fs = require('node:fs');
@@ -42,6 +70,14 @@ jobs:
           console.log(`version=${pkg.version}`);
           console.log(`server_name=${server.name}`);
           NODE
+
+          if [ -n "$RELEASE_TAG" ]; then
+            TAG_VERSION="${RELEASE_TAG#mcp-v}"
+            if [ "$TAG_VERSION" = "$RELEASE_TAG" ] || [ "$TAG_VERSION" != "$(node -p "require('./packages/mcp/package.json').version")" ]; then
+              echo "Release tag ${RELEASE_TAG} does not match the checked-out MCP package version."
+              exit 1
+            fi
+          fi
 
       - name: Verify npm artifact exists
         shell: bash

--- a/scripts/tests/publish-mcp-workflow.test.mjs
+++ b/scripts/tests/publish-mcp-workflow.test.mjs
@@ -32,7 +32,7 @@ test("publish-mcp workflow enforces mcp tag parity against package and server me
   assert.match(workflow, /does not match server\.json version/);
 });
 
-test("publish-mcp workflow covers trusted publishing, local-pack proof, and published smoke", async () => {
+test("publish-mcp workflow covers trusted publishing, published smoke, and registry handoff", async () => {
   const workflowPath = path.join(ROOT_DIR, ".github", "workflows", "publish-mcp.yml");
   const workflow = await readFile(workflowPath, "utf8");
 
@@ -40,6 +40,7 @@ test("publish-mcp workflow covers trusted publishing, local-pack proof, and publ
   assert.match(workflow, /inputs:\s*[\s\S]*tag:/);
   assert.match(workflow, /permissions:\s*[\s\S]*id-token:\s*write/);
   assert.match(workflow, /permissions:\s*[\s\S]*contents:\s*write/);
+  assert.match(workflow, /permissions:\s*[\s\S]*actions:\s*write/);
   assert.match(workflow, /pnpm install --frozen-lockfile/);
   assert.match(workflow, /pnpm --filter @martinloop\/mcp lint/);
   assert.match(workflow, /pnpm --filter @martinloop\/mcp test/);
@@ -56,6 +57,9 @@ test("publish-mcp workflow covers trusted publishing, local-pack proof, and publ
   assert.match(workflow, /softprops\/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b/);
   assert.match(workflow, /name:\s*"@martinloop\/mcp/);
   assert.match(workflow, /body_path:\s*"docs\/release\/MCP-\$\{\{\s*steps\.mcp-metadata\.outputs\.package_version\s*\}\}-RELEASE-NOTES\.md"/);
+  assert.match(workflow, /Register published MCP release/);
+  assert.match(workflow, /gh workflow run register-current-mcp\.yml --ref main -f tag="\$RELEASE_TAG"/);
+  assert.match(workflow, /RELEASE_TAG:\s*\$\{\{ steps\.release-vars\.outputs\.tag \}\}/);
   assert.doesNotMatch(workflow, /registry-url/);
   assert.doesNotMatch(workflow, /NODE_AUTH_TOKEN/);
   assert.doesNotMatch(workflow, /NPM_TOKEN/);

--- a/scripts/tests/register-current-mcp-workflow.test.mjs
+++ b/scripts/tests/register-current-mcp-workflow.test.mjs
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+test("MCP registry workflow registers the exact immutable release tag with OIDC", async () => {
+  const workflowPath = path.join(ROOT_DIR, ".github", "workflows", "register-current-mcp.yml");
+  const workflow = await readFile(workflowPath, "utf8");
+
+  assert.match(workflow, /workflow_dispatch:\s*[\s\S]*inputs:\s*[\s\S]*tag:/);
+  assert.match(workflow, /Expected an mcp-vX\.Y\.Z tag/);
+  assert.match(workflow, /ref:\s*\$\{\{ steps\.release-ref\.outputs\.ref \}\}/);
+  assert.match(workflow, /fetch-depth:\s*0/);
+  assert.match(workflow, /TAG_VERSION="\$\{RELEASE_TAG#mcp-v\}"/);
+  assert.match(workflow, /does not match the checked-out MCP package version/);
+  assert.match(workflow, /permissions:\s*[\s\S]*contents:\s*read/);
+  assert.match(workflow, /permissions:\s*[\s\S]*id-token:\s*write/);
+  assert.match(workflow, /npm view "\$\{\{ steps\.mcp-metadata\.outputs\.package_name \}\}@\$\{\{ steps\.mcp-metadata\.outputs\.version \}\}" version/);
+  assert.match(workflow, /mcp-publisher login github-oidc/);
+  assert.match(workflow, /mcp-publisher publish/);
+  assert.match(workflow, /Verify official MCP Registry listing/);
+  assert.match(workflow, /registry\.modelcontextprotocol\.io/);
+  assert.doesNotMatch(workflow, /NODE_AUTH_TOKEN/);
+  assert.doesNotMatch(workflow, /NPM_TOKEN/);
+  assert.doesNotMatch(workflow, /secrets\./);
+});


### PR DESCRIPTION
## Summary
- make MCP publication hand off to official MCP Registry registration only after npm verification and GitHub release creation
- make registry registration consume the exact immutable `mcp-vX.Y.Z` tag
- preserve GitHub OIDC registry authentication
- add regression coverage for the publisher-to-registry handoff and exact-tag registration

## Current 0.5.3 blocker
Hosted live verification confirmed root npm, MCP npm, both GitHub releases, the root tarball, MCPB asset, and MCPB checksum. The official MCP Registry alone returned 404 for 0.5.3.

## Merge behavior
Because `register-current-mcp.yml` itself changes, merging this PR also triggers the existing main-path registration workflow for the current 0.5.3 metadata. Future MCP releases dispatch the registry workflow from the exact immutable MCP tag after publication succeeds.