### PR TITLE
Fix MCP smoke launcher on Windows

### DIFF
--- a/packages/mcp/scripts/build-package-lib.mjs
+++ b/packages/mcp/scripts/build-package-lib.mjs
@@ -377,10 +377,19 @@ export function createCommandLaunch(command, args, platform = process.platform) 
     return { command, args };
   }
 
+  if (!requiresWindowsCommandShim(command)) {
+    return { command, args };
+  }
+
   return {
     command: process.env.ComSpec ?? "cmd.exe",
     args: ["/d", "/s", "/c", toCmdCommand(command, args)],
   };
+}
+
+function requiresWindowsCommandShim(command) {
+  const extension = path.extname(command).toLowerCase();
+  return extension === ".cmd" || extension === ".bat";
 }
 
 function toCmdCommand(command, args) {

--- a/packages/mcp/scripts/smoke-package.mjs
+++ b/packages/mcp/scripts/smoke-package.mjs
@@ -557,10 +557,19 @@ function createCommandLaunch(command, args) {
     return { command, args };
   }
 
+  if (!requiresWindowsCommandShim(command)) {
+    return { command, args };
+  }
+
   return {
     command: process.env.ComSpec ?? "cmd.exe",
     args: ["/d", "/s", "/c", toCmdCommand(command, args)],
   };
+}
+
+function requiresWindowsCommandShim(command) {
+  const extension = path.extname(command).toLowerCase();
+  return extension === ".cmd" || extension === ".bat";
 }
 
 function toCmdCommand(command, args) {

--- a/packages/mcp/tests/build-package.test.ts
+++ b/packages/mcp/tests/build-package.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from "vitest";
 import packageJson from "../package.json";
 import serverJson from "../server.json";
 
-import { rewritePackageSpecifiers, workspaceBuildCommandArgs } from "../scripts/build-package-lib.mjs";
+import {
+  createCommandLaunch,
+  rewritePackageSpecifiers,
+  workspaceBuildCommandArgs,
+} from "../scripts/build-package-lib.mjs";
 
 describe("rewritePackageSpecifiers", () => {
   it("rewrites nested internal package subpaths without truncating them", () => {
@@ -55,6 +59,37 @@ describe("workspaceBuildCommandArgs", () => {
       "--filter",
       "@martin/contracts",
       "build"
+    ]);
+  });
+});
+
+describe("createCommandLaunch", () => {
+  it("spawns native Windows executables directly so paths with spaces are not reparsed by cmd", () => {
+    const launch = createCommandLaunch(
+      "C:\\Program Files\\nodejs\\node.exe",
+      ["C:\\Users\\Example\\smoke.mjs"],
+      "win32",
+    );
+
+    expect(launch).toEqual({
+      command: "C:\\Program Files\\nodejs\\node.exe",
+      args: ["C:\\Users\\Example\\smoke.mjs"],
+    });
+  });
+
+  it("keeps Windows command shims behind cmd.exe", () => {
+    const launch = createCommandLaunch(
+      "pnpm.cmd",
+      ["--filter", "@martinloop/mcp", "build"],
+      "win32",
+    );
+
+    expect(launch.command.toLowerCase()).toContain("cmd");
+    expect(launch.args).toEqual([
+      "/d",
+      "/s",
+      "/c",
+      "pnpm.cmd --filter @martinloop/mcp build",
     ]);
   });
 });


### PR DESCRIPTION
## Summary
- launch native Windows executables directly in MCP package smoke helpers
- keep command shims such as pnpm.cmd behind cmd.exe
- add regression coverage for Node paths with spaces

## Validation
- pnpm --filter @martinloop/mcp test -- tests/build-package.test.ts
- pnpm --filter @martinloop/mcp smoke:pack
- pnpm release:matrix:local

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows command launching by running native executables directly.
  * Continued using the Windows command shell only for batch commands, improving compatibility and reliability.

* **Tests**
  * Added coverage for direct native executable launches and batch-command handling on Windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->