### PR TITLE
Harden CLI artifacts and release E2E gates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,6 +119,9 @@ jobs:
           echo "martin-loop@${{ steps.package-version.outputs.version }} did not become visible on npm in time."
           exit 1
 
+      - name: Verify published root artifact E2E
+        run: node ./scripts/published-artifact-e2e.mjs --package-spec "martin-loop@${{ steps.package-version.outputs.version }}"
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b
         with:

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -17,7 +17,7 @@ import {
   resolveCliCommandAvailability,
   createVerifierOnlyAdapter,
 } from "@martin/adapters";
-import { runMartin, classifyRoute, getHistoricalDirectSuccessRate, getPreference, recordPreference, writeExitSignal, type MartinAdapter } from "@martin/core";
+import { runMartin, classifyRoute, createFileRunStore, getHistoricalDirectSuccessRate, getPreference, recordPreference, writeExitSignal, type MartinAdapter } from "@martin/core";
 import {
   fetchSelectedMessage,
   getCliInstalledVersion,
@@ -1628,6 +1628,7 @@ async function executeRunCommand(
       budget: resolvedRequest.budget,
       metadata: executionMetadata,
       adapter,
+      store: createFileRunStore({ runsRoot: cliEnvironment.runsRoot }),
     });
     result = await offerArcadeWhileWaiting(governedTask, {
       outputMode,

--- a/packages/cli/tests/cli.test.ts
+++ b/packages/cli/tests/cli.test.ts
@@ -132,6 +132,58 @@ function installChangingRunAdapter(changedFiles: string[]): void {
   __setRunAdapterOverrideForTests(adapter);
 }
 
+function installWritingRunAdapter(filePath: string, contents: string): void {
+  const adapter: NonNullable<Parameters<typeof __setRunAdapterOverrideForTests>[0]> = {
+    adapterId: "agent-cli:cli-artifact-test",
+    kind: "agent-cli",
+    label: "CLI artifact persistence test adapter",
+    metadata: { providerId: "codex", model: "test-artifact-producer" },
+    async execute(request) {
+      await mkdir(join(request.context.repoRoot ?? process.cwd(), filePath.split("/").slice(0, -1).join("/")), {
+        recursive: true
+      });
+      await writeFile(join(request.context.repoRoot ?? process.cwd(), filePath), contents, "utf8");
+      return {
+        status: "completed",
+        summary: "Created a controlled CLI test artifact.",
+        usage: {
+          actualUsd: 0,
+          tokensIn: 0,
+          tokensOut: 0,
+          provenance: "actual"
+        },
+        verification: {
+          passed: true,
+          summary: "Verification completed in CLI artifact persistence test.",
+          binding: {
+            runId: request.loopId,
+            workspaceId: request.workspaceId,
+            cwd: request.context.repoRoot ?? process.cwd(),
+            commands: request.context.verificationPlan,
+          },
+          steps: request.context.verificationPlan.map((command) => ({
+            command,
+            launched: true,
+            completed: true,
+            crashed: false,
+            exitCode: 0,
+            timedOut: false,
+          })),
+        },
+        execution: {
+          changedFiles: [filePath],
+          diffStats: {
+            filesChanged: 1,
+            addedLines: 1,
+            deletedLines: 0
+          }
+        }
+      };
+    }
+  };
+  __setRunAdapterOverrideForTests(adapter);
+}
+
 afterEach(() => {
   __setRunAdapterOverrideForTests(undefined);
 });
@@ -962,6 +1014,71 @@ describe("executeCli", () => {
       expect(payload.loop.task.providerExecutionTimeoutMs).toBe(900000);
       expect(payload.loop.receiptScope.providerExecutionTimeoutMs).toBe(900000);
       expect(payload.loop.task.agentExecutionIntent).toBe("governed-autonomous");
+    } finally {
+      await rm(directory, { force: true, recursive: true });
+    }
+  });
+
+  it("persists patch decision artifacts for real CLI governed runs", { timeout: 30_000 }, async () => {
+    const directory = await mkdtemp(join(tmpdir(), "martin-cli-patch-decision-"));
+
+    try {
+      installWritingRunAdapter("src/cli-artifact.ts", "export const cliArtifact = true;\n");
+      await writeFile(join(directory, "README.md"), "# CLI patch decision fixture\n", "utf8");
+      initializeCommittedGitRepository(directory);
+      const previousMartinLive = process.env.MARTIN_LIVE;
+      process.env.MARTIN_LIVE = "false";
+      const result = await withIsolatedRunsEnv(directory, () =>
+        executeCli([
+          "--json",
+          "run",
+          "--objective",
+          "Create a source artifact through the CLI",
+          "--engine",
+          "codex",
+          "--verify",
+          `"${process.execPath}" -e "process.exit(0)"`,
+          "--cwd",
+          directory,
+          "--allow-path",
+          "src/cli-artifact.ts"
+        ])
+      );
+      if (previousMartinLive === undefined) {
+        delete process.env.MARTIN_LIVE;
+      } else {
+        process.env.MARTIN_LIVE = previousMartinLive;
+      }
+
+      expect([0, 7]).toContain(result.exitCode);
+      const payload = JSON.parse(result.stdout);
+      expect(payload.loop.lifecycleState).toBe("completed");
+      expect(payload.loop.events).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "verification.completed",
+            payload: expect.objectContaining({
+              passed: true,
+              changedFiles: ["src/cli-artifact.ts"]
+            })
+          })
+        ])
+      );
+
+      const patchDecision = JSON.parse(
+        await readFile(
+          join(
+            payload.environment.runsRoot,
+            payload.loop.loopId,
+            "artifacts",
+            "attempt-001",
+            "patch-decision.json"
+          ),
+          "utf8"
+        )
+      );
+      expect(patchDecision.decision).toBe("KEEP");
+      expect(patchDecision.reasonCodes).toContain("verifier_passed");
     } finally {
       await rm(directory, { force: true, recursive: true });
     }

