### PR TITLE
test: exercise current public promotion guard

### DIFF
--- a/.martin/promotion-manifest.json
+++ b/.martin/promotion-manifest.json
@@ -3,7 +3,7 @@
   "privateRepository": "martin-Loop/ML_Core_OSS_Internal",
   "privateMergeSha": "c0c5b618a30dd453c6955966a88aa9c3e8c26db2",
   "privateMainShaValidated": "c0c5b618a30dd453c6955966a88aa9c3e8c26db2",
-  "publicBaseSha": "1560565ab23239a0fbde2f48c58a9db445c6d43b",
+  "publicBaseSha": "988469fe7f2194dc4484abc28bcf1ffcda91eddf",
   "internalHealthPassed": true,
-  "validatedAt": "2026-08-29T18:23:16.000Z"
+  "validatedAt": "2026-08-30T15:23:00.000Z"
 }


### PR DESCRIPTION
Runtime-only closeout probe for the 0.5.7 E2E audit.

Observed result: **PASS**. `Public Promotion Guard` run 33319437069 executed `verify-public-promotion`; conflict-marker rejection and promotion-manifest verification both completed successfully. The non-promotion lane was skipped as intended.

Closed without merge. No product code change was intended.