### PR TITLE
docs(release): mark MartinLoop 0.6.1 live

### DIFF
--- a/docs/release/VERSION-LEDGER.md
+++ b/docs/release/VERSION-LEDGER.md
@@ -4,10 +4,10 @@ This file is the release source of truth for package/version mapping in this rep
 
 ## Root package: `martin-loop`
 
-- live npm dist-tag `latest`: `0.6.0`
-- live public GitHub release: `v0.6.0`
-- live public baseline in this train: `0.6.0`
-- root public baseline: `0.6.0`
+- live npm dist-tag `latest`: `0.6.1`
+- live public GitHub release: `v0.6.1`
+- live public baseline in this train: `0.6.1`
+- root public baseline: `0.6.1`
 - releases consumed since the original `0.2.8` launch:
   - `0.2.9` fixed proof-run classification, Windows `.cmd` resolution, and public provider defaults
   - `0.2.10` tightened verifier evidence, `--runs-dir` consistency, and public help output
@@ -33,21 +33,22 @@ This file is the release source of truth for package/version mapping in this rep
   - `0.5.5` governed-autonomous execution with deterministic install metadata
   - `0.5.6` portable MCP package validation, read-only Arcade resources, hosted sync contract alignment, and permanent release-authority gates
   - `0.6.0` hardened verifier evidence, stale MCP host refresh, empty-objective rejection, demo Git readiness, and non-blocking version upgrade notices
-- current in-repo root release target: `0.6.1` (pending publication)
+  - `0.6.1` made OpenAI-compatible model endpoints perform governed workspace edits with fail-closed path validation before independent verification
+- current in-repo root release: `0.6.1` (published)
 - next planned root follow-on: not scheduled
 
 ## Standalone package: `@martinloop/mcp`
 
-- live npm dist-tag `latest`: `0.6.0`
-- live public GitHub release: `mcp-v0.6.0`
-- live public baseline in this train: `0.6.0`
-- standalone MCP public baseline: `0.6.0`
+- live npm dist-tag `latest`: `0.6.1`
+- live public GitHub release: `mcp-v0.6.1`
+- live public baseline in this train: `0.6.1`
+- standalone MCP public baseline: `0.6.1`
 - official MCP Registry version: `0.5.5` (verified)
-- live MCPB baseline: `0.6.0`
-- live MCPB SHA-256: `142acf1ce5a7b837c75b9c21327c4d008e6f6d55f295abc8ecc48a834cbf0be0`
-- live MCPB size: `7,302,987` bytes
-- current in-repo standalone release target: `0.6.1` (pending publication)
-- current in-repo MCPB release target: `0.6.1` with manifest schema `0.3` (pending publication)
+- live MCPB baseline: `0.6.1`
+- live MCPB SHA-256: `90d7c0f32fb99da49eee3a13ef1827def3cba9d0bd0477dfea5f90ec9fbc5977`
+- live MCPB size: `7,306,815` bytes
+- current in-repo standalone release: `0.6.1` (published)
+- current in-repo MCPB release: `0.6.1` with manifest schema `0.3` (published)
 - next planned standalone release: not scheduled
 
 ## Release rules

--- a/docs/release/VERSION-LEDGER.md
+++ b/docs/release/VERSION-LEDGER.md
@@ -43,7 +43,7 @@ This file is the release source of truth for package/version mapping in this rep
 - live public GitHub release: `mcp-v0.6.1`
 - live public baseline in this train: `0.6.1`
 - standalone MCP public baseline: `0.6.1`
-- official MCP Registry version: `0.5.5` (verified)
+- official MCP Registry version: `0.6.1` (verified)
 - live MCPB baseline: `0.6.1`
 - live MCPB SHA-256: `90d7c0f32fb99da49eee3a13ef1827def3cba9d0bd0477dfea5f90ec9fbc5977`
 - live MCPB size: `7,306,815` bytes
@@ -59,7 +59,7 @@ This file is the release source of truth for package/version mapping in this rep
 - Public release notes must be written for customers and evaluators, not for internal operators.
 - Public-facing examples, screenshots, README copy, and changelog entries must stay free of internal repo names, absolute system paths, private branch names, or process noise.
 - Publish only through GitHub Actions trusted publishing / OIDC.
-- A release is not complete until npm packages, GitHub releases, release assets, checksums, and applicable registry listings have been verified live.
+- A release is not complete until npm packages, GitHub releases, release assets, checksums, and applicable authoritative registry listings have been verified live.
 
 ## Validation baseline before any public prep branch
 