--- a/scripts/published-artifact-e2e.mjs
+++ b/scripts/published-artifact-e2e.mjs
@@ -1,0 +1,331 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { packRootRelease } from "./pack-root-release.mjs";
+
+const ACCEPTANCE_FILE = "src/packaged-artifact-e2e.ts";
+const ACCEPTANCE_CONTENT = "export const packagedArtifactE2e = true;\n";
+const LEDGER_FILENAME = "ledger.jsonl";
+
+function parseArgs(argv) {
+  const specArg = argv.find((arg) => arg.startsWith("--package-spec="));
+  const specIndex = argv.indexOf("--package-spec");
+  const packageSpec = specArg
+    ? specArg.slice("--package-spec=".length)
+    : specIndex === -1
+      ? undefined
+      : argv[specIndex + 1];
+
+  if (!packageSpec) {
+    throw new Error("Missing --package-spec. Use --package-spec=pack or --package-spec martin-loop@x.y.z.");
+  }
+
+  return { packageSpec };
+}
+
+async function resolvePackageSpec(packageSpec, rootDir, tempRoot) {
+  if (packageSpec !== "pack") {
+    return packageSpec;
+  }
+
+  const result = await packRootRelease({
+    rootDir,
+    outputDir: path.join(tempRoot, "pack"),
+  });
+  return result.tarballPath;
+}
+
+async function runCommand(command, options) {
+  const execution = resolvePublishedArtifactCommandExecution(command, process.platform);
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(execution.command, execution.args, {
+      cwd: options.cwd,
+      env: options.env ?? process.env,
+      shell: execution.shell,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (chunk) => {
+      const text = chunk.toString();
+      stdout += text;
+      if (options.echo) process.stdout.write(text);
+    });
+
+    child.stderr.on("data", (chunk) => {
+      const text = chunk.toString();
+      stderr += text;
+      if (options.echo) process.stderr.write(text);
+    });
+
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code !== 0) {
+        reject(new Error(`Command failed (${code ?? "unknown"}): ${command.join(" ")}\n${stdout}${stderr}`));
+        return;
+      }
+      resolve({ stdout, stderr });
+    });
+  });
+}
+
+export function resolvePublishedArtifactCommandExecution(command, platform = process.platform, comSpec = process.env.ComSpec ?? "cmd.exe") {
+  if (platform !== "win32") {
+    return {
+      command: command[0],
+      args: command.slice(1),
+      shell: false,
+    };
+  }
+
+  const executable = resolveWindowsExecutable(command[0]);
+  if (requiresWindowsCommandShim(executable)) {
+    return {
+      command: comSpec,
+      args: ["/d", "/c", executable, ...command.slice(1)],
+      shell: false,
+    };
+  }
+
+  return {
+    command: executable,
+    args: command.slice(1),
+    shell: false,
+  };
+}
+
+function resolveWindowsExecutable(command) {
+  if (path.extname(command).length > 0) {
+    return command;
+  }
+
+  if (command === "npm" || command === "pnpm" || command === "npx") {
+    return `${command}.cmd`;
+  }
+
+  return command;
+}
+
+function requiresWindowsCommandShim(command) {
+  const extension = path.extname(command).toLowerCase();
+  return extension === ".cmd" || extension === ".bat";
+}
+
+async function writeConsumerRunner(consumerDir, workspaceDir, runsRoot) {
+  const runnerPath = path.join(consumerDir, "packaged-artifact-e2e-runner.mjs");
+  const source = `
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { createFileRunStore, runMartin } from "martin-loop";
+import { verifyReceiptIntegrityFromFiles } from "martin-loop/core";
+
+const workspaceDir = ${JSON.stringify(workspaceDir)};
+const runsRoot = ${JSON.stringify(runsRoot)};
+const acceptanceFile = ${JSON.stringify(ACCEPTANCE_FILE)};
+const acceptanceContent = ${JSON.stringify(ACCEPTANCE_CONTENT)};
+
+const store = createFileRunStore({ runsRoot });
+const adapter = {
+  adapterId: "direct:packaged-artifact-e2e",
+  kind: "direct-provider",
+  label: "Packaged artifact E2E adapter",
+  metadata: {
+    providerId: "packaged-artifact-e2e",
+    model: "deterministic"
+  },
+  async execute(request) {
+    await mkdir(join(workspaceDir, "src"), { recursive: true });
+    await writeFile(join(workspaceDir, acceptanceFile), acceptanceContent, "utf8");
+    return {
+      status: "completed",
+      summary: "Created the packaged artifact E2E source file.",
+      usage: {
+        actualUsd: 0,
+        tokensIn: 0,
+        tokensOut: 0,
+        provenance: "actual"
+      },
+      verification: {
+        passed: true,
+        summary: "Packaged artifact E2E verifier passed.",
+        binding: {
+          runId: request.loopId,
+          workspaceId: request.workspaceId,
+          cwd: request.context.repoRoot ?? workspaceDir,
+          commands: request.context.verificationPlan
+        },
+        steps: request.context.verificationPlan.map((command) => ({
+          command,
+          launched: true,
+          completed: true,
+          crashed: false,
+          exitCode: 0,
+          timedOut: false
+        }))
+      },
+      execution: {
+        changedFiles: [acceptanceFile],
+        diffStats: {
+          filesChanged: 1,
+          addedLines: 1,
+          deletedLines: 0
+        }
+      }
+    };
+  }
+};
+
+const result = await runMartin({
+  workspaceId: "ws_packaged_artifact_e2e",
+  projectId: "proj_packaged_artifact_e2e",
+  task: {
+    title: "Packaged artifact E2E",
+    objective: "Create a new allowed source file from an installed package artifact.",
+    verificationPlan: ["node -e \\"process.exit(0)\\""],
+    repoRoot: workspaceDir,
+    allowedPaths: [acceptanceFile]
+  },
+  budget: {
+    maxUsd: 1,
+    softLimitUsd: 1,
+    maxIterations: 1
+  },
+  adapter,
+  store
+});
+
+const loopId = result.loop.loopId;
+const loopRoot = join(runsRoot, loopId);
+const persistedContent = await readFile(join(workspaceDir, acceptanceFile), "utf8");
+const ledger = await readFile(join(loopRoot, ${JSON.stringify(LEDGER_FILENAME)}), "utf8");
+const patchDecision = JSON.parse(await readFile(join(loopRoot, "artifacts", "attempt-001", "patch-decision.json"), "utf8"));
+const receipt = await verifyReceiptIntegrityFromFiles({
+  runId: loopId,
+  runsRoot,
+  loopRecordPath: join(loopRoot, "loop-record.json"),
+  ledgerPath: join(loopRoot, ${JSON.stringify(LEDGER_FILENAME)})
+});
+
+if (result.decision.lifecycleState !== "completed") {
+  throw new Error("Expected completed lifecycle, received " + result.decision.lifecycleState);
+}
+if (persistedContent !== acceptanceContent) {
+  throw new Error("Accepted file content mismatch.");
+}
+if (patchDecision.decision !== "KEEP") {
+  throw new Error("Expected KEEP patch decision, received " + patchDecision.decision);
+}
+if (patchDecision.reasonCodes.includes("grounding_failure")) {
+  throw new Error("Unexpected grounding_failure in KEEP patch decision.");
+}
+if (ledger.includes("attempt.discarded") || ledger.includes("repo_grounding_failure")) {
+  throw new Error("Unexpected discard or grounding failure in ledger.");
+}
+if (receipt.state !== "verified") {
+  throw new Error("Expected verified receipt integrity, received " + receipt.state);
+}
+
+process.stdout.write(JSON.stringify({
+  ok: true,
+  packageVersion: (await import("martin-loop/package.json", { with: { type: "json" } })).default.version,
+  loopId,
+  lifecycleState: result.decision.lifecycleState,
+  patchDecision: patchDecision.decision,
+  receiptState: receipt.state,
+  keyId: receipt.keyId,
+  loopRecordSha256: receipt.loopRecordSha256,
+  ledgerSha256: receipt.ledgerSha256,
+  changedFiles: result.loop.events.find((event) => event.type === "verification.completed")?.payload?.changedFiles ?? []
+}, null, 2) + "\\n");
+`;
+
+  await writeFile(runnerPath, source, "utf8");
+  return runnerPath;
+}
+
+export async function runPublishedArtifactE2e(options) {
+  const rootDir = options.rootDir ?? process.cwd();
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "martin published artifact e2e "));
+  const consumerDir = path.join(tempRoot, "consumer");
+  const workspaceDir = path.join(tempRoot, "workspace");
+  const runsRoot = path.join(tempRoot, "runs");
+  const keysRoot = path.join(tempRoot, "keys");
+  const queueRoot = path.join(tempRoot, "queue");
+  const stateRoot = path.join(tempRoot, "state");
+  const groundingRoot = path.join(tempRoot, "grounding");
+
+  await Promise.all([
+    mkdir(consumerDir, { recursive: true }),
+    mkdir(workspaceDir, { recursive: true }),
+    mkdir(runsRoot, { recursive: true }),
+    mkdir(keysRoot, { recursive: true }),
+    mkdir(queueRoot, { recursive: true }),
+    mkdir(stateRoot, { recursive: true }),
+    mkdir(groundingRoot, { recursive: true }),
+  ]);
+
+  const resolvedPackageSpec = await resolvePackageSpec(options.packageSpec, rootDir, tempRoot);
+
+  await writeFile(path.join(consumerDir, "package.json"), `${JSON.stringify({
+    name: "martin-published-artifact-e2e-consumer",
+    version: "1.0.0",
+    private: true,
+    type: "module",
+  }, null, 2)}\n`, "utf8");
+  await writeFile(path.join(workspaceDir, "README.md"), "# Packaged artifact E2E fixture\n", "utf8");
+  await runCommand(["git", "init"], { cwd: workspaceDir });
+  await runCommand(["git", "config", "user.email", "packaged-artifact-e2e@example.invalid"], { cwd: workspaceDir });
+  await runCommand(["git", "config", "user.name", "Packaged Artifact E2E"], { cwd: workspaceDir });
+  await runCommand(["git", "add", "README.md"], { cwd: workspaceDir });
+  await runCommand(["git", "commit", "-m", "Add packaged artifact E2E fixture"], { cwd: workspaceDir });
+  await runCommand(["npm", "install", "--save-exact", resolvedPackageSpec], { cwd: consumerDir, echo: true });
+
+  const runnerPath = await writeConsumerRunner(consumerDir, workspaceDir, runsRoot);
+  const env = {
+    ...process.env,
+    MARTIN_RUNS_DIR: runsRoot,
+    MARTIN_INTEGRITY_KEY_DIR: keysRoot,
+    MARTIN_SYNC_QUEUE_DIR: queueRoot,
+    MARTIN_STATE_DIR: stateRoot,
+    MARTIN_GROUNDING_DIR: groundingRoot,
+    GIT_CONFIG_COUNT: "1",
+    GIT_CONFIG_KEY_0: "safe.directory",
+    GIT_CONFIG_VALUE_0: workspaceDir,
+  };
+  const result = await runCommand(["node", runnerPath], { cwd: consumerDir, env, echo: true });
+
+  return {
+    tempRoot,
+    packageSpec: options.packageSpec,
+    resolvedPackageSpec,
+    output: JSON.parse(result.stdout),
+  };
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const result = await runPublishedArtifactE2e({
+    packageSpec: options.packageSpec,
+    rootDir: process.cwd(),
+  });
+
+  process.stdout.write(`\nPUBLISHED_ARTIFACT_E2E=${JSON.stringify(result, null, 2)}\n`);
+}
+
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : "";
+const modulePath = fileURLToPath(import.meta.url);
+if (invokedPath === path.resolve(modulePath)) {
+  main().catch((error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`Published artifact E2E failed: ${message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/rc-validation.mjs
+++ b/scripts/rc-validation.mjs
@@ -13,6 +13,7 @@ const RC_VALIDATION_STEPS = [
   ["pnpm", "public:smoke"],
   ["pnpm", "--filter", "@martinloop/mcp", "smoke:pack"],
   ["pnpm", "mcp:published:smoke:pack"],
+  ["node", "./scripts/published-artifact-e2e.mjs", "--package-spec=pack"],
 ];
 
 export function createRcValidationPlan(options = {}) {
@@ -122,10 +123,18 @@ export function resolveRcCommandExecution(
   comSpec = process.env.ComSpec ?? "cmd.exe",
 ) {
   if (platform === "win32") {
-    const commandLine = command.map(quoteForWindowsShell).join(" ");
+    const executable = resolveWindowsExecutable(command[0]);
+    if (requiresWindowsCommandShim(executable)) {
+      return {
+        command: comSpec,
+        args: ["/d", "/c", executable, ...command.slice(1)],
+        shell: false,
+      };
+    }
+
     return {
-      command: comSpec,
-      args: ["/d", "/s", "/c", commandLine],
+      command: executable,
+      args: command.slice(1),
       shell: false,
     };
   }
@@ -137,20 +146,29 @@ export function resolveRcCommandExecution(
   };
 }
 
+function resolveWindowsExecutable(command) {
+  if (path.extname(command).length > 0) {
+    return command;
+  }
+
+  if (command === "npm" || command === "pnpm" || command === "npx") {
+    return `${command}.cmd`;
+  }
+
+  return command;
+}
+
+function requiresWindowsCommandShim(command) {
+  const extension = path.extname(command).toLowerCase();
+  return extension === ".cmd" || extension === ".bat";
+}
+
 function slugify(value) {
   return value
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "")
     .slice(0, 80);
-}
-
-function quoteForWindowsShell(value) {
-  if (!/[\s"&|<>^]/.test(value)) {
-    return value;
-  }
-
-  return `"${value.replace(/"/g, '\\"')}"`;
 }
 
 async function main() {

--- a/scripts/release-matrix.mjs
+++ b/scripts/release-matrix.mjs
@@ -17,6 +17,7 @@ const RELEASE_MATRIX_STEPS = [
   ["pnpm", "public:smoke"],
   ["pnpm", "--filter", "@martinloop/mcp", "smoke:pack"],
   ["pnpm", "mcp:published:smoke:pack"],
+  ["node", "./scripts/published-artifact-e2e.mjs", "--package-spec=pack"],
 ];
 
 const RELEASE_MATRIX_LANES = [

--- a/scripts/tests/published-artifact-e2e.test.mjs
+++ b/scripts/tests/published-artifact-e2e.test.mjs
@@ -1,0 +1,35 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { resolvePublishedArtifactCommandExecution } from "../published-artifact-e2e.mjs";
+
+test("published artifact E2E runs native Windows executables without a command shell", () => {
+  const execution = resolvePublishedArtifactCommandExecution(
+    ["git", "commit", "-m", "Add packaged artifact E2E fixture"],
+    "win32",
+    "C:\\Windows\\System32\\cmd.exe",
+  );
+
+  assert.equal(execution.command, "git");
+  assert.deepEqual(execution.args, ["commit", "-m", "Add packaged artifact E2E fixture"]);
+  assert.equal(execution.shell, false);
+});
+
+test("published artifact E2E keeps Windows command shims behind cmd.exe", () => {
+  const execution = resolvePublishedArtifactCommandExecution(
+    ["npm", "install", "--save-exact", "C:\\Temp With Spaces\\martin-loop-0.5.8.tgz"],
+    "win32",
+    "C:\\Windows\\System32\\cmd.exe",
+  );
+
+  assert.equal(execution.command, "C:\\Windows\\System32\\cmd.exe");
+  assert.equal(execution.shell, false);
+  assert.deepEqual(execution.args, [
+    "/d",
+    "/c",
+    "npm.cmd",
+    "install",
+    "--save-exact",
+    "C:\\Temp With Spaces\\martin-loop-0.5.8.tgz",
+  ]);
+});

--- a/scripts/tests/rc-validation.test.mjs
+++ b/scripts/tests/rc-validation.test.mjs
@@ -18,7 +18,8 @@ test("createRcValidationPlan omits install by default and includes the OSS-safe 
   assert.ok(commands.includes("pnpm oss:validate"));
   assert.ok(commands.includes("pnpm public:smoke"));
   assert.ok(commands.includes("pnpm --filter @martinloop/mcp smoke:pack"));
-  assert.equal(commands.at(-1), "pnpm mcp:published:smoke:pack");
+  assert.ok(commands.includes("node ./scripts/published-artifact-e2e.mjs --package-spec=pack"));
+  assert.equal(commands.at(-1), "node ./scripts/published-artifact-e2e.mjs --package-spec=pack");
   assert.ok(!commands.includes("pnpm install --frozen-lockfile"));
 });
 
@@ -46,7 +47,7 @@ test("createRcValidationEnvironment points HOME-style state at an isolated direc
   assert.notEqual(env.HOME, "C:\\Users\\ExampleUser");
 });
 
