### PR TITLE
Improve Glama MCP tool quality

### DIFF
--- a/.martin/promotion-manifest.json
+++ b/.martin/promotion-manifest.json
@@ -1,9 +1,10 @@
 {
   "schemaVersion": "martin.public-promotion.v1",
   "privateRepository": "martin-Loop/ML_Core_OSS_Internal",
-  "privateMergeSha": "c0c5b618a30dd453c6955966a88aa9c3e8c26db2",
-  "privateMainShaValidated": "c0c5b618a30dd453c6955966a88aa9c3e8c26db2",
-  "publicBaseSha": "1560565ab23239a0fbde2f48c58a9db445c6d43b",
-  "internalHealthPassed": true,
-  "validatedAt": "2026-08-29T18:23:16.000Z"
+  "privateMergeSha": "5f8274f34465045405d3642ef4e944ddf7d1f675",
+  "privateMainShaValidated": "5f8274f34465045405d3642ef4e944ddf7d1f675",
+  "publicBaseSha": "90f704a1417ac4cb8b4712c4cfaf44f55e92a76a",
+  "promotedBy": "Codex",
+  "validatedAt": "2026-09-02T00:54:54.280Z",
+  "internalHealthPassed": true
 }

--- a/packages/mcp/src/arcade/capabilities.ts
+++ b/packages/mcp/src/arcade/capabilities.ts
@@ -33,11 +33,85 @@ export function buildArcadeToolDefinitions(capabilities: unknown) {
     },
     {
       name: "martin_arcade_status",
-      description: "Read authoritative MartinLoop evidence for the Arcade view without changing run state.",
+      description:
+        "Read the read-only evidence projection used by the Arcade view. Provide loopId for one exact run or omit it to load the latest run. Use only for Arcade rendering; use martin_status for budget pressure or martin_run_dossier for full evidence. This tool reads persisted evidence and never changes run state.",
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false
+      },
       inputSchema: {
         type: "object",
         additionalProperties: false,
-        properties: { loopId: { type: "string" } }
+        properties: {
+          loopId: {
+            type: "string",
+            description: "Optional MartinLoop run identifier. Omit it to read the latest persisted run."
+          }
+        }
+      },
+      outputSchema: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          loopId: { type: "string", description: "Run identifier represented by this Arcade snapshot." },
+          lifecycleState: { type: "string", description: "Current persisted lifecycle state." },
+          completed: { type: "boolean", description: "Whether the run is outside an active lifecycle state." },
+          displayOutcome: {
+            anyOf: [
+              { type: "string", enum: ["VERIFIED", "STOPPED", "NEEDS REVIEW"] },
+              { type: "null" }
+            ],
+            description: "Terminal verified-handoff outcome, or null while the run is active."
+          },
+          verification: {
+            type: "object",
+            additionalProperties: true,
+            description: "Persisted verifier evidence summary."
+          },
+          receiptIntegrity: {
+            type: "object",
+            additionalProperties: true,
+            description: "Persisted receipt-integrity verdict."
+          },
+          attempts: { type: "integer", minimum: 0, description: "Number of recorded attempts." },
+          cost: {
+            type: "object",
+            additionalProperties: false,
+            properties: {
+              actualUsd: { type: "number" },
+              provenance: { type: "string" }
+            },
+            required: ["actualUsd", "provenance"]
+          },
+          budget: {
+            type: "object",
+            additionalProperties: false,
+            properties: {
+              maxUsd: { type: "number" },
+              remainingUsd: { type: "number" }
+            },
+            required: ["maxUsd", "remainingUsd"]
+          },
+          warnings: {
+            type: "array",
+            items: { type: "string" },
+            description: "Evidence or interpretation warnings for the Arcade view."
+          }
+        },
+        required: [
+          "loopId",
+          "lifecycleState",
+          "completed",
+          "displayOutcome",
+          "verification",
+          "receiptIntegrity",
+          "attempts",
+          "cost",
+          "budget",
+          "warnings"
+        ]
       },
       _meta: { ui: { visibility: ["app"] } }
     }

--- a/packages/mcp/src/discovery-metadata.ts
+++ b/packages/mcp/src/discovery-metadata.ts
@@ -85,6 +85,25 @@ export const MARTIN_PAID_REMOTE_TOOL_NAMES = [
   "martin_eval"
 ] as const;
 
