### PR TITLE
ci: build MCP shared types before publish lint

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -66,6 +66,8 @@ jobs:
 
       - name: Verify MCP package
         run: |
+          pnpm --filter @martin/contracts build
+          pnpm --filter @martin/presentation build
           pnpm --filter @martinloop/mcp lint
           pnpm --filter @martinloop/mcp test
           pnpm --filter @martinloop/mcp build


### PR DESCRIPTION
Builds the shared contracts and presentation type artifacts before the standalone MCP publish lint. This preserves the existing immutable 0.5.5 tags and unblocks the documented existing-tag publisher recovery path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved MCP package verification by building required supporting packages before validation, linting, testing, and smoke checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->