### PR TITLE
Fix grounding for allowed new artifacts

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1808,7 +1808,7 @@ export async function runMartin(input: RunMartinInput): Promise<RunMartinResult>
     // VERIFY: Run grounding scan on patch diff if available
     // Uses the task's repoRoot to build/load the grounding index, then scans any diff
     let groundingScanResult: GroundingScanResult | undefined;
-    const patchDiff = buildPatchDiff(result, changedFiles);
+    const patchDiff = buildPatchDiff(result, changedFiles, input.task.repoRoot);
     if (patchDiff && input.task.repoRoot) {
       try {
         const groundingIndex = await loadOrBuildRepoGroundingIndex(input.task.repoRoot);
@@ -2360,20 +2360,43 @@ function resolveChangedFiles(
   return listAttemptChangedFilesSinceBoundary({ repoRoot, boundary: rollbackBoundary });
 }
 
-function buildPatchDiff(result: MartinAdapterResult, changedFiles: string[]): string | undefined {
+function buildPatchDiff(
+  result: MartinAdapterResult,
+  changedFiles: string[],
+  repoRoot?: string
+): string | undefined {
   // Use structured diff stats to build a minimal diff header if no raw diff is available
-  if (result.execution?.changedFiles?.length) {
-    // Build a synthetic diff header from changed file list
-    return result.execution.changedFiles
-      .map((file) => `--- a/${file}\n+++ b/${file}\n@@ -0,0 +1 @@\n+`)
-      .join("\n");
-  }
-  if (changedFiles.length > 0) {
-    return changedFiles
-      .map((file) => `--- a/${file}\n+++ b/${file}\n@@ -0,0 +1 @@\n+`)
+  const files = result.execution?.changedFiles?.length ? result.execution.changedFiles : changedFiles;
+  if (files.length > 0) {
+    return files
+      .map((file) => buildSyntheticDiffHeader(file, repoRoot))
       .join("\n");
   }
   return undefined;
+}
+
+function buildSyntheticDiffHeader(file: string, repoRoot?: string): string {
+  const normalizedFile = file.replace(/\\/gu, "/");
+  const isNewWorkspaceFile = repoRoot ? isUntrackedWorkspaceFile(repoRoot, normalizedFile) : false;
+  const before = isNewWorkspaceFile ? "/dev/null" : `a/${normalizedFile}`;
+
+  return `--- ${before}\n+++ b/${normalizedFile}\n@@ -0,0 +1 @@\n+`;
+}
+
+function isUntrackedWorkspaceFile(repoRoot: string, file: string): boolean {
+  const result = spawnSync("git", ["ls-files", "--others", "--exclude-standard", "--", file], {
+    cwd: repoRoot,
+    encoding: "utf8"
+  });
+
+  if (result.status !== 0 || typeof result.stdout !== "string") {
+    return false;
+  }
+
+  return result.stdout
+    .split(/\r?\n/u)
+    .map((line) => line.trim().replace(/\\/gu, "/"))
+    .includes(file);
 }
 
 function createBudgetSettlement(input: {

--- a/packages/core/tests/runtime.test.ts
+++ b/packages/core/tests/runtime.test.ts
@@ -1958,6 +1958,110 @@ const store: import("../src/index").RunStore = {
     expect(patchScore.reasonCodes).toContain("verifier_passed");
   });
 
+  it("keeps an allowed verifier-passing artifact created during the attempt", async () => {
+    const runsRoot = await mkdtemp(join(tmpdir(), "martin-patch-new-artifact-"));
+    const repoRoot = join(runsRoot, "repo");
+    await mkdir(repoRoot, { recursive: true });
+    initializeGitRepo(repoRoot);
+    const store = createFileRunStore({ runsRoot });
+
+    const adapter: MartinAdapter = {
+      adapterId: "direct:patch-new-artifact",
+      kind: "direct-provider",
+      label: "Patch new artifact adapter",
+      metadata: {
+        providerId: "openai",
+        model: "gpt-5-mini"
+      },
+      async execute(request) {
+        await writeFile(join(repoRoot, "RESULT.txt"), "MARTINLOOP_057_FINAL_E2E_OK\n", "utf8");
+        return {
+          status: "completed",
+          summary: "Created the requested result artifact and passed verification.",
+          usage: {
+            actualUsd: 0.18,
+            tokensIn: 75,
+            tokensOut: 32
+          },
+          verification: {
+            passed: true,
+            summary: "node verify.mjs passed",
+            binding: {
+              runId: request.loopId,
+              workspaceId: request.workspaceId,
+              cwd: request.context.repoRoot ?? process.cwd(),
+              commands: request.context.verificationPlan,
+            },
+            steps: request.context.verificationPlan.map((command) => ({
+              command,
+              launched: true,
+              completed: true,
+              crashed: false,
+              exitCode: 0,
+              timedOut: false
+            })),
+          },
+          execution: {
+            changedFiles: ["RESULT.txt"],
+            diffStats: {
+              filesChanged: 1,
+              addedLines: 1,
+              deletedLines: 0
+            }
+          }
+        };
+      }
+    };
+
+    const result = await runMartin({
+      workspaceId: "ws_patch",
+      projectId: "proj_patch",
+      task: {
+        title: "Keep an allowed result artifact",
+        objective: "Create RESULT.txt as the release E2E acceptance artifact.",
+        verificationPlan: ["node verify.mjs"],
+        repoRoot,
+        allowedPaths: ["RESULT.txt"]
+      },
+      budget: {
+        maxUsd: 10,
+        softLimitUsd: 8,
+        maxIterations: 2
+      },
+      adapter,
+      store,
+      now: createTimestampSource([
+        "2026-04-03T11:05:00.000Z",
+        "2026-04-03T11:05:01.000Z",
+        "2026-04-03T11:05:02.000Z",
+        "2026-04-03T11:05:03.000Z",
+        "2026-04-03T11:05:04.000Z",
+        "2026-04-03T11:05:05.000Z",
+        "2026-04-03T11:05:06.000Z"
+      ]),
+      idFactory: createIdFactory()
+    });
+
+    const ledger = await readLedger(runsRoot, result.loop.loopId);
+    const keptEvent = ledger.find((entry) => entry.kind === "attempt.kept");
+    const discardedEvent = ledger.find((entry) => entry.kind === "attempt.discarded");
+    const patchDecision = JSON.parse(
+      await readFile(
+        join(runsRoot, result.loop.loopId, "artifacts", "attempt-001", "patch-decision.json"),
+        "utf8"
+      )
+    );
+
+    expect(result.decision.lifecycleState).toBe("completed");
+    expect(keptEvent?.payload).toMatchObject({
+      decision: "KEEP"
+    });
+    expect(discardedEvent).toBeUndefined();
+    expect(patchDecision.decision).toBe("KEEP");
+    expect(patchDecision.reasonCodes).toContain("verifier_passed");
+    expect(patchDecision.reasonCodes).not.toContain("grounding_failure");
+  });
+
   it("discards grounding-failure patches and persists patch decision artifacts", async () => {
     const runsRoot = await mkdtemp(join(tmpdir(), "martin-patch-discard-"));
     const repoRoot = join(runsRoot, "repo");


### PR DESCRIPTION
## Summary
- keep verifier-passing artifacts that are created during an attempt when they are explicitly allowed
- preserve grounding rejection for changed-file claims that are not backed by actual workspace state
- add a focused runtime regression test for fresh acceptance artifacts

## Validation
- pnpm --filter @martin/core test -- tests/runtime.test.ts
- pnpm --filter @martin/core lint
- pnpm --filter @martin/core build
- pnpm --filter @martin/core test -- tests/grounding.test.ts
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved patch previews for newly created workspace files.
  * Standardized file paths across platforms.
  * Preserved valid artifacts when verification succeeds.

* **Tests**
  * Added coverage confirming approved artifacts are retained and correctly recorded after a successful run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->