+export const MARTIN_DIRECTORY_TOOL_NAMES = [
+  "martin_doctor",
+  "martin_estimate",
+  "martin_plan",
+  "martin_preflight",
+  "martin_run",
+  "martin_pause",
+  "martin_cancel",
+  "martin_continue",
+  "martin_list_runs",
+  "martin_triage_runs",
+  "martin_get_run",
+  "martin_get_verification_results",
+  "martin_dossier",
+  "martin_logs",
+  "martin_arcade",
+  "martin_arcade_status"
+] as const;
+
 export const MARTIN_RESOURCE_URIS = [
   "martin://server/health",
   "martin://runs/recent",
@@ -158,6 +177,7 @@ export function buildMartinDiscoveryMetadata(serverVersion: string): MartinDisco
     profiles: {
       minimal: [...MARTIN_MINIMAL_TOOL_NAMES],
       diagnostic: [...MARTIN_DIAGNOSTIC_TOOL_NAMES],
+      directory: [...MARTIN_DIRECTORY_TOOL_NAMES],
       "github-review": [...MARTIN_GITHUB_REVIEW_TOOL_NAMES],
       "full-local": [...MARTIN_TOOL_NAMES],
       starter: [...MARTIN_STARTER_TOOL_NAMES],

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -39,6 +39,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 
 import { MARTIN_MCP_PACKAGE_VERSION } from "./package-version.js";
+import { MARTIN_DIRECTORY_TOOL_NAMES } from "./discovery-metadata.js";
 import {
   MARTIN_ARCADE_FALLBACK_TEXT,
   MARTIN_ARCADE_MIME_TYPE,
@@ -84,6 +85,14 @@ const stringArraySchema = {
   type: "array",
   items: { type: "string" }
 } as const;
+
+export type MartinMcpToolProfile = "full" | "directory";
+
+const martinDirectoryToolNames = new Set<string>(MARTIN_DIRECTORY_TOOL_NAMES);
+
+export function shouldExposeMartinTool(name: string, profile: MartinMcpToolProfile): boolean {
+  return profile === "full" || martinDirectoryToolNames.has(name);
+}
 
 const loopPreviewSchema = {
   type: "object",
@@ -895,7 +904,9 @@ const prReviewOutputSchema = {
 export function createMartinMcpServer(serverInfo?: {
   name?: string;
   version?: string;
+  toolProfile?: MartinMcpToolProfile;
 }) {
+  const toolProfile = serverInfo?.toolProfile ?? "full";
   const server = new Server(
     {
       name: serverInfo?.name ?? "martin-loop",
@@ -1028,7 +1039,7 @@ export function createMartinMcpServer(serverInfo?: {
     {
       name: "martin_status",
       description:
-        "Return the current budget and cost state of a Martin loop record.",
+        "Read the current budget, cost, remaining limits, and stop pressure for one MartinLoop run. Provide exactly one selector: loopJson for an inline record, file for a saved record, loopId for a run-store ID, or latest for the newest run; runsDir only changes the run-store root. Use for a compact budget check. Do not use for full events or artifacts; use martin_get_run or martin_run_dossier instead.",
       annotations: {
         readOnlyHint: true,
         idempotentHint: true
@@ -1041,11 +1052,11 @@ export function createMartinMcpServer(serverInfo?: {
           file: {
             type: "string",
             description:
-              "Optional path under the Martin runs root to a loop-record.json file, a legacy .jsonl file, or a run-store directory."
+              "Path under the Martin runs root to a loop-record.json file, a legacy .jsonl file, or a run-store directory. Mutually exclusive with loopJson, loopId, and latest."
           },
           loopId: {
             type: "string",
-            description: "Loop ID resolved as <runsDir>/<loopId>/loop-record.json."
+            description: "Loop ID resolved as <runsDir>/<loopId>/loop-record.json. Mutually exclusive with loopJson, file, and latest."
           },
           runsDir: {
             type: "string",
@@ -1053,7 +1064,7 @@ export function createMartinMcpServer(serverInfo?: {
           },
           latest: {
             const: true,
-            description: "When true, loads the most recently updated loop record in the runs directory."
+            description: "When true, loads the most recently updated loop record. Mutually exclusive with loopJson, file, and loopId."
           }
         },
         oneOf: [
@@ -1250,7 +1261,7 @@ export function createMartinMcpServer(serverInfo?: {
     {
       name: "martin_pause",
       description:
-        "Record a durable pause request for a Martin run so humans and runtimes can see that execution should pause before risky follow-up work.",
+        "Write a durable pause receipt for one canonical MartinLoop run. Provide exactly one selector: file, loopId, or latest; runsDir changes the run-store root, while reason and requestedBy add audit context. Use for a temporary hold before risky follow-up work. This records a request and does not kill a process; use martin_cancel to abandon work or martin_continue to resume.",
       annotations: {
         destructiveHint: true,
         idempotentHint: false
@@ -1259,12 +1270,12 @@ export function createMartinMcpServer(serverInfo?: {
         type: "object",
         additionalProperties: false,
         properties: {
-          file: { type: "string" },
-          loopId: { type: "string" },
-          runsDir: { type: "string" },
-          latest: { const: true },
-          reason: { type: "string" },
-          requestedBy: { type: "string" }
+          file: { type: "string", description: "Path to one canonical run record or directory. Mutually exclusive with loopId and latest." },
+          loopId: { type: "string", description: "Canonical MartinLoop run identifier. Mutually exclusive with file and latest." },
+          runsDir: { type: "string", description: "Optional run-store root override used to resolve loopId or latest." },
+          latest: { const: true, description: "When true, targets the latest canonical run. Mutually exclusive with file and loopId." },
+          reason: { type: "string", description: "Optional non-empty reason recorded in the pause receipt." },
+          requestedBy: { type: "string", description: "Optional human or runtime identity label recorded for audit context." }
         },
         oneOf: [{ required: ["file"] }, { required: ["loopId"] }, { required: ["latest"] }]
       },
@@ -1273,7 +1284,7 @@ export function createMartinMcpServer(serverInfo?: {
     {
       name: "martin_cancel",
       description:
-        "Record a durable cancellation request for a Martin run. This writes a control receipt; it does not silently kill a process without evidence.",
+        "Write a durable cancellation receipt for one canonical MartinLoop run. Provide exactly one selector: file, loopId, or latest; runsDir changes the run-store root, while reason and requestedBy add audit context. Use when work must be abandoned, not temporarily held. This records a request and does not kill a process; use martin_pause for a reversible hold.",
       annotations: {
         destructiveHint: true,
         idempotentHint: false
@@ -1282,12 +1293,12 @@ export function createMartinMcpServer(serverInfo?: {
         type: "object",
         additionalProperties: false,
         properties: {
-          file: { type: "string" },
-          loopId: { type: "string" },
-          runsDir: { type: "string" },
-          latest: { const: true },
-          reason: { type: "string" },
-          requestedBy: { type: "string" }
+          file: { type: "string", description: "Path to one canonical run record or directory. Mutually exclusive with loopId and latest." },
+          loopId: { type: "string", description: "Canonical MartinLoop run identifier. Mutually exclusive with file and latest." },
+          runsDir: { type: "string", description: "Optional run-store root override used to resolve loopId or latest." },
+          latest: { const: true, description: "When true, targets the latest canonical run. Mutually exclusive with file and loopId." },
+          reason: { type: "string", description: "Optional non-empty reason recorded in the cancellation receipt." },
+          requestedBy: { type: "string", description: "Optional human or runtime identity label recorded for audit context." }
         },
         oneOf: [{ required: ["file"] }, { required: ["loopId"] }, { required: ["latest"] }]
       },
@@ -1474,7 +1485,7 @@ export function createMartinMcpServer(serverInfo?: {
     {
       name: "martin_run_dossier",
       description:
-        "Return the full governed execution dossier for one Martin run, including attempts, events, artifacts, and related discovery surfaces.",
+        "Read the full structured execution dossier for one MartinLoop run, including attempts, events, artifacts, verification, integrity, cost, and related discovery surfaces. Provide exactly one selector: file, loopId, or latest; runsDir changes the run-store root. Use for comprehensive evidence review. Do not use for a compact state check; use martin_get_run, or use martin_dossier when formatted sharing output is required.",
       annotations: {
         readOnlyHint: true,
         idempotentHint: true
@@ -1485,13 +1496,13 @@ export function createMartinMcpServer(serverInfo?: {
         properties: {
           file: {
             type: "string",
-            description: "Path to a canonical loop-record.json, legacy file, or run-store directory."
+            description: "Path to a canonical loop-record.json, legacy file, or run-store directory. Mutually exclusive with loopId and latest."
           },
-          loopId: { type: "string", description: "Loop ID under the run store." },
-          runsDir: { type: "string", description: "Optional runs-root override." },
+          loopId: { type: "string", description: "Loop ID under the run store. Mutually exclusive with file and latest." },
+          runsDir: { type: "string", description: "Optional run-store root override used to resolve loopId or latest." },
           latest: {
             const: true,
-            description: "When true, loads the most recently updated loop record in the run store."
+            description: "When true, loads the most recently updated loop record. Mutually exclusive with file and loopId."
           }
         },
         oneOf: [
@@ -1505,7 +1516,7 @@ export function createMartinMcpServer(serverInfo?: {
     {
       name: "martin_dossier",
       description:
-        "Read-only evidence summary for a Martin run, with JSON, Markdown, or GitHub PR formatting. Use after martin_run, before merge/release claims, or when sharing what happened. Do not use as a substitute for missing verifier evidence. Next: review verification results, retry, or hand off the receipt.",
+        "Read a formatted evidence summary for one MartinLoop run. Provide exactly one selector: file, loopId, or latest; runsDir changes the run-store root. Set format to json, md, or github-pr; json is the default. Use after martin_run, before merge or release claims, or when sharing what happened. Do not use as a substitute for missing verifier evidence; use martin_run_dossier for the full structured record. Next: review verification results, retry, or hand off the receipt.",
       annotations: {
         readOnlyHint: true,
         idempotentHint: true
@@ -1514,11 +1525,11 @@ export function createMartinMcpServer(serverInfo?: {
         type: "object",
         additionalProperties: false,
         properties: {
-          file: { type: "string" },
-          loopId: { type: "string" },
-          runsDir: { type: "string" },
-          latest: { const: true },
-          format: { type: "string", enum: ["json", "md", "github-pr"] }
+          file: { type: "string", description: "Path to one run record or directory. Mutually exclusive with loopId and latest." },
+          loopId: { type: "string", description: "MartinLoop run identifier. Mutually exclusive with file and latest." },
+          runsDir: { type: "string", description: "Optional run-store root override used to resolve loopId or latest." },
+          latest: { const: true, description: "When true, loads the latest run. Mutually exclusive with file and loopId." },
+          format: { type: "string", enum: ["json", "md", "github-pr"], description: "Output format. Defaults to json." }
         },
         oneOf: [{ required: ["file"] }, { required: ["loopId"] }, { required: ["latest"] }]
       },
@@ -1695,7 +1706,7 @@ export function createMartinMcpServer(serverInfo?: {
       }
     },
     ...buildArcadeToolDefinitions(server.getClientCapabilities())
-  ]
+  ].filter((tool) => shouldExposeMartinTool(tool.name, toolProfile))
   }));
 
   server.setRequestHandler(ListResourcesRequestSchema, () => {
@@ -2113,8 +2124,10 @@ function normalizeRunBudget(input: Parameters<typeof runLoopTool>[0]): LoopBudge
   });
 }
 
-export async function connectMartinMcpStdioServer() {
-  const server = createMartinMcpServer();
+export async function connectMartinMcpStdioServer(options: { toolProfile?: MartinMcpToolProfile } = {}) {
+  const server = createMartinMcpServer({
+    ...(options.toolProfile ? { toolProfile: options.toolProfile } : {})
+  });
   const transport = new StdioServerTransport();
   await server.connect(transport);
   return server;
@@ -2124,6 +2137,7 @@ export interface MartinMcpHttpServerOptions {
   host?: string;
   port?: number;
   path?: string;
+  toolProfile?: MartinMcpToolProfile;
 }
 
 export interface MartinMcpHttpServerHandle {
@@ -2135,21 +2149,32 @@ export interface MartinMcpHttpServerHandle {
   close: () => Promise<void>;
 }
 
-export function parseMartinMcpServerArgs(argv: string[]): { transport: "stdio" } | {
+export function parseMartinMcpServerArgs(argv: string[]): { transport: "stdio"; toolProfile?: MartinMcpToolProfile } | {
   transport: "http";
   host: string;
   port: number;
   path: string;
+  toolProfile?: MartinMcpToolProfile;
 } {
   let transport: "stdio" | "http" = "stdio";
   let host = "127.0.0.1";
   let port = 3033;
   let path = "/mcp";
+  let toolProfile: MartinMcpToolProfile | undefined;
 
   for (let index = 0; index < argv.length; index += 1) {
     const token = argv[index];
     if (token === "--http") {
       transport = "http";
+      continue;
+    }
+    if (token === "--tool-profile") {
+      const next = argv[index + 1];
+      if (next !== "full" && next !== "directory") {
+        throw new Error(`Invalid --tool-profile value '${next ?? ""}'.`);
+      }
+      toolProfile = next;
+      index += 1;
       continue;
     }
     if (token === "--port") {
@@ -2182,8 +2207,8 @@ export function parseMartinMcpServerArgs(argv: string[]): { transport: "stdio" }
   }
 
   return transport === "http"
-    ? { transport, host, port, path }
-    : { transport };
+    ? { transport, host, port, path, ...(toolProfile ? { toolProfile } : {}) }
+    : { transport, ...(toolProfile ? { toolProfile } : {}) };
 }
 
 export async function connectMartinMcpHttpServer(
@@ -2193,7 +2218,9 @@ export async function connectMartinMcpHttpServer(
   const port = options.port ?? 3033;
   const path = options.path ?? "/mcp";
 
-  const mcpServer = createMartinMcpServer();
+  const mcpServer = createMartinMcpServer({
+    ...(options.toolProfile ? { toolProfile: options.toolProfile } : {})
+  });
   const transport = new StreamableHTTPServerTransport({
     sessionIdGenerator: undefined
   });
@@ -2291,7 +2318,7 @@ if (isDirectExecution()) {
   if (startup.transport === "http") {
     await connectMartinMcpHttpServer(startup);
   } else {
-    await connectMartinMcpStdioServer();
+    await connectMartinMcpStdioServer({ toolProfile: startup.toolProfile });
   }
 }
 

--- a/packages/mcp/tests/arcade-app.test.ts
+++ b/packages/mcp/tests/arcade-app.test.ts
@@ -70,7 +70,23 @@ describe("Arcade MCP App capability contract", () => {
     expect(tools.find((tool) => tool.name === "martin_arcade_status")?.inputSchema).toEqual({
       type: "object",
       additionalProperties: false,
-      properties: { loopId: { type: "string" } }
+      properties: {
+        loopId: {
+          type: "string",
+          description: "Optional MartinLoop run identifier. Omit it to read the latest persisted run."
+        }
+      }
+    });
+    expect(tools.find((tool) => tool.name === "martin_arcade_status")?.annotations).toEqual({
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false
+    });
+    expect(tools.find((tool) => tool.name === "martin_arcade_status")?.outputSchema).toMatchObject({
+      type: "object",
+      additionalProperties: false,
+      required: expect.arrayContaining(["loopId", "displayOutcome", "verification", "receiptIntegrity"])
     });
   });
 

--- a/packages/mcp/tests/server-validation.test.ts
+++ b/packages/mcp/tests/server-validation.test.ts
@@ -28,7 +28,8 @@ import {
 import {
   connectMartinMcpHttpServer,
   createMartinMcpServer,
-  parseMartinMcpServerArgs
+  parseMartinMcpServerArgs,
+  shouldExposeMartinTool
 } from "../src/server.js";
 
 type ServerRequestHandler = (request: unknown, extra: unknown) => Promise<unknown>;
@@ -517,6 +518,37 @@ describe("server validation", () => {
       path: "/bridge"
     });
     expect(() => parseMartinMcpServerArgs(["--http", "--port", "NaN"])).toThrow("Invalid --port value");
+    expect(parseMartinMcpServerArgs(["--tool-profile", "directory"])).toEqual({
+      transport: "stdio",
+      toolProfile: "directory"
+    });
+    expect(() => parseMartinMcpServerArgs(["--tool-profile", "unknown"])).toThrow(
+      "Invalid --tool-profile value"
+    );
+  });
+
+  it("offers a focused directory profile without changing the full tool surface", async () => {
+    const fullServer = createMartinMcpServer() as unknown as ServerWithRequestHandlers;
+    const directoryServer = createMartinMcpServer({ toolProfile: "directory" }) as unknown as ServerWithRequestHandlers;
+    const fullListTools = fullServer._requestHandlers.get("tools/list");
+    const directoryListTools = directoryServer._requestHandlers.get("tools/list");
+    if (!fullListTools || !directoryListTools) {
+      throw new Error("Expected tools/list request handlers.");
+    }
+
+    const fullResult = await fullListTools({ method: "tools/list" }, {}) as { tools: Array<{ name: string }> };
+    const directoryResult = await directoryListTools({ method: "tools/list" }, {}) as { tools: Array<{ name: string }> };
+    const directoryNames = directoryResult.tools.map((tool) => tool.name);
+
+    expect(fullResult.tools).toHaveLength(24);
+    expect(directoryResult.tools).toHaveLength(16);
+    expect(directoryNames).toContain("martin_arcade_status");
+    expect(directoryNames).toContain("martin_cancel");
+    expect(directoryNames).not.toContain("martin_status");
+    expect(directoryNames).not.toContain("martin_inspect");
+    expect(directoryNames).not.toContain("martin_run_dossier");
+    expect(shouldExposeMartinTool("martin_status", "full")).toBe(true);
+    expect(shouldExposeMartinTool("martin_status", "directory")).toBe(false);
   });
 
   it("serves the MCP endpoint over streamable HTTP", async () => {
@@ -645,6 +677,46 @@ describe("server validation", () => {
     expect(runDescription).toContain("doctor/estimate/plan/preflight receipts");
     expect(runDescription).not.toContain("hard-blocks until");
     expect(runDescription).not.toContain("caller forgot");
+  });
+
+  it("keeps Glama-sensitive tool definitions explicit and disambiguated", async () => {
+    const server = createMartinMcpServer() as unknown as ServerWithRequestHandlers;
+    const listTools = server._requestHandlers.get("tools/list");
+    if (!listTools) {
+      throw new Error("Expected tools/list request handler.");
+    }
+
+    const result = await listTools({ method: "tools/list" }, {}) as {
+      tools: Array<{
+        name: string;
+        description?: string;
+        inputSchema?: { properties?: Record<string, { description?: string }> };
+      }>;
+    };
+    const tools = new Map(result.tools.map((tool) => [tool.name, tool]));
+
+    for (const toolName of [
+      "martin_arcade_status",
+      "martin_cancel",
+      "martin_dossier",
+      "martin_pause",
+      "martin_run_dossier",
+      "martin_status"
+    ]) {
+      const description = tools.get(toolName)?.description ?? "";
+      expect(description, `${toolName} should tell agents when to use it`).toMatch(/\bUse\b/u);
+      expect(description, `${toolName} should route agents to a sibling when appropriate`).toMatch(/\buse martin_/u);
+    }
+
+    for (const toolName of ["martin_cancel", "martin_dossier", "martin_pause"]) {
+      const properties = tools.get(toolName)?.inputSchema?.properties ?? {};
+      for (const propertyName of Object.keys(properties)) {
+        expect(
+          properties[propertyName]?.description,
+          `${toolName}.${propertyName} should explain its selector or audit role`
+        ).toBeTruthy();
+      }
+    }
   });
 
   it("blocks martin_run before spend when the MCP receipt chain is missing", async () => {


### PR DESCRIPTION
## Summary

Promotes the reviewed public-safe MCP tool-definition improvements from private main.

- adds complete schemas, annotations, and routing guidance for lower-scoring Glama tools
- keeps `martin_cancel` correctly marked destructive while clarifying its durable-request semantics
- adds a focused 16-tool `directory` discovery profile for hosted directories
- keeps the default/full 24-tool MCP surface unchanged for existing users
- adds regression coverage for both tool definitions and profile selection

## Promotion provenance

- Private merge: `5f8274f34465045405d3642ef4e944ddf7d1f675`
- Validated private main: `5f8274f34465045405d3642ef4e944ddf7d1f675`
- Public base: `90f704a1417ac4cb8b4712c4cfaf44f55e92a76a`
- Fresh private-main release validation: macOS, Ubuntu, and Windows all passed
- Promotion manifest: `.martin/promotion-manifest.json`

## Scope

No version bump, package publication, tag, release, or default runtime behavior change is included. Glama can opt into the focused profile with:

```
node packages/mcp/dist/server.js --tool-profile directory
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a directory tool profile that exposes a focused subset of MCP tools.
  - Added support for selecting the tool profile through server configuration or the command line.
  - Enhanced Arcade status output with structured verification, receipt, attempt, cost, budget, and warning details.

- **Documentation**
  - Clarified tool usage, selector rules, audit context, and read-only behavior.
  - Added clearer input and output schema descriptions for improved interoperability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->