### PR TITLE
chore(release): trigger trusted MCP registry registration

### DIFF
--- a/.github/workflows/register-current-mcp.yml
+++ b/.github/workflows/register-current-mcp.yml
@@ -7,6 +7,7 @@ on:
         description: Existing mcp-vX.Y.Z tag to register
         required: true
         type: string
+  # A workflow-file update merged to main intentionally registers the current aligned MCP release.
   push:
     branches:
       - main


### PR DESCRIPTION
Documents the existing main-branch workflow-file trigger. When this workflow-only change merges to `main`, the existing trusted OIDC job registers the current aligned `@martinloop/mcp` release and verifies both the official MCP Registry and MCPCentral.

No package/runtime/version/min-supported state changes.