### PR TITLE
docs(release): mark MartinLoop 0.6.0 live

### DIFF
--- a/docs/release/VERSION-LEDGER.md
+++ b/docs/release/VERSION-LEDGER.md
@@ -4,10 +4,10 @@ This file is the release source of truth for package/version mapping in this rep
 
 ## Root package: `martin-loop`
 
-- live npm dist-tag `latest`: `0.5.8`
-- live public GitHub release: `v0.5.8`
-- live public baseline in this train: `0.5.8`
-- root public baseline: `0.5.8`
+- live npm dist-tag `latest`: `0.6.0`
+- live public GitHub release: `v0.6.0`
+- live public baseline in this train: `0.6.0`
+- root public baseline: `0.6.0`
 - releases consumed since the original `0.2.8` launch:
   - `0.2.9` fixed proof-run classification, Windows `.cmd` resolution, and public provider defaults
   - `0.2.10` tightened verifier evidence, `--runs-dir` consistency, and public help output
@@ -32,21 +32,22 @@ This file is the release source of truth for package/version mapping in this rep
   - `0.5.4` provider-neutral governed autonomy and exact-binary Codex negotiation
   - `0.5.5` governed-autonomous execution with deterministic install metadata
   - `0.5.6` portable MCP package validation, read-only Arcade resources, hosted sync contract alignment, and permanent release-authority gates
-- current in-repo root release target: `0.6.0` (pending publication)
+  - `0.6.0` hardened verifier evidence, stale MCP host refresh, empty-objective rejection, demo Git readiness, and non-blocking version upgrade notices
+- current in-repo root release: `0.6.0` (published)
 - next planned root follow-on: not scheduled
 
 ## Standalone package: `@martinloop/mcp`
 
-- live npm dist-tag `latest`: `0.5.8`
-- live public GitHub release: `mcp-v0.5.8`
-- live public baseline in this train: `0.5.8`
-- standalone MCP public baseline: `0.5.8`
+- live npm dist-tag `latest`: `0.6.0`
+- live public GitHub release: `mcp-v0.6.0`
+- live public baseline in this train: `0.6.0`
+- standalone MCP public baseline: `0.6.0`
 - official MCP Registry version: `0.5.5` (verified)
-- live MCPB baseline: `0.5.5`
-- live MCPB SHA-256: `6f3da0e77978a47bbc7ffec8db6b3a42bff2cb7e8642372523eab53af79c05d2`
-- live MCPB size: `8,113,133` bytes
-- current in-repo standalone release target: `0.6.0` (pending publication)
-- current in-repo MCPB release target: `0.6.0` with manifest schema `0.3` (pending publication)
+- live MCPB baseline: `0.6.0`
+- live MCPB SHA-256: `142acf1ce5a7b837c75b9c21327c4d008e6f6d55f295abc8ecc48a834cbf0be0`
+- live MCPB size: `7,302,987` bytes
+- current in-repo standalone release: `0.6.0` (published)
+- current in-repo MCPB release: `0.6.0` with manifest schema `0.3` (published)
 - next planned standalone release: not scheduled
 
 ## Release rules

--- a/scripts/tests/mcp-release-docs.test.mjs
+++ b/scripts/tests/mcp-release-docs.test.mjs
@@ -26,26 +26,38 @@ test("current MCP metadata stays aligned for the release cut", async () => {
   await access(releaseNotesPath);
 });
 
-test("version ledger separates live public truth from the pending release target", async () => {
+test("version ledger records the published release as live public truth", async () => {
   const ledger = await readRepoFile(path.join("docs", "release", "VERSION-LEDGER.md"));
 
-  assert.match(ledger, new RegExp(escapeRegex("live npm dist-tag `latest`: `0.5.8`")));
-  assert.match(ledger, new RegExp(escapeRegex("live public GitHub release: `v0.5.8`")));
-  assert.match(ledger, new RegExp(escapeRegex("live public GitHub release: `mcp-v0.5.8`")));
-  assert.match(ledger, /root public baseline: `\d+\.\d+\.\d+`/);
-  assert.match(ledger, /live public GitHub release: `v\d+\.\d+\.\d+`/);
   assert.match(
     ledger,
-    new RegExp(escapeRegex("standalone MCP public baseline: `0.5.8`")),
+    new RegExp(escapeRegex(`live npm dist-tag \`latest\`: \`${rootPackageJson.version}\``)),
   );
   assert.match(
     ledger,
-    new RegExp(escapeRegex(`current in-repo standalone release target: \`${packageJson.version}\` (pending publication)`))
+    new RegExp(escapeRegex(`live public GitHub release: \`v${rootPackageJson.version}\``)),
   );
   assert.match(
     ledger,
-    new RegExp(escapeRegex(`current in-repo root release target: \`${rootPackageJson.version}\` (pending publication)`))
+    new RegExp(escapeRegex(`live public GitHub release: \`mcp-v${packageJson.version}\``)),
   );
+  assert.match(
+    ledger,
+    new RegExp(escapeRegex(`root public baseline: \`${rootPackageJson.version}\``)),
+  );
+  assert.match(
+    ledger,
+    new RegExp(escapeRegex(`standalone MCP public baseline: \`${packageJson.version}\``)),
+  );
+  assert.match(
+    ledger,
+    new RegExp(escapeRegex(`current in-repo standalone release: \`${packageJson.version}\` (published)`)),
+  );
+  assert.match(
+    ledger,
+    new RegExp(escapeRegex(`current in-repo root release: \`${rootPackageJson.version}\` (published)`)),
+  );
+  assert.doesNotMatch(ledger, /current in-repo .*pending publication/);
   assert.match(ledger, /next planned root follow-on: not scheduled/);
   assert.match(ledger, /next planned standalone release: not scheduled/);
 });


### PR DESCRIPTION
Updates the version ledger after trusted publishing completed successfully.

Verified live state:
- `martin-loop@0.6.0` published and availability checked by the trusted root release workflow
- root published-artifact E2E passed
- GitHub release `v0.6.0` exists with `martin-loop-0.6.0.tgz`
- `@martinloop/mcp@0.6.0` published and verified by the trusted MCP workflow
- GitHub release `mcp-v0.6.0` exists with MCPB + checksum
- live MCPB SHA-256 and size recorded from the release asset
- official MCP Registry remains at the last separately verified registry version; this update does not infer registry publication from npm

No tags, package versions, or `min-supported` state are changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the version ledger to record the completed publication of the 0.6.0 release.
  - Synchronized release status, version references, package metadata, checksums, and artifact size for the root package and MCP package.
  - Added 0.6.0 to the release history and marked previously pending release entries as published.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->