### PR TITLE
test: canonicalize packed MCP smoke workspace

### DIFF
--- a/packages/mcp/scripts/smoke-package.mjs
+++ b/packages/mcp/scripts/smoke-package.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { spawn } from "node:child_process";
-import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, realpath, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -29,6 +29,10 @@ const REQUIRED_TOOLS = [
   "martin_run_dossier",
 ];
 export const PUBLISHED_PACKAGE_SPEC = "@martinloop/mcp";
+
+export async function resolveSmokeWorkspaceRoot(tempRoot) {
+  return realpath(tempRoot);
+}
 const REQUIRED_TARBALL_FILES = [
   "README.md",
   "dist/server.d.ts",
@@ -72,6 +76,7 @@ const SMOKE_LOOP_RECORD = {
 export async function runStandaloneMcpSmoke(options = {}) {
   const packageDir = path.resolve(options.packageDir ?? fileURLToPath(new URL("..", import.meta.url)));
   const tempRoot = await mkdtemp(path.join(os.tmpdir(), "martin-mcp-smoke-"));
+  const workspaceRoot = await resolveSmokeWorkspaceRoot(tempRoot);
   const packDir = path.join(tempRoot, "pack");
   const installRoot = path.join(tempRoot, "install");
   const npmCacheDir = path.join(tempRoot, ".npm-cache");
@@ -121,7 +126,7 @@ export async function runStandaloneMcpSmoke(options = {}) {
     transport = new StdioClientTransport({
       command: launch.command,
       args: launch.args,
-      cwd: tempRoot,
+      cwd: workspaceRoot,
       env: {
         ...sanitizePackageManagerEnv(process.env),
         MARTIN_LIVE: "false",
@@ -165,7 +170,7 @@ export async function runStandaloneMcpSmoke(options = {}) {
       name: "martin_preflight",
       arguments: {
         objective: "Verify packaged MCP human proof surface",
-        workingDirectory: tempRoot,
+        workingDirectory: workspaceRoot,
         engine: "codex",
         verificationPlan: ["node --version"],
         maxUsd: 1,
@@ -173,6 +178,9 @@ export async function runStandaloneMcpSmoke(options = {}) {
       },
     });
     const preflightPayload = readStructuredContent(preflightResult, "martin_preflight");
+    if (preflightPayload.receiptScope?.workingDirectory !== workspaceRoot) {
+      throw new Error("Packaged martin_preflight did not preserve the canonical workspace root.");
+    }
     const preflightPresentation = assertHumanFirstCompatibilityResponse(
       preflightResult,
       "martin_preflight",

--- a/scripts/tests/mcp-smoke-portability.test.mjs
+++ b/scripts/tests/mcp-smoke-portability.test.mjs
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: MartinLoop contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from "node:assert/strict";
+import { mkdtemp, realpath, rm, symlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { resolveSmokeWorkspaceRoot } from "../../packages/mcp/scripts/smoke-package.mjs";
+
+test("packed MCP smoke canonicalizes temporary workspace aliases", async () => {
+  const fixtureRoot = await mkdtemp(path.join(tmpdir(), "martin-mcp-canonical-"));
+  const target = path.join(fixtureRoot, "target");
+  const alias = path.join(fixtureRoot, "alias");
+
+  try {
+    await symlink(fixtureRoot, target, process.platform === "win32" ? "junction" : "dir");
+    await symlink(target, alias, process.platform === "win32" ? "junction" : "dir");
+    assert.equal(await resolveSmokeWorkspaceRoot(alias), await realpath(fixtureRoot));
+  } finally {
+    await rm(fixtureRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- canonicalize the packed MCP smoke workspace before launching the server
- use one canonical workspace value for process cwd, requests, and assertions
- add a focused regression for temporary-directory aliases

## Validation

- pnpm --filter @martinloop/mcp smoke:pack
- 
ode --test scripts/tests/mcp-smoke-portability.test.mjs
- git diff --check

Production workspace-boundary behavior is unchanged.