### PR TITLE
fix(adapters): require Codex launch-probe provenance

### DIFF
--- a/packages/adapters/src/codex-capabilities.ts
+++ b/packages/adapters/src/codex-capabilities.ts
@@ -70,6 +70,20 @@ export interface CodexExecArgsOptions {
 
 type SpawnSyncLike = typeof spawnSync;
 const capabilityCache = new Map<string, CodexCapabilityProfile>();
+const launchProbeVerifiedAutonomyResolutions = new WeakSet<CodexAutonomyResolution>();
+
+export function markCodexAutonomyResolutionVerifiedByLaunchProbe(
+  resolution: CodexAutonomyResolution
+): CodexAutonomyResolution {
+  launchProbeVerifiedAutonomyResolutions.add(resolution);
+  return resolution;
+}
+
+export function isCodexAutonomyResolutionVerifiedByLaunchProbe(
+  resolution: CodexAutonomyResolution
+): boolean {
+  return launchProbeVerifiedAutonomyResolutions.has(resolution);
+}
 
 function escapeRegex(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");

--- a/packages/adapters/src/codex-cli.ts
+++ b/packages/adapters/src/codex-cli.ts
@@ -7,6 +7,7 @@ import {
 import {
   buildCodexExecArgs,
   buildCodexStdin,
+  isCodexAutonomyResolutionVerifiedByLaunchProbe,
   probeCodexCapabilities,
   type CodexAutonomyResolution,
   type CodexCapabilityProfile
@@ -67,6 +68,9 @@ export function createCodexCliAdapter(options: CodexCliAdapterOptions = {}) {
   }
   if (autonomyResolution && autonomyResolution.binaryPath !== selectedBinary) {
     throw new Error("Codex exact binary autonomy resolution mismatch.");
+  }
+  if (autonomyResolution && !isCodexAutonomyResolutionVerifiedByLaunchProbe(autonomyResolution)) {
+    throw new Error("Codex autonomy resolution was not verified by the launch probe.");
   }
   const sandbox = options.sandbox ?? "workspace-write";
   const extraArgs = options.extraArgs ?? [];

--- a/packages/adapters/src/codex-launcher.ts
+++ b/packages/adapters/src/codex-launcher.ts
@@ -1,8 +1,13 @@
 import {
   buildCodexExecArgs as buildCapabilityDrivenCodexExecArgs,
+  markCodexAutonomyResolutionVerifiedByLaunchProbe,
   type CodexCapabilityProfile,
   type CodexExecArgsOptions
 } from "./codex-capabilities.js";
+import {
+  probeCodexLaunch as probeCodexLaunchHost,
+  type CodexLaunchProbeResult
+} from "./codex-host.js";
 
 /**
  * Compatibility facade for callers that still populate the original
@@ -27,11 +32,27 @@ export function buildCodexExecArgs(options: CodexExecArgsOptions): string[] {
   });
 }
 
+/**
+ * Public launch-probe facade. Only a successful probe may brand an autonomy
+ * resolution as safe for adapter execution; structurally similar objects
+ * supplied directly by callers remain untrusted.
+ */
+export function probeCodexLaunch(
+  input: Parameters<typeof probeCodexLaunchHost>[0]
+): CodexLaunchProbeResult {
+  const result = probeCodexLaunchHost(input);
+  if (result.ok && result.autonomyResolution) {
+    markCodexAutonomyResolutionVerifiedByLaunchProbe(result.autonomyResolution);
+  }
+  return result;
+}
+
 export {
   buildCodexStdin,
   cacheCodexCapabilityProfile,
   clearCodexCapabilityCacheForTests,
   codexWriteStrategies,
+  isCodexAutonomyResolutionVerifiedByLaunchProbe,
   probeCodexCapabilities,
   resolveCodexAutonomyCandidates,
   type CodexAutonomyResolution,
@@ -49,7 +70,6 @@ export {
   checkCodexSandboxPreflight,
   detectCodexHostPlatform,
   diagnoseCodexHost,
-  probeCodexLaunch,
   probeFilesystemWriteCapability,
   resolveCliCommandAvailability,
   type CliCommandAvailability,

--- a/packages/adapters/tests/codex-cli.test.ts
+++ b/packages/adapters/tests/codex-cli.test.ts
@@ -10,6 +10,7 @@ import {
   type CodexCapabilityProfile,
   type SpawnLike
 } from "../src/index.js";
+import { markCodexAutonomyResolutionVerifiedByLaunchProbe } from "../src/codex-capabilities.js";
 
 interface SpawnCall {
   command: string;
@@ -93,7 +94,7 @@ function negotiatedProfile(overrides: Partial<CodexCapabilityProfile> = {}): Cod
   };
 }
 
-function negotiatedAutonomy(
+function rawAutonomy(
   overrides: Partial<CodexAutonomyResolution> = {}
 ): CodexAutonomyResolution {
   return {
@@ -106,7 +107,20 @@ function negotiatedAutonomy(
   };
 }
 
+function negotiatedAutonomy(
+  overrides: Partial<CodexAutonomyResolution> = {}
+): CodexAutonomyResolution {
+  return markCodexAutonomyResolutionVerifiedByLaunchProbe(rawAutonomy(overrides));
+}
+
 describe("capability-driven Codex adapter", () => {
+  it("rejects a structurally valid autonomy resolution that did not pass the launch probe", () => {
+    expect(() => createCodexCliAdapter({
+      capabilityProfile: negotiatedProfile(),
+      autonomyResolution: rawAutonomy()
+    })).toThrow(/not verified by the launch probe/iu);
+  });
+
   it("routes provider execution to the exact selected binary while preserving Codex identity", async () => {
     const calls: SpawnCall[] = [];
     const selectedBinary = "C:\\Program Files\\OpenAI\\Codex\\codex.exe";


### PR DESCRIPTION
Urgent source hardening promoted from the private authoritative repo. Low-level createCodexCliAdapter callers can no longer supply a structurally valid autonomyResolution unless that exact resolution was branded by a successful probeCodexLaunch result. Standard CLI/MCP paths already use the probe-bound flow.

No release/version change in this PR. GitHub Actions quota is unavailable. Local Windows evidence from the side-agent investigation before handoff: focused Codex adapter tests green (3 files / 48 tests), adapters lint PASS, adapters build PASS, baseline PASS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Codex autonomy resolutions are now validated against a successful launch probe before use.
  - Unverified autonomy configurations are rejected with a clear error instead of being accepted.
  - Launch results now preserve verification status for consistent validation across the Codex integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->