-test("resolveRcCommandExecution avoids shell mode on Windows by invoking cmd.exe explicitly", () => {
+test("resolveRcCommandExecution keeps Windows command shims behind cmd.exe without joining argv", () => {
   const execution = resolveRcCommandExecution(
     ["pnpm", "--filter", "@martin/core", "test"],
     "win32",
@@ -54,6 +55,18 @@ test("resolveRcCommandExecution avoids shell mode on Windows by invoking cmd.exe
   );
 
   assert.equal(execution.command, "C:\\Windows\\System32\\cmd.exe");
-  assert.deepEqual(execution.args, ["/d", "/s", "/c", "pnpm --filter @martin/core test"]);
+  assert.deepEqual(execution.args, ["/d", "/c", "pnpm.cmd", "--filter", "@martin/core", "test"]);
+  assert.equal(execution.shell, false);
+});
+
+test("resolveRcCommandExecution runs native Windows executables directly", () => {
+  const execution = resolveRcCommandExecution(
+    ["node", "./scripts/published-artifact-e2e.mjs", "--package-spec=pack"],
+    "win32",
+    "C:\\Windows\\System32\\cmd.exe",
+  );
+
+  assert.equal(execution.command, "node");
+  assert.deepEqual(execution.args, ["./scripts/published-artifact-e2e.mjs", "--package-spec=pack"]);
   assert.equal(execution.shell, false);
 });

--- a/scripts/tests/release-matrix.test.mjs
+++ b/scripts/tests/release-matrix.test.mjs
@@ -40,6 +40,24 @@ test("createReleaseMatrixPlan checks root package boundaries before the full tes
   }
 });
 
+test("createReleaseMatrixPlan runs a packaged root artifact E2E before declaring the lane green", () => {
+  const plan = createReleaseMatrixPlan({ rootDir: "C:/repo" });
+
+  for (const lane of plan.lanes) {
+    const commands = lane.steps.map((step) => step.command.join(" "));
+
+    assert.ok(
+      commands.includes("node ./scripts/published-artifact-e2e.mjs --package-spec=pack"),
+      `${lane.id} lane should exercise the packed root artifact E2E`,
+    );
+    assert.equal(
+      commands.at(-1),
+      "node ./scripts/published-artifact-e2e.mjs --package-spec=pack",
+      `${lane.id} lane should finish on the packaged root artifact E2E`,
+    );
+  }
+});
+
 test("resolveReleaseMatrixLane selects the correct local platform lane", () => {
   const plan = createReleaseMatrixPlan({ rootDir: "C:/repo" });
 

--- a/scripts/tests/root-release-workflow.test.mjs
+++ b/scripts/tests/root-release-workflow.test.mjs
@@ -17,6 +17,10 @@ test("root release workflow uses GitHub Actions trusted publishing without npm t
   assert.match(workflow, /npm install -g npm@latest/);
   assert.match(workflow, /npm publish "\$\{\{ steps\.root-pack\.outputs\.tarball \}\}" --access public --provenance/);
   assert.match(workflow, /npm view "martin-loop@\$\{\{ steps\.package-version\.outputs\.version \}\}" version/);
+  assert.match(
+    workflow,
+    /node \.\/scripts\/published-artifact-e2e\.mjs --package-spec "martin-loop@\$\{\{ steps\.package-version\.outputs\.version \}\}"/,
+  );
   assert.match(workflow, /actions\/checkout@v6/);
   assert.match(workflow, /pnpm\/action-setup@b0f76dfb45f55f8421693e4803ac7bb65143bd34/);
   assert.match(workflow, /actions\/setup-node@v6/);


### PR DESCRIPTION
## Summary
- persist CLI governed-run patch decisions through the Core file run store
- add a lightweight packaged root artifact E2E gate to release validation
- run the packaged artifact E2E after root npm publication in the release workflow
- fix Windows release-harness command execution so package-manager shims preserve argv boundaries on paths with spaces

## Scope
- no version bump
- no release publication
- no tag changes
- release-harness and CLI artifact durability only

## Validation
- node --test scripts/tests/rc-validation.test.mjs scripts/tests/release-matrix.test.mjs scripts/tests/root-release-workflow.test.mjs scripts/tests/published-artifact-e2e.test.mjs: PASS, 16/16
- pnpm --filter @martin/cli test -- tests/cli.test.ts: PASS, 44/44
- node ./scripts/published-artifact-e2e.mjs --package-spec=pack: PASS; lifecycle completed; patchDecision KEEP; receipt verified
- git diff --check: PASS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI runs now persist run data in the configured runs directory.
  * Added end-to-end verification for packaged and published release artifacts.

* **Bug Fixes**
  * Improved Windows command execution during release validation for native executables and command shims.

* **Tests**
  * Added coverage confirming successful runs, patch decisions, receipt integrity, and release-matrix validation.

* **Release Process**
  * Published-artifact checks now run across release lanes before a GitHub Release is created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->