### PR TITLE
Improve Codex governance discovery

### DIFF
--- a/packages/cli/src/mcp-config.ts
+++ b/packages/cli/src/mcp-config.ts
@@ -229,6 +229,9 @@ async function maybeInstallGovernance(
   if (options.installGovernance && plan.host === "claude") {
     await installClaudeGovernanceHooks();
   }
+  if (options.installGovernance && plan.host === "codex") {
+    await installCodexGovernanceInstructions(plan, options);
+  }
 }
 
 /**
@@ -300,6 +303,123 @@ async function installClaudeGovernanceHooks(): Promise<void> {
   settings.hooks = { ...hooks, PreToolUse: preToolUse, Stop: stop };
   await mkdir(path.join(homedir(), ".claude"), { recursive: true });
   await writeFileAtomically(settingsPath, JSON.stringify(settings, null, 2) + "\n");
+}
+
+const MARTIN_CODEX_GOVERNANCE_BEGIN = "<!-- BEGIN MARTINLOOP GOVERNANCE -->";
+const MARTIN_CODEX_GOVERNANCE_END = "<!-- END MARTINLOOP GOVERNANCE -->";
+
+async function installCodexGovernanceInstructions(
+  plan: MartinMcpInstallPlan,
+  options: MartinMcpInstallOptions
+): Promise<void> {
+  const targetPath = plan.governanceHooks.targetPath;
+  if (!targetPath) {
+    throw new CliCommandError(
+      "environment",
+      "Codex governance installation needs an explicit instruction target.",
+      {
+        suggestion: plan.governanceHooks.instructions
+      }
+    );
+  }
+  const resolvedTargetPath = isAbsoluteAnyPlatform(targetPath)
+    ? targetPath
+    : joinTargetPath(plan.cwd, targetPath);
+
+  const existing = await readFile(resolvedTargetPath, "utf8").catch((error: NodeJS.ErrnoException) => {
+    if (error.code === "ENOENT") return undefined;
+    throw error;
+  });
+  const merged = mergeMartinCodexGovernanceSection(existing ?? "", plan.governanceHooks.content);
+
+  if (existing === merged) {
+    return;
+  }
+
+  await recordMartinMcpInstall({
+    host: plan.host,
+    scope: plan.scope,
+    targetPath: resolvedTargetPath,
+    content: merged,
+    ...(existing !== undefined ? { previousContent: existing } : {}),
+    stateRoot: options.stateRoot
+  });
+}
+
+function mergeMartinCodexGovernanceSection(existing: string, content: string): string {
+  const eol = detectDominantEol(existing);
+  const managedSection = renderMartinCodexGovernanceSection(content, eol);
+  const beginIndexes = findAllIndexes(existing, MARTIN_CODEX_GOVERNANCE_BEGIN);
+  const endIndexes = findAllIndexes(existing, MARTIN_CODEX_GOVERNANCE_END);
+  const beginIndex = beginIndexes[0] ?? -1;
+  const endIndex = endIndexes[0] ?? -1;
+
+  if (
+    beginIndexes.length > 1 ||
+    endIndexes.length > 1 ||
+    beginIndexes.length !== endIndexes.length ||
+    (beginIndex !== -1 && endIndex < beginIndex)
+  ) {
+    throw new CliCommandError(
+      "environment",
+      "Refusing to modify Codex instructions because the MartinLoop managed section is malformed.",
+      {
+        suggestion:
+          "Fix or remove the partial MartinLoop governance section, then rerun `martin mcp install --install-governance`."
+      }
+    );
+  }
+
+  if (beginIndex !== -1) {
+    return [
+      existing.slice(0, beginIndex),
+      managedSection,
+      existing.slice(endIndex + MARTIN_CODEX_GOVERNANCE_END.length)
+    ].join("");
+  }
+
+  if (existing.length === 0) {
+    return `${managedSection}${eol}`;
+  }
+
+  return `${existing}${buildAppendSeparator(existing, eol)}${managedSection}${eol}`;
+}
+
+function renderMartinCodexGovernanceSection(content: string, eol: string): string {
+  return [
+    MARTIN_CODEX_GOVERNANCE_BEGIN,
+    content.trimEnd().replace(/\r\n|\n|\r/gu, eol),
+    MARTIN_CODEX_GOVERNANCE_END
+  ].join(eol);
+}
+
+function buildAppendSeparator(existing: string, eol: string): string {
+  if (existing.endsWith(`${eol}${eol}`)) {
+    return "";
+  }
+  if (existing.endsWith(eol)) {
+    return eol;
+  }
+  return `${eol}${eol}`;
+}
+
+function detectDominantEol(content: string): "\r\n" | "\n" {
+  const crlfCount = content.match(/\r\n/gu)?.length ?? 0;
+  const lfCount = content.match(/\n/gu)?.length ?? 0;
+  const lfOnlyCount = lfCount - crlfCount;
+  return crlfCount > lfOnlyCount ? "\r\n" : "\n";
+}
+
+function findAllIndexes(haystack: string, needle: string): number[] {
+  const indexes: number[] = [];
+  let offset = 0;
+  while (offset < haystack.length) {
+    const index = haystack.indexOf(needle, offset);
+    if (index === -1) break;
+    indexes.push(index);
+    offset = index + needle.length;
+  }
+  return indexes;
 }
 
 function normalizeInput(input: MartinMcpConfigInput): Required<Omit<MartinMcpConfigInput, "remoteUrl">> & {
@@ -595,6 +715,10 @@ function joinTargetPath(basePath: string, ...segments: string[]): string {
   return usesWindowsSeparators(basePath)
     ? path.win32.join(basePath, ...segments)
     : path.join(basePath, ...segments);
+}
+
+function isAbsoluteAnyPlatform(value: string): boolean {
+  return path.isAbsolute(value) || path.win32.isAbsolute(value);
 }
 
 // ---------------------------------------------------------------------------
@@ -937,22 +1061,27 @@ function buildGovernanceHooks(host: MartinMcpHost, scope: MartinMcpScope): Gover
         host,
         supported: true,
         mechanism: "Codex AGENTS.md governance instructions",
-        targetPath: scope === "user" ? null : "AGENTS.md",
+        targetPath: scope === "user" ? joinTargetPath(resolveCodexHome(), "AGENTS.md") : "AGENTS.md",
         content: [
           "## MartinLoop Governance",
           "",
-          "Before executing any coding task:",
-          "1. Call `martin_doctor` to confirm environment readiness",
-          "2. Call `martin_estimate` to preview cost and route",
-          "3. Call `martin_plan` to scope the bounded approach",
-          "4. Call `martin_preflight` to validate the run contract",
-          "5. Only then call `martin_run`",
-          "6. After completion, call `martin_dossier` to generate the receipt",
+          "MartinLoop is available in this Codex environment.",
           "",
+          "Use MartinLoop proactively for non-trivial software implementation, debugging, risky changes, failed prior attempts, and release-readiness questions.",
+          "For read-only diagnosis, prefer `martin_doctor`, `martin_estimate`, `martin_plan`, `martin_preflight`, `martin_triage_runs`, and evidence/dossier reads before recommending next steps.",
+          "When the user has authorized code changes, use the appropriate governed sequence through `martin_run`, then surface verifier-backed evidence with `martin_dossier`.",
+          "Reuse valid prior Martin context when continuing a session instead of blindly repeating every setup step.",
+          "",
+          "Do not use MartinLoop for unrelated conversation, trivial text edits, or non-software tasks.",
+          "Do not mutate code when the user only asked for diagnosis or explanation.",
+          "Stop and ask when policy, budget, credentials, scope, or destructive risk requires explicit consent.",
           "Never claim success without verifier-backed completion evidence from MartinLoop.",
           ""
         ].join("\n"),
-        instructions: "Add the governance section to your project's AGENTS.md or ~/.codex/instructions.md."
+        instructions:
+          scope === "user"
+            ? "Install the Martin-managed governance section into CODEX_HOME/AGENTS.md."
+            : "Install the Martin-managed governance section into the project AGENTS.md."
       };
 
     case "gemini":

--- a/packages/cli/tests/mcp-config.test.ts
+++ b/packages/cli/tests/mcp-config.test.ts
@@ -174,6 +174,300 @@ describe("mcp config helpers", () => {
     }
   });
 
+  it("installs project-scope Codex governance into AGENTS.md when explicitly requested", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "martin-cli-codex-governance-"));
+
+    try {
+      const agentsPath = join(cwd, "AGENTS.md");
+      await writeFile(
+        agentsPath,
+        [
+          "# Project Instructions",
+          "",
+          "Preserve this unrelated guidance.",
+          ""
+        ].join("\n"),
+        "utf8"
+      );
+
+      await installMcpConfig(
+        {
+          host: "codex",
+          scope: "project",
+          cwd,
+          runsRoot: join(cwd, ".runs")
+        },
+        { installGovernance: true, stateRoot: join(cwd, ".state") }
+      );
+
+      const installed = await readFile(agentsPath, "utf8");
+      expect(installed).toContain("Preserve this unrelated guidance.");
+      expect(installed).toContain("BEGIN MARTINLOOP GOVERNANCE");
+      expect(installed).toContain("MartinLoop is available");
+      expect(installed).toContain("martin_doctor");
+      expect(installed).toContain("martin_run");
+      expect(installed).toContain("END MARTINLOOP GOVERNANCE");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps Codex governance installation idempotent", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "martin-cli-codex-governance-idempotent-"));
+
+    try {
+      await installMcpConfig(
+        {
+          host: "codex",
+          scope: "project",
+          cwd,
+          runsRoot: join(cwd, ".runs")
+        },
+        { installGovernance: true, stateRoot: join(cwd, ".state") }
+      );
+      await installMcpConfig(
+        {
+          host: "codex",
+          scope: "project",
+          cwd,
+          runsRoot: join(cwd, ".runs")
+        },
+        { installGovernance: true, stateRoot: join(cwd, ".state") }
+      );
+
+      const installed = await readFile(join(cwd, "AGENTS.md"), "utf8");
+      expect(installed.match(/BEGIN MARTINLOOP GOVERNANCE/gu)).toHaveLength(1);
+      expect(installed.match(/END MARTINLOOP GOVERNANCE/gu)).toHaveLength(1);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("replaces an existing Martin-managed Codex governance section without duplicating user instructions", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "martin-cli-codex-governance-replace-"));
+
+    try {
+      const agentsPath = join(cwd, "AGENTS.md");
+      await writeFile(
+        agentsPath,
+        [
+          "# Existing Instructions",
+          "",
+          "<!-- BEGIN MARTINLOOP GOVERNANCE -->",
+          "old Martin section",
+          "<!-- END MARTINLOOP GOVERNANCE -->",
+          "",
+          "Keep this project-specific rule.",
+          ""
+        ].join("\n"),
+        "utf8"
+      );
+
+      await installMcpConfig(
+        {
+          host: "codex",
+          scope: "project",
+          cwd,
+          runsRoot: join(cwd, ".runs")
+        },
+        { installGovernance: true, stateRoot: join(cwd, ".state") }
+      );
+
+      const installed = await readFile(agentsPath, "utf8");
+      expect(installed).not.toContain("old Martin section");
+      expect(installed).toContain("Keep this project-specific rule.");
+      expect(installed.match(/BEGIN MARTINLOOP GOVERNANCE/gu)).toHaveLength(1);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves non-Martin Codex instruction bytes exactly when replacing a managed section", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "martin-cli-codex-governance-preserve-"));
+
+    try {
+      const agentsPath = join(cwd, "AGENTS.md");
+      const prefix = [
+        "# Existing Instructions",
+        "",
+        "",
+        "Keep   unusual   spacing.",
+        "  - preserve leading indentation",
+        ""
+      ].join("\n");
+      const suffix = [
+        "",
+        "",
+        "Trailing project rule:",
+        "",
+        "",
+        "  leave these blank lines alone",
+        ""
+      ].join("\n");
+      await writeFile(
+        agentsPath,
+        `${prefix}<!-- BEGIN MARTINLOOP GOVERNANCE -->\nold Martin section\n<!-- END MARTINLOOP GOVERNANCE -->${suffix}`,
+        "utf8"
+      );
+
+      await installMcpConfig(
+        {
+          host: "codex",
+          scope: "project",
+          cwd,
+          runsRoot: join(cwd, ".runs")
+        },
+        { installGovernance: true, stateRoot: join(cwd, ".state") }
+      );
+
+      const installed = await readFile(agentsPath, "utf8");
+      const beginIndex = installed.indexOf("<!-- BEGIN MARTINLOOP GOVERNANCE -->");
+      const endIndex = installed.indexOf("<!-- END MARTINLOOP GOVERNANCE -->");
+      expect(beginIndex).toBe(prefix.length);
+      expect(installed.slice(0, beginIndex)).toBe(prefix);
+      expect(installed.slice(endIndex + "<!-- END MARTINLOOP GOVERNANCE -->".length)).toBe(suffix);
+      expect(installed).not.toContain("old Martin section");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves an existing CRLF AGENTS.md convention around the managed Codex section", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "martin-cli-codex-governance-crlf-"));
+
+    try {
+      const agentsPath = join(cwd, "AGENTS.md");
+      const prefix = "# Existing Instructions\r\n\r\nKeep CRLF.\r\n";
+      const suffix = "\r\n\r\nAfter section stays CRLF.\r\n";
+      await writeFile(
+        agentsPath,
+        `${prefix}<!-- BEGIN MARTINLOOP GOVERNANCE -->\r\nold Martin section\r\n<!-- END MARTINLOOP GOVERNANCE -->${suffix}`,
+        "utf8"
+      );
+
+      await installMcpConfig(
+        {
+          host: "codex",
+          scope: "project",
+          cwd,
+          runsRoot: join(cwd, ".runs")
+        },
+        { installGovernance: true, stateRoot: join(cwd, ".state") }
+      );
+
+      const installed = await readFile(agentsPath, "utf8");
+      expect(installed.slice(0, prefix.length)).toBe(prefix);
+      expect(installed.endsWith(suffix)).toBe(true);
+      expect(installed).toContain("<!-- BEGIN MARTINLOOP GOVERNANCE -->\r\n## MartinLoop Governance\r\n");
+      expect(installed).not.toMatch(/(?<!\r)\n/u);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses to install Codex governance over a malformed managed section", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "martin-cli-codex-governance-malformed-"));
+
+    try {
+      const agentsPath = join(cwd, "AGENTS.md");
+      await writeFile(
+        agentsPath,
+        [
+          "# Existing Instructions",
+          "",
+          "<!-- BEGIN MARTINLOOP GOVERNANCE -->",
+          "partial Martin section without an end sentinel",
+          ""
+        ].join("\n"),
+        "utf8"
+      );
+
+      await expect(
+        installMcpConfig(
+          {
+            host: "codex",
+            scope: "project",
+            cwd,
+            runsRoot: join(cwd, ".runs")
+          },
+          { installGovernance: true, stateRoot: join(cwd, ".state") }
+        )
+      ).rejects.toThrow(/managed section is malformed/u);
+
+      expect(await readFile(agentsPath, "utf8")).toContain("partial Martin section");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses to install Codex governance when duplicate managed sections are present", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "martin-cli-codex-governance-duplicate-"));
+
+    try {
+      const agentsPath = join(cwd, "AGENTS.md");
+      const existing = [
+        "# Existing Instructions",
+        "",
+        "<!-- BEGIN MARTINLOOP GOVERNANCE -->",
+        "first Martin section",
+        "<!-- END MARTINLOOP GOVERNANCE -->",
+        "",
+        "<!-- BEGIN MARTINLOOP GOVERNANCE -->",
+        "second Martin section",
+        "<!-- END MARTINLOOP GOVERNANCE -->",
+        ""
+      ].join("\n");
+      await writeFile(agentsPath, existing, "utf8");
+
+      await expect(
+        installMcpConfig(
+          {
+            host: "codex",
+            scope: "project",
+            cwd,
+            runsRoot: join(cwd, ".runs")
+          },
+          { installGovernance: true, stateRoot: join(cwd, ".state") }
+        )
+      ).rejects.toThrow(/managed section is malformed/u);
+
+      expect(await readFile(agentsPath, "utf8")).toBe(existing);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("installs user-scope Codex governance into CODEX_HOME AGENTS.md when explicitly requested", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "martin-cli-codex-user-governance-"));
+    const codexHome = join(cwd, ".codex-home");
+    const previousCodexHome = process.env.CODEX_HOME;
+
+    try {
+      process.env.CODEX_HOME = codexHome;
+
+      await installMcpConfig(
+        {
+          host: "codex",
+          scope: "user",
+          cwd,
+          runsRoot: join(cwd, ".runs")
+        },
+        { installGovernance: true, stateRoot: join(cwd, ".state") }
+      );
+
+      const installed = await readFile(join(codexHome, "AGENTS.md"), "utf8");
+      expect(installed).toContain("BEGIN MARTINLOOP GOVERNANCE");
+      expect(installed).toContain("Use MartinLoop proactively for non-trivial software implementation");
+    } finally {
+      if (previousCodexHome === undefined) {
+        delete process.env.CODEX_HOME;
+      } else {
+        process.env.CODEX_HOME = previousCodexHome;
+      }
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("treats existing Claude configs with a martin-loop block as idempotent", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "martin-cli-claude-config-"));
 

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -918,7 +918,7 @@ export function createMartinMcpServer(serverInfo?: {
     {
       name: "martin_run",
       description:
-        "Execute a governed Martin Loop run on a coding task and return the run summary, spend, artifact rollup, and verification state. This hard-blocks until martin_doctor, martin_estimate, martin_plan, and martin_preflight receipts exist for the same task.",
+        "Execute a governed MartinLoop coding run after MCP workflow admission is satisfied. Use when the user has authorized implementation, bug fixing, tests, or refactoring and doctor/estimate/plan/preflight receipts match this task. Do not use for question-only diagnosis or when policy, budget, credentials, or scope still need consent. Next: read martin_dossier and verifier evidence.",
       annotations: {
         destructiveHint: true,
         idempotentHint: false,
@@ -1068,7 +1068,7 @@ export function createMartinMcpServer(serverInfo?: {
     {
       name: "martin_doctor",
       description:
-        "Read-only environment and run-store diagnostics for the Martin MCP server. This is the expected first call before governed work begins.",
+        "Read-only environment, engine, workspace, and run-store diagnostics for MartinLoop. Use first for software work, fresh installs, suspicious state, or before retries. Do not use as proof that a task is complete. Next: call martin_estimate or martin_triage_runs depending on whether this is new work or failed prior work.",
       annotations: {
         readOnlyHint: true,
         idempotentHint: true
@@ -1097,7 +1097,7 @@ export function createMartinMcpServer(serverInfo?: {
     {
       name: "martin_plan",
       description:
-        "Read-only planning step that turns an objective into a scoped implementation plan, verifier proposal, policy pack, and risk recommendation. Use before preflight and before any real coding run.",
+        "Read-only planning step that turns an objective into bounded scope, verifier proposal, policy pack, and risk recommendation. Use for authorized software changes before preflight/run. Do not use to mutate files or replace the verifier. Next: call martin_preflight with the chosen scope, budget, and verifier.",
       annotations: {
         readOnlyHint: true,
         idempotentHint: true
@@ -1133,7 +1133,7 @@ export function createMartinMcpServer(serverInfo?: {
     {
       name: "martin_preflight",
       description:
-        "Read-only validation of a planned Martin run before any execution or spend. This is the last required step before martin_run.",
+        "Read-only validation of the exact run contract before execution or spend. Use after planning and before martin_run to check engine, verifier, path scope, and budget. Do not use as execution or completion proof. Next: call martin_run if allowed, otherwise resolve the reported blocker.",
       annotations: {
         readOnlyHint: true,
         idempotentHint: true
@@ -1349,7 +1349,7 @@ export function createMartinMcpServer(serverInfo?: {
     {
       name: "martin_triage_runs",
       description:
-        "Prioritize Martin runs that need operator or agent attention based on verification, lifecycle, and budget pressure.",
+        "Read-only prioritization of saved Martin runs that need attention. Use when the user says a prior attempt failed, asks what to fix next, or resumes an interrupted session. Do not use for a brand-new objective with no relevant run history. Next: inspect the selected run or dossier before retrying.",
       annotations: {
         readOnlyHint: true,
         idempotentHint: true
@@ -1505,7 +1505,7 @@ export function createMartinMcpServer(serverInfo?: {
     {
       name: "martin_dossier",
       description:
-        "Alias for martin_run_dossier with support for JSON, Markdown, or GitHub PR formatting. Use after martin_run to understand what happened and whether the result is actually safe to trust.",
+        "Read-only evidence summary for a Martin run, with JSON, Markdown, or GitHub PR formatting. Use after martin_run, before merge/release claims, or when sharing what happened. Do not use as a substitute for missing verifier evidence. Next: review verification results, retry, or hand off the receipt.",
       annotations: {
         readOnlyHint: true,
         idempotentHint: true
@@ -1639,7 +1639,7 @@ export function createMartinMcpServer(serverInfo?: {
     {
       name: "martin_estimate",
       description:
-        "Estimate the cost, recommended route, and Pre Work Burn for an objective without spending anything. Use before martin_run to understand what a task will cost.",
+        "Read-only cost, route, and pre-work burn estimate for a software objective. Use before planning/preflight when a change may spend agent time or exceed budget. Do not use for casual questions or as permission to execute. Next: call martin_plan if the estimate is acceptable, or ask for consent if budget/risk is high.",
       annotations: {
         readOnlyHint: true,
         idempotentHint: true

--- a/packages/mcp/tests/server-validation.test.ts
+++ b/packages/mcp/tests/server-validation.test.ts
@@ -611,6 +611,42 @@ describe("server validation", () => {
     expect(normalizedServerSource).toMatch(/attemptIndex:\s*\{\s*type:\s*"integer",\s*minimum:\s*1,/m);
   });
 
+  it("keeps starter tool descriptions aligned with proactive selection and MCP runtime admission", async () => {
+    const server = createMartinMcpServer() as unknown as ServerWithRequestHandlers;
+    const listTools = server._requestHandlers.get("tools/list");
+    if (!listTools) {
+      throw new Error("Expected tools/list request handler.");
+    }
+
+    const result = await listTools({ method: "tools/list" }, {}) as {
+      tools: Array<{ name: string; description?: string }>;
+    };
+    const descriptions = new Map(
+      result.tools.map((tool) => [tool.name, tool.description ?? ""])
+    );
+
+    for (const toolName of [
+      "martin_doctor",
+      "martin_estimate",
+      "martin_plan",
+      "martin_preflight",
+      "martin_run",
+      "martin_triage_runs",
+      "martin_dossier"
+    ]) {
+      const description = descriptions.get(toolName) ?? "";
+      expect(description, `${toolName} should tell the host when to use it`).toMatch(/\bUse\b/u);
+      expect(description, `${toolName} should tell the host when not to use it`).toMatch(/\bDo not use\b/u);
+      expect(description, `${toolName} should tell the host the likely next action`).toMatch(/\bNext:/u);
+    }
+
+    const runDescription = descriptions.get("martin_run") ?? "";
+    expect(runDescription).toContain("MCP workflow admission");
+    expect(runDescription).toContain("doctor/estimate/plan/preflight receipts");
+    expect(runDescription).not.toContain("hard-blocks until");
+    expect(runDescription).not.toContain("caller forgot");
+  });
+
   it("blocks martin_run before spend when the MCP receipt chain is missing", async () => {
     await withValidationRunsRoot(async () => {
       await withValidationWorkspaceRoot(async () => {


### PR DESCRIPTION
## Summary

Improves the Codex setup path so MartinLoop governance guidance can be installed into Codex instruction files when explicitly requested. Also clarifies starter MCP tool descriptions so agents get better guidance about when to use doctor, planning, preflight, governed runs, triage, and dossier evidence.

## Scope

Changed files are intentionally limited to:
- packages/cli/src/mcp-config.ts
- packages/cli/tests/mcp-config.test.ts
- packages/mcp/src/server.ts
- packages/mcp/tests/server-validation.test.ts

No version bump, tag, publish, release, hosted-service, or payment changes are included.

## Validation

- pnpm build
- pnpm --filter @martin/cli test -- tests/mcp-config.test.ts tests/auto-governance.test.ts tests/cli.test.ts
- pnpm --filter @martinloop/mcp test -- tests/mcp-discovery.test.ts tests/server-validation.test.ts tests/mcp-tools.test.ts
- pnpm --filter @martinloop/mcp smoke:pack
- pnpm release:validate:platforms
- pnpm public:promotion-guard
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Codex governance installation for project and user scopes.
  * Governance instructions can be safely updated while preserving existing content and line endings.
  * Added clearer guidance for MCP tools, including recommended workflows and appropriate tool usage.

* **Bug Fixes**
  * Prevented duplicate or malformed governance sections during installation.

* **Tests**
  * Added coverage for Codex installation, updates, formatting preservation, validation, and MCP tool guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->