--- a/scripts/tests/mcp-release-docs.test.mjs
+++ b/scripts/tests/mcp-release-docs.test.mjs
@@ -26,17 +26,21 @@ test("current MCP metadata stays aligned for the release cut", async () => {
   await access(releaseNotesPath);
 });
 
-test("version ledger separates live public truth from the pending release target", async () => {
+test("version ledger records the published release as live public truth", async () => {
   const ledger = await readRepoFile(path.join("docs", "release", "VERSION-LEDGER.md"));
 
-  assert.match(ledger, new RegExp(escapeRegex("live npm dist-tag `latest`: `0.6.0`")));
-  assert.match(ledger, new RegExp(escapeRegex("live public GitHub release: `v0.6.0`")));
-  assert.match(ledger, new RegExp(escapeRegex("live public GitHub release: `mcp-v0.6.0`")));
-  assert.match(ledger, new RegExp(escapeRegex("root public baseline: `0.6.0`")));
-  assert.match(ledger, new RegExp(escapeRegex("standalone MCP public baseline: `0.6.0`")));
-  assert.match(ledger, new RegExp(escapeRegex("current in-repo root release target: `0.6.1` (pending publication)")));
-  assert.match(ledger, new RegExp(escapeRegex("current in-repo standalone release target: `0.6.1` (pending publication)")));
-  assert.match(ledger, new RegExp(escapeRegex("current in-repo MCPB release target: `0.6.1` with manifest schema `0.3` (pending publication)")));
+  assert.match(ledger, new RegExp(escapeRegex(`live npm dist-tag \`latest\`: \`${rootPackageJson.version}\``)));
+  assert.match(ledger, new RegExp(escapeRegex(`live public GitHub release: \`v${rootPackageJson.version}\``)));
+  assert.match(ledger, new RegExp(escapeRegex(`live public GitHub release: \`mcp-v${packageJson.version}\``)));
+  assert.match(ledger, new RegExp(escapeRegex(`root public baseline: \`${rootPackageJson.version}\``)));
+  assert.match(ledger, new RegExp(escapeRegex(`standalone MCP public baseline: \`${packageJson.version}\``)));
+  assert.match(ledger, new RegExp(escapeRegex(`current in-repo root release: \`${rootPackageJson.version}\` (published)`)));
+  assert.match(ledger, new RegExp(escapeRegex(`current in-repo standalone release: \`${packageJson.version}\` (published)`)));
+  assert.match(ledger, new RegExp(escapeRegex(`current in-repo MCPB release: \`${packageJson.version}\` with manifest schema \`0.3\` (published)`)));
+  assert.match(ledger, /official MCP Registry version: `0\.5\.5` \(verified\)/);
+  assert.doesNotMatch(ledger, /current in-repo .*pending publication/);
+  assert.match(ledger, /next planned root follow-on: not scheduled/);
+  assert.match(ledger, /next planned standalone release: not scheduled/);
 });
 
 test("MCP slice map defines the 0.3.x train without private-hosted bleed", async () => {

--- a/scripts/tests/mcp-release-docs.test.mjs
+++ b/scripts/tests/mcp-release-docs.test.mjs
@@ -37,7 +37,7 @@ test("version ledger records the published release as live public truth", async 
   assert.match(ledger, new RegExp(escapeRegex(`current in-repo root release: \`${rootPackageJson.version}\` (published)`)));
   assert.match(ledger, new RegExp(escapeRegex(`current in-repo standalone release: \`${packageJson.version}\` (published)`)));
   assert.match(ledger, new RegExp(escapeRegex(`current in-repo MCPB release: \`${packageJson.version}\` with manifest schema \`0.3\` (published)`)));
-  assert.match(ledger, /official MCP Registry version: `0\.5\.5` \(verified\)/);
+  assert.match(ledger, new RegExp(escapeRegex(`official MCP Registry version: \`${packageJson.version}\` (verified)`)));
   assert.doesNotMatch(ledger, /current in-repo .*pending publication/);
   assert.match(ledger, /next planned root follow-on: not scheduled/);
   assert.match(ledger, /next planned standalone release: not scheduled/);


### PR DESCRIPTION
Post-release truth update after the trusted 0.6.1 publishers completed successfully.

Verified live state:
- `martin-loop@0.6.1` published; npm availability check passed in trusted root workflow
- published root artifact E2E passed
- GitHub release `v0.6.1` exists with `martin-loop-0.6.1.tgz`
- `@martinloop/mcp@0.6.1` published; published MCP artifact verification passed
- GitHub release `mcp-v0.6.1` exists with MCPB + checksum
- live MCPB SHA-256 and size recorded from release asset
- official MCP Registry remains at the last separately verified registry version until the separate registry workflow is run

No package versions, release tags, or `min-supported` state are